### PR TITLE
Introduce a transitionary structure called Tick.

### DIFF
--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/KeyFlow.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/KeyFlow.scala
@@ -1,6 +1,15 @@
 package com.evolutiongaming.kafka.flow
 
+import cats.Applicative
+import cats.Monad
 import cats.data.NonEmptyList
+import cats.effect.Sync
+import cats.effect.concurrent.Ref
+import cats.mtl.MonadState
+import cats.syntax.all._
+import com.evolutiongaming.kafka.flow.persistence.Persistence
+import com.evolutiongaming.kafka.flow.timer.ReadTimestamps
+import com.olegpy.meow.effects._
 import timer.TimerFlow
 
 trait KeyFlow[F[_], E] extends RecordFlow[F, E] with TimerFlow[F]
@@ -8,12 +17,64 @@ trait KeyFlow[F[_], E] extends RecordFlow[F, E] with TimerFlow[F]
 object KeyFlow {
 
   /** Create buffered flow from RecordFlow and TimerFlow */
+  @deprecated("Use KeyFlow.of with fold parameter instead of RecordFlow.of", "0.1.0")
   def apply[F[_], E](
     recordFlow: RecordFlow[F, E],
     timerFlow: TimerFlow[F]
   ): KeyFlow[F, E] = new KeyFlow[F, E] {
     def apply(records: NonEmptyList[E]) = recordFlow(records)
     def onTimer = timerFlow.onTimer
+  }
+
+  /** Create flow which persists snapshots, events and restores state if needed */
+  def of[F[_]: Sync: KeyContext, S, A](
+    fold: FoldOption[F, S, A],
+    tick: TickOption[F, S],
+    persistence: Persistence[F, S, A],
+    timer: TimerFlow[F]
+  ): F[KeyFlow[F, A]] = Ref.of(none[S]) flatMap { storage =>
+    of(storage.stateInstance, fold, tick, persistence, timer)
+  }
+
+  /** Create flow which persists snapshots, events and restores state if needed */
+  def of[F[_]: Monad: KeyContext, S, A](
+    storage: MonadState[F, Option[S]],
+    fold: FoldOption[F, S, A],
+    tick: TickOption[F, S],
+    persistence: Persistence[F, S, A],
+    timer: TimerFlow[F]
+  ): F[KeyFlow[F, A]] =
+    for {
+      state <- persistence.read(KeyContext[F].log)
+      _ <- storage.set(state)
+      foldToState = FoldToState(storage, fold, persistence)
+      tickToState = TickToState(storage, tick, persistence)
+    } yield new KeyFlow[F, A] {
+      def apply(records: NonEmptyList[A]) = foldToState(records)
+      def onTimer = tickToState.run *> timer.onTimer
+    }
+
+
+  /** Does not save anything to the database */
+  def transient[F[_]: Sync: KeyContext: ReadTimestamps, K, S, A](
+    fold: FoldOption[F, S, A],
+    tick: TickOption[F, S],
+    timer: TimerFlow[F]
+  ): F[KeyFlow[F, A]] =
+    for {
+      startedAt <- ReadTimestamps[F].current
+      _ <- KeyContext[F].hold(startedAt.offset)
+      storage <- Ref.of(none[S])
+      foldToState = FoldToState(storage.stateInstance, fold, Persistence.empty[F, S, A])
+      tickToState = TickToState(storage.stateInstance, tick, Persistence.empty[F, S, A])
+    } yield new KeyFlow[F, A] {
+      def apply(records: NonEmptyList[A]) = foldToState(records)
+      def onTimer = tickToState.run *> timer.onTimer
+    }
+
+  def empty[F[_]: Applicative, A]: RecordFlow[F, A] = new KeyFlow[F, A] {
+    def apply(records: NonEmptyList[A]) = ().pure[F]
+    def onTimer = ().pure[F]
   }
 
 }

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/KeyStateOf.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/KeyStateOf.scala
@@ -88,8 +88,30 @@ object KeyStateOf {
 
   /** Recovers keys as soon as partition is assigned.
     *
-    * This version only requires `TimerFlowOf` and uses default `RecordFlow`
-    * which reads the state from the generic persistence folds it using
+    * This version only requires `TimerFlowOf` and uses default `Keyflow`
+    * which reads the state from the generic persistence and folds it using
+    * default `FoldToState`.
+    *
+    * It also uses default implementaion of `Tick` which does nothing and
+    * does not touch the state.
+    */
+  def eagerRecovery[F[_]: Sync, K, S, A](
+    applicationId: String,
+    groupId: String,
+    keysOf: KeysOf[F, K],
+    timersOf: TimersOf[F, K],
+    persistenceOf: PersistenceOf[F, K, S, A],
+    timerFlowOf: TimerFlowOf[F],
+    fold: FoldOption[F, S, A]
+  ): KeyStateOf[F, K, A] = eagerRecovery(
+    applicationId, groupId, keysOf, timersOf, persistenceOf, timerFlowOf,
+    fold, TickOption.unit
+  )
+
+  /** Recovers keys as soon as partition is assigned.
+    *
+    * This version only requires `TimerFlowOf` and uses default `Keyflow`
+    * which reads the state from the generic persistence and folds it using
     * default `FoldToState`.
     */
   def eagerRecovery[F[_]: Sync, K, S, A](
@@ -151,7 +173,7 @@ object KeyStateOf {
     timersOf: TimersOf[F, K],
     persistenceOf: PersistenceOf[F, K, S, A],
     keyFlowOf: KeyFlowOf[F, S, A],
-    fold: FoldOption[F, S, A],
+    fold: FoldOption[F, S, A]
   ): KeyStateOf[F, K, A] = new KeyStateOf[F, K, A] {
 
     def apply(key: K, createdAt: Timestamp, context: KeyContext[F]) = {

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/RecordFlow.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/RecordFlow.scala
@@ -26,6 +26,7 @@ trait RecordFlow[F[_], A] {
 object RecordFlow {
 
   /** Create flow which persists snapshots, events and restores state if needed */
+  @deprecated("Use KeyFlow.of with fold parameter instead of RecordFlow.of", "0.1.0")
   def of[F[_]: Sync: KeyContext, S, A](
     fold: FoldOption[F, S, A],
     persistence: Persistence[F, S, A]
@@ -34,6 +35,7 @@ object RecordFlow {
   }
 
   /** Create flow which persists snapshots, events and restores state if needed */
+  @deprecated("Use KeyFlow.of with fold parameter instead of RecordFlow.of", "0.1.0")
   def of[F[_]: Monad: KeyContext, S, A](
     storage: MonadState[F, Option[S]],
     fold: FoldOption[F, S, A],
@@ -47,6 +49,7 @@ object RecordFlow {
 
 
   /** Does not save anything to the database */
+  @deprecated("Use KeyFlow.of with fold parameter instead of RecordFlow.of", "0.1.0")
   def transient[F[_]: Sync: KeyContext: ReadTimestamps, K, S, A](
     fold: FoldOption[F, S, A]
   ): F[RecordFlow[F, A]] =
@@ -56,6 +59,7 @@ object RecordFlow {
       foldToState <- FoldToState.of(None, fold, Persistence.empty[F, S, A])
     } yield records => foldToState(records)
 
+  @deprecated("Use KeyFlow.of with fold parameter instead of RecordFlow.of", "0.1.0")
   def empty[F[_]: Applicative, A]: RecordFlow[F, A] = { _ =>
     ().pure[F]
   }

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/Tick.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/Tick.scala
@@ -2,11 +2,27 @@ package com.evolutiongaming.kafka.flow
 
 import cats.Applicative
 import cats.syntax.all._
+import cats.Functor
 
 case class Tick[F[_], S](run: S => F[S]) {
 
   /** Alias for `run` */
   def apply(s: S): F[S] = run(s)
+
+  /** Transforms the state `S` of the `Tick` to something else.
+    *
+    * It is possible to use additional information from previous `T` to
+    * build a new state.
+    *
+    * The common use for this method is to augument original state with
+    * some metainformation, i.e. offset or sequence number.
+    *
+    * See also `StateT#transformS` for more details.
+    */
+  def expand[T](f: T => S)(g: (S, T) => T)(implicit F: Functor[F]): Tick[F, T] =
+    Tick { t =>
+      run(f(t)) map (g(_, t))
+    }
 
   /** Constructs `Fold` which ignores all incoming `A` elements and just triggers underlying `run` */
   def toFold[A]: Fold[F, S, A] = Fold { (s, _) =>

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/Tick.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/Tick.scala
@@ -8,6 +8,11 @@ case class Tick[F[_], S](run: S => F[S]) {
   /** Alias for `run` */
   def apply(s: S): F[S] = run(s)
 
+  /** Constructs `Fold` which ignores all incoming `A` elements and just triggers underlying `run` */
+  def toFold[A]: Fold[F, S, A] = Fold { (s, _) =>
+    run(s)
+  }
+
 }
 object Tick {
 

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/Tick.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/Tick.scala
@@ -1,0 +1,16 @@
+package com.evolutiongaming.kafka.flow
+
+import cats.Applicative
+import cats.syntax.all._
+
+case class Tick[F[_], S](run: S => F[S]) {
+
+  /** Alias for `run` */
+  def apply(s: S): F[S] = run(s)
+
+}
+object Tick {
+
+  def unit[F[_]: Applicative, S] = Tick[F, S](_.pure[F])
+
+}

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/TickOption.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/TickOption.scala
@@ -7,8 +7,14 @@ case class TickOption[F[_], S](value: Tick[F, Option[S]]) {
   /** Alias for `value.run` */
   def apply(s: Option[S]): F[Option[S]] = value(s)
 
+  /** Constructs `FoldOption` which ignores all incoming `A` elements and just triggers underlying `value.run` */
+  def toFold[A]: FoldOption[F, S, A] = FoldOption(value.toFold[A])
+
 }
 object TickOption {
+
+  def of[F[_], S](run: Option[S] => F[Option[S]]): TickOption[F, S] =
+    TickOption(Tick(run))
 
   def unit[F[_]: Applicative, S]: TickOption[F, S] = TickOption(Tick.unit)
 

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/TickOption.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/TickOption.scala
@@ -1,0 +1,15 @@
+package com.evolutiongaming.kafka.flow
+
+import cats.Applicative
+
+case class TickOption[F[_], S](value: Tick[F, Option[S]]) {
+
+  /** Alias for `value.run` */
+  def apply(s: Option[S]): F[Option[S]] = value(s)
+
+}
+object TickOption {
+
+  def unit[F[_]: Applicative, S]: TickOption[F, S] = TickOption(Tick.unit)
+
+}

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/TickOption.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/TickOption.scala
@@ -1,11 +1,35 @@
 package com.evolutiongaming.kafka.flow
 
 import cats.Applicative
+import cats.Functor
 
 case class TickOption[F[_], S](value: Tick[F, Option[S]]) {
 
   /** Alias for `value.run` */
   def apply(s: Option[S]): F[Option[S]] = value(s)
+
+  /** Transforms the state `S` of the `Tick` to something else.
+    *
+    * It is possible to use additional information from previous `T` to
+    * build a new state.
+    *
+    * The common use for this method is to augument original state with
+    * some metainformation, i.e. offset or sequence number.
+    *
+    * See also `StateT#transformS` for more details.
+    *
+    * If any of `S` or `T` is `None` then the output will also be `None`,
+    * though underlying `run` will be called anyway.
+    */
+  def expand[T](f: T => S)(g: (S, T) => T)(implicit F: Functor[F]): TickOption[F, T] =
+    TickOption {
+      value.expand[Option[T]](_ map f) { (s, t) =>
+        for {
+          s <- s
+          t <- t
+        } yield g(s, t)
+      }
+    }
 
   /** Constructs `FoldOption` which ignores all incoming `A` elements and just triggers underlying `value.run` */
   def toFold[A]: FoldOption[F, S, A] = FoldOption(value.toFold[A])

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/TickToState.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/TickToState.scala
@@ -1,0 +1,52 @@
+package com.evolutiongaming.kafka.flow
+
+import cats.Monad
+import cats.effect.Sync
+import cats.effect.concurrent.Ref
+import cats.syntax.all._
+import cats.mtl.MonadState
+import com.olegpy.meow.effects._
+import persistence.Persistence
+
+/** Calls the stateful routine stored inside */
+trait TickToState[F[_]] {
+
+  def run: F[Unit]
+
+}
+
+object TickToState {
+
+  def of[F[_]: Sync: KeyContext, S](
+    initialState: Option[S],
+    tick: TickOption[F, S],
+    persistence: Persistence[F, S, _],
+  ): F[TickToState[F]] = Ref.of(initialState) map { storage =>
+    TickToState(storage.stateInstance, tick, persistence)
+  }
+
+  /** Uses `tick` to call the effect on a state stored inside of `storage`.
+    *
+    * Performs the necessary actions upon the state being changes, i.e.
+    * sends it to persistence, or removes the key if the flow processing
+    * is finished.
+    */
+  def apply[F[_]: Monad: KeyContext, S](
+    storage: MonadState[F, Option[S]],
+    tick: TickOption[F, S],
+    persistence: Persistence[F, S, _],
+  ): TickToState[F] = new TickToState[F] {
+    def run = for {
+      state <- storage.get
+      state <- tick(state)
+      _ <- state traverse_ persistence.replaceState
+      _ <- storage set state
+      _ <- if (state.isEmpty) {
+        persistence.delete *> KeyContext[F].remove
+      } else {
+        ().pure[F]
+      }
+    } yield ()
+  }
+
+}

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/PartitionFlowSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/PartitionFlowSpec.scala
@@ -213,10 +213,9 @@ object PartitionFlowSpec {
             for {
               timers <- TimerContext.memory[IO, String](key, createdAt)
               persistence <- persistenceOf(key, fold, timers)
-              recordFlow <- RecordFlow.of(fold, persistence)
               timerFlowOf = TimerFlowOf.unloadOrphaned[IO](fireEvery = 0.minutes)
               timerFlow <- timerFlowOf(context, persistence, timers)
-              keyFlow = KeyFlow(recordFlow, timerFlow)
+              keyFlow <- KeyFlow.of(fold, TickOption.unit[IO, State], persistence, timerFlow)
             } yield KeyState(keyFlow, timers)
           }
         def all(topicPartition: TopicPartition) = Stream.empty

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.1.1-SNAPSHOT"
+version in ThisBuild := "0.1.1"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.1.2"
+version in ThisBuild := "0.1.3-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.1.0-SNAPSHOT"
+version in ThisBuild := "0.1.0"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.1.1"
+version in ThisBuild := "0.1.2-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.1.0"
+version in ThisBuild := "0.1.1-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.1.2-SNAPSHOT"
+version in ThisBuild := "0.1.2"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.23-SNAPSHOT"
+version in ThisBuild := "0.1.0-SNAPSHOT"


### PR DESCRIPTION
It is requried to allow one to reuse Timer and FoldToState functionality easily without having to copy-paste KeyFlow or RecordFlow code.