### PR TITLE
Store only one snapshot per key

### DIFF
--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/CassandraSnapshots.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/CassandraSnapshots.scala
@@ -57,8 +57,8 @@ class CassandraSnapshots[F[_]: MonadThrowable: Clock, T](
     } yield ()
 
   def get(key: KafkaKey): F[Option[KafkaSnapshot[T]]] =
-    getLegacy(key) flatMap { snapshot =>
-      if (snapshot.isDefined) snapshot.pure else getNew(key)
+    getNew(key) flatMap { snapshot =>
+      if (snapshot.isDefined) snapshot.pure else getLegacy(key)
     }
 
   def getLegacy(key: KafkaKey): F[Option[KafkaSnapshot[T]]] = {

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/CassandraSnapshots.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/CassandraSnapshots.scala
@@ -27,18 +27,18 @@ class CassandraSnapshots[F[_]: MonadThrowable: Clock, T](
     for {
       preparedStatement <- session.prepare(
         """ UPDATE
-          |   snapshots
+          |   snapshots_v2
           | SET
           |   created = :created,
           |   metadata = :metadata,
-          |   value = :value
+          |   value = :value,
+          |   offset = :offset
           | WHERE
           |   application_id = :application_id
           |   AND group_id = :group_id
           |   AND topic = :topic
           |   AND partition = :partition
           |   AND key = :key
-          |   AND offset = :offset
         """.stripMargin
       )
       created <- Clock[F].instant
@@ -56,7 +56,12 @@ class CassandraSnapshots[F[_]: MonadThrowable: Clock, T](
       _ <- session.execute(boundStatement).first.void
     } yield ()
 
-  def get(key: KafkaKey): F[Option[KafkaSnapshot[T]]] = {
+  def get(key: KafkaKey): F[Option[KafkaSnapshot[T]]] =
+    getLegacy(key) flatMap { snapshot =>
+      if (snapshot.isDefined) snapshot.pure else getNew(key)
+    }
+
+  def getLegacy(key: KafkaKey): F[Option[KafkaSnapshot[T]]] = {
 
     // we cannot use DecodeRow here because Code[T].decode is effectful
     def decode(row: Row): F[KafkaSnapshot[T]] = {
@@ -100,12 +105,82 @@ class CassandraSnapshots[F[_]: MonadThrowable: Clock, T](
 
   }
 
-  def delete(key: KafkaKey): F[Unit] = {
+  def getNew(key: KafkaKey): F[Option[KafkaSnapshot[T]]] = {
+
+    // we cannot use DecodeRow here because Code[T].decode is effectful
+    def decode(row: Row): F[KafkaSnapshot[T]] = {
+      val value = row.decode[ByteVector]("value")
+      value.fromBytes map { value =>
+        KafkaSnapshot[T](
+          offset = row.decode[Offset]("offset"),
+          metadata = row.decode[String]("metadata"),
+          value = value
+        )
+      }
+    }
+
+    for {
+      preparedStatement <- session.prepare(
+        """ SELECT
+          |   offset,
+          |   metadata,
+          |   value
+          | FROM
+          |   snapshots_v2
+          | WHERE
+          |   application_id = :application_id
+          |   AND group_id = :group_id
+          |   AND topic = :topic
+          |   AND partition = :partition
+          |   AND key = :key
+        """.stripMargin
+      )
+      boundStatement = preparedStatement.bind()
+        .encode("application_id", key.applicationId)
+        .encode("group_id", key.groupId)
+        .encode("topic", key.topicPartition.topic)
+        .encode("partition", key.topicPartition.partition)
+        .encode("key", key.key)
+      row <- session.execute(boundStatement).first
+      snapshot <- (row map decode).sequence
+    } yield snapshot
+
+  }
+
+  def delete(key: KafkaKey): F[Unit] =
+    deleteLegacy(key) *> deleteNew(key)
+
+  def deleteLegacy(key: KafkaKey): F[Unit] = {
 
     for {
       preparedStatement <- session.prepare(
         """ DELETE FROM
           |   snapshots
+          | WHERE
+          |   application_id = :application_id
+          |   AND group_id = :group_id
+          |   AND topic = :topic
+          |   AND partition = :partition
+          |   AND key = :key
+        """.stripMargin
+      )
+      boundStatement = preparedStatement.bind()
+        .encode("application_id", key.applicationId)
+        .encode("group_id", key.groupId)
+        .encode("topic", key.topicPartition.topic)
+        .encode("partition", key.topicPartition.partition)
+        .encode("key", key.key)
+      _ <- session.execute(boundStatement).first.void
+    } yield ()
+
+  }
+
+  def deleteNew(key: KafkaKey): F[Unit] = {
+
+    for {
+      preparedStatement <- session.prepare(
+        """ DELETE FROM
+          |   snapshots_v2
           | WHERE
           |   application_id = :application_id
           |   AND group_id = :group_id

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotSchema.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotSchema.scala
@@ -44,7 +44,7 @@ private[snapshot] object SnapshotSchema {
           |created TIMESTAMP,
           |metadata TEXT,
           |value BLOB,
-          |PRIMARY KEY(application_id, group_id, topic, partition, key)
+          |PRIMARY KEY((application_id, group_id, topic, partition, key))
           |)
           |""".stripMargin
       ).first.void

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotSchema.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotSchema.scala
@@ -32,6 +32,21 @@ private[snapshot] object SnapshotSchema {
           |PRIMARY KEY((application_id, group_id, topic, partition, key), offset)
           |)
           |""".stripMargin
+      ).first *>
+      session.execute(
+        """CREATE TABLE IF NOT EXISTS snapshots_v2(
+          |application_id TEXT,
+          |group_id TEXT,
+          |topic TEXT,
+          |partition INT,
+          |key TEXT,
+          |offset BIGINT,
+          |created TIMESTAMP,
+          |metadata TEXT,
+          |value BLOB,
+          |PRIMARY KEY(application_id, group_id, topic, partition, key)
+          |)
+          |""".stripMargin
       ).first.void
     }
     def truncate = synchronize("SnapshotSchema") {


### PR DESCRIPTION
This is required to avoid growing number of stored snapshots forever for long living entities. The change is backwards compatible and deployment without a downtime is supported.