### PR TITLE
Avoid the need to define the codec twice

### DIFF
--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/CassandraPersistence.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/CassandraPersistence.scala
@@ -1,6 +1,7 @@
 package com.evolutiongaming.kafka.flow.cassandra
 
 import cats.Monad
+import cats.arrow.FunctionK
 import cats.effect.Clock
 import cats.syntax.all._
 import com.evolutiongaming.cassandra.sync.CassandraSync
@@ -12,12 +13,13 @@ import com.evolutiongaming.kafka.flow.snapshot.CassandraSnapshots
 import com.evolutiongaming.kafka.journal.FromBytes
 import com.evolutiongaming.kafka.journal.ToBytes
 import com.evolutiongaming.kafka.journal.eventual.cassandra.CassandraSession
+import scala.util.Try
 
 trait CassandraPersistence[F[_], S] extends PersistenceModule[F, S]
 object CassandraPersistence {
 
   /** Creates schema in Cassandra if not there yet */
-  def withSchema[F[_]: MonadThrowable: Clock, S](
+  def withSchemaF[F[_]: MonadThrowable: Clock, S](
     session: CassandraSession[F],
     sync: CassandraSync[F]
   )(implicit
@@ -31,6 +33,24 @@ object CassandraPersistence {
     def keys = _keys
     def journals = _journals
     def snapshots = _snapshots
+  }
+
+  /** Creates schema in Cassandra if not there yet
+    *
+    * This method uses the same `JsonCodec[Try]` as `JournalParser` does to
+    * simplify defining the basic application.
+    */
+  def withSchema[F[_]: MonadThrowable: Clock, S](
+    session: CassandraSession[F],
+    sync: CassandraSync[F]
+  )(implicit
+    fromBytes: FromBytes[Try, S],
+    toBytes: ToBytes[Try, S]
+  ): F[PersistenceModule[F, S]] = {
+    val fromTry = FunctionK.liftFunction[Try, F](MonadThrowable[F].fromTry)
+    implicit val _fromBytes = fromBytes mapK fromTry
+    implicit val _toBytes = toBytes mapK fromTry
+    withSchemaF(session, sync)
   }
 
   /** Deletes all data in Cassandra */


### PR DESCRIPTION
Avoid the need to define the codec twice, i.e. like this:

    implicit val journalCodec = JsonCodec.default[Try]
    implicit val journalParser = JournalParser.of[F]

    implicit val stateCodec = JsonCodec.default[F]
    CassandraPersistence.withSchema[F, State](...)