### PR TITLE
Add filtering capabilities to PartitionFlow

### DIFF
--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/PartitionFlow.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/PartitionFlow.scala
@@ -1,10 +1,10 @@
 package com.evolutiongaming.kafka.flow
 
-import cats.Parallel
 import cats.data.NonEmptyList
 import cats.effect.concurrent.Ref
 import cats.effect.{Clock, Concurrent, Resource}
 import cats.syntax.all._
+import cats.{Applicative, Parallel}
 import com.evolutiongaming.catshelper.ClockHelper._
 import com.evolutiongaming.catshelper.{Log, LogOf}
 import com.evolutiongaming.kafka.flow.kafka.OffsetToCommit
@@ -33,15 +33,39 @@ object PartitionFlow {
     def timers: TimerContext[F]      = state.timers
   }
 
+  trait FilterRecord[F[_]] {
+    def apply(consRecord: ConsRecord): F[Boolean]
+  }
+
+  object FilterRecord {
+    def empty[F[_]: Applicative]: FilterRecord[F] =
+      _ => true.pure[F]
+
+    def of[F[_]](f: ConsRecord => F[Boolean]): FilterRecord[F] =
+      record => f(record)
+
+    def of[F[_]: Applicative](f: ConsRecord => Boolean): FilterRecord[F] =
+      record => f(record).pure[F]
+  }
+
   def resource[F[_]: Concurrent: Parallel: PartitionContext: Clock: LogOf, S](
     topicPartition: TopicPartition,
     assignedAt: Offset,
     keyStateOf: KeyStateOf[F],
     config: PartitionFlowConfig
   ): Resource[F, PartitionFlow[F]] =
+    resource(topicPartition, assignedAt, keyStateOf, config, FilterRecord.empty[F])
+
+  def resource[F[_]: Concurrent: Parallel: PartitionContext: Clock: LogOf, S](
+    topicPartition: TopicPartition,
+    assignedAt: Offset,
+    keyStateOf: KeyStateOf[F],
+    config: PartitionFlowConfig,
+    filter: FilterRecord[F]
+  ): Resource[F, PartitionFlow[F]] =
     LogResource[F](getClass, topicPartition.toString) flatMap { implicit log =>
       Cache.loading[F, String, PartitionKey[F]] flatMap { cache =>
-        of(topicPartition, assignedAt, keyStateOf, cache, config)
+        of(topicPartition, assignedAt, keyStateOf, cache, config, filter)
       }
     }
 
@@ -50,7 +74,8 @@ object PartitionFlow {
     assignedAt: Offset,
     keyStateOf: KeyStateOf[F],
     cache: Cache[F, String, PartitionKey[F]],
-    config: PartitionFlowConfig
+    config: PartitionFlowConfig,
+    filter: FilterRecord[F]
   ): Resource[F, PartitionFlow[F]] = for {
     clock <- Resource.eval(Clock[F].instant)
     committedOffset <- Resource.eval(Ref.of(assignedAt))
@@ -65,7 +90,8 @@ object PartitionFlow {
       triggerTimersAt = triggerTimersAt,
       commitOffsetsAt = commitOffsetsAt,
       cache = cache,
-      config = config
+      config = config,
+      filter = filter
     )
   } yield flow
 
@@ -78,10 +104,11 @@ object PartitionFlow {
     triggerTimersAt: Ref[F, Instant],
     commitOffsetsAt: Ref[F, Instant],
     cache: Cache[F, String, PartitionKey[F]],
-    config: PartitionFlowConfig
+    config: PartitionFlowConfig,
+    filter: FilterRecord[F]
   ): Resource[F, PartitionFlow[F]] = {
 
-    def stateOf(createdAt: Timestamp, key: String) =
+    def stateOf(createdAt: Timestamp, key: String): F[PartitionKey[F]] =
       cache.getOrUpdateReleasable(key) {
         Releasable.of {
           for {
@@ -122,7 +149,10 @@ object PartitionFlow {
         // we might return the support in future if such will be required
         case (Some(key), records) => (key, records)
       }
-      _ <- keys.toList parTraverse_ { case (key, records) =>
+      filteredRecords <- keys.toList.parTraverseFilter { case (key, records) =>
+        records.toList.filterA(filter.apply).map(filtered => NonEmptyList.fromList(filtered).map(nel => (key, nel)))
+      }
+      _ <- filteredRecords.parTraverse_ { case (key, records) =>
         val startedAt = Timestamp(
           clock = clock,
           watermark = records.head.timestampAndType map (_.timestamp),

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/PartitionFlowOf.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/PartitionFlowOf.scala
@@ -18,13 +18,7 @@ trait PartitionFlowOf[F[_]] {
 }
 object PartitionFlowOf {
 
-  /** Creates `PartitionFlowOf` for specific application without filtering of events */
-  def apply[F[_]: Concurrent: Timer: Parallel: LogOf, S](
-    keyStateOf: KeyStateOf[F],
-    config: PartitionFlowConfig = PartitionFlowConfig()
-  ): PartitionFlowOf[F] = apply(keyStateOf, config, FilterRecord.empty[F])
-
-  /** Creates `PartitionFlowOf` for specific application with filtering of events
+  /** Creates `PartitionFlowOf` for specific application with optional filtering of events
     *
     * @param filter determines whether an incoming consumer record should be processed or skipped.
     *               Skipping a record means that (1) no state will be restored for that key; (2) no fold will be executed for that event.
@@ -34,7 +28,7 @@ object PartitionFlowOf {
   def apply[F[_]: Concurrent: Timer: Parallel: LogOf, S](
     keyStateOf: KeyStateOf[F],
     config: PartitionFlowConfig,
-    filter: FilterRecord[F]
+    filter: Option[FilterRecord[F]] = None
   ): PartitionFlowOf[F] = { (topicPartition, assignedAt, context) =>
     implicit val _context = context
     PartitionFlow.resource(topicPartition, assignedAt, keyStateOf, config, filter)

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/PartitionFlowOf.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/PartitionFlowOf.scala
@@ -27,7 +27,7 @@ object PartitionFlowOf {
     */
   def apply[F[_]: Concurrent: Timer: Parallel: LogOf, S](
     keyStateOf: KeyStateOf[F],
-    config: PartitionFlowConfig,
+    config: PartitionFlowConfig = PartitionFlowConfig(),
     filter: Option[FilterRecord[F]] = None
   ): PartitionFlowOf[F] = { (topicPartition, assignedAt, context) =>
     implicit val _context = context

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/PartitionFlowSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/PartitionFlowSpec.scala
@@ -234,7 +234,7 @@ class PartitionFlowSpec extends FunSuite {
           TimerFlowOf.persistPeriodically(fireEvery = 0.minute, persistEvery = 0.minute, ignorePersistErrors = true),
         persistenceOf =
           PersistenceOf.snapshotsOnly(keysOf = keysOf, snapshotsOf = SnapshotsOf.backedBy(snapshotDatabase)),
-        filter = record => record.key.map(key => IO(key.value != skippedKey)).getOrElse(IO.pure(true))
+        filter = Some(record => record.key.map(key => IO(key.value != skippedKey)).getOrElse(IO.pure(true)))
       )
     }
 
@@ -313,7 +313,7 @@ object PartitionFlowSpec {
     def makeFlow(
       timerFlowOf: TimerFlowOf[IO],
       persistenceOf: PersistenceOf[IO, String, State, ConsRecord],
-      filter: FilterRecord[IO] = FilterRecord.empty[IO]
+      filter: Option[FilterRecord[IO]] = none
     ): Resource[IO, PartitionFlow[IO]] = {
       val keyStateOf: KeyStateOf[IO] = new KeyStateOf[IO] {
         def apply(

--- a/persistence-kafka/src/it/scala/com/evolutiongaming/kafka/flow/StatefulProcessingWithKafkaSpec.scala
+++ b/persistence-kafka/src/it/scala/com/evolutiongaming/kafka/flow/StatefulProcessingWithKafkaSpec.scala
@@ -5,7 +5,6 @@ import cats.effect.{Blocker, IO, Resource}
 import cats.syntax.all._
 import cats.{Applicative, Functor, Monad}
 import com.evolutiongaming.catshelper.{Log, LogOf}
-import com.evolutiongaming.kafka.flow.PartitionFlow.FilterRecord
 import com.evolutiongaming.kafka.flow.StatefulProcessingWithKafkaSpec._
 import com.evolutiongaming.kafka.flow.kafka.KafkaModule
 import com.evolutiongaming.kafka.flow.kafkapersistence.{KafkaPersistenceModule, KafkaPersistenceModuleOf, kafkaEagerRecovery}
@@ -254,7 +253,7 @@ class StatefulProcessingWithKafkaSpec(val globalRead: GlobalRead) extends KafkaS
           commitOffsetsInterval = 0.seconds
         ),
         tick = TickOption.id[IO, State],
-        filter = FilterRecord.empty[IO]
+        filter = none
       )
     } yield TopicFlowOf(partitionFlowOf)
   }

--- a/persistence-kafka/src/it/scala/com/evolutiongaming/kafka/flow/StatefulProcessingWithKafkaSpec.scala
+++ b/persistence-kafka/src/it/scala/com/evolutiongaming/kafka/flow/StatefulProcessingWithKafkaSpec.scala
@@ -5,13 +5,10 @@ import cats.effect.{Blocker, IO, Resource}
 import cats.syntax.all._
 import cats.{Applicative, Functor, Monad}
 import com.evolutiongaming.catshelper.{Log, LogOf}
+import com.evolutiongaming.kafka.flow.PartitionFlow.FilterRecord
 import com.evolutiongaming.kafka.flow.StatefulProcessingWithKafkaSpec._
 import com.evolutiongaming.kafka.flow.kafka.KafkaModule
-import com.evolutiongaming.kafka.flow.kafkapersistence.{
-  KafkaPersistenceModule,
-  KafkaPersistenceModuleOf,
-  kafkaEagerRecovery
-}
+import com.evolutiongaming.kafka.flow.kafkapersistence.{KafkaPersistenceModule, KafkaPersistenceModuleOf, kafkaEagerRecovery}
 import com.evolutiongaming.kafka.flow.key.KeysOf
 import com.evolutiongaming.kafka.flow.persistence.{PersistenceOf, SnapshotPersistenceOf}
 import com.evolutiongaming.kafka.flow.snapshot.{SnapshotDatabase, SnapshotsOf}
@@ -256,7 +253,8 @@ class StatefulProcessingWithKafkaSpec(val globalRead: GlobalRead) extends KafkaS
           triggerTimersInterval = 0.seconds,
           commitOffsetsInterval = 0.seconds
         ),
-        tick = TickOption.id[IO, State]
+        tick = TickOption.id[IO, State],
+        filter = FilterRecord.empty[IO]
       )
     } yield TopicFlowOf(partitionFlowOf)
   }

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/package.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/package.scala
@@ -4,6 +4,7 @@ import cats.effect.{Concurrent, Resource, Timer}
 import cats.syntax.all._
 import cats.{Eval, Foldable, Monad, Parallel}
 import com.evolutiongaming.catshelper.LogOf
+import com.evolutiongaming.kafka.flow.PartitionFlow.FilterRecord
 import com.evolutiongaming.kafka.flow.metrics.syntax._
 import com.evolutiongaming.kafka.flow.timer.{TimerFlowOf, TimersOf}
 import com.evolutiongaming.kafka.journal.ConsRecord
@@ -38,6 +39,8 @@ package object kafkapersistence {
     *   val businessLogicFold: FoldOption[F, State, ConsRecord] = ... // your business logic here in this fold
     *   val tick: TickOption[F, State] = ... // optional additional Tick to change state, use TickOption.id if not used
     *   val partitionFlowConfig: PartitionFlowConfig = ... // additional configuration for partition flow
+    *   val metrics: FlowMetrics[F] = ... // internal metrics
+    *   val filter: FilterRecord[F] = ... // allows skipping some records, see the description in `PartitionFlowOf#apply`
     *
     *   val partitionFlowOf = kafkaEagerRecovery[F, State](
     *     kafkaPersistenceModuleOf  = persistenceModuleOf,
@@ -47,7 +50,9 @@ package object kafkapersistence {
     *     timerFlowOf               = timerFlowOf,
     *     fold                      = businessLogicFold,
     *     partitionFlowConfig       = partitionFlowConfig,
-    *     tick                      = tick
+    *     tick                      = tick,
+    *     metrics                   = metrics,
+    *     filter                    = filter
     *   )
     *
     *   val topicFlowOf = TopicFlowOf(partitionFlowOf)
@@ -73,7 +78,8 @@ package object kafkapersistence {
     fold: FoldOption[F, S, ConsRecord],
     tick: TickOption[F, S],
     partitionFlowConfig: PartitionFlowConfig,
-    metrics: FlowMetrics[F] = FlowMetrics.empty[F]
+    metrics: FlowMetrics[F] = FlowMetrics.empty[F],
+    filter: FilterRecord[F]
   ): PartitionFlowOf[F] =
     new PartitionFlowOf[F] {
       override def apply(
@@ -85,7 +91,7 @@ package object kafkapersistence {
           // TODO: per-partition persistence module with 'String -> ByteVector' cache or global persistence module with 'KafkaKey -> ByteVector' cache?
           // Latter would require initialization of PartitionFlowOf as a Resource
           kafkaPersistenceModule <- kafkaPersistenceModuleOf.make(topicPartition.partition)
-          partitionFlowOf = PartitionFlowOf[F, S](
+          partitionFlowOf = PartitionFlowOf.apply[F, S](
             keyStateOf = KeyStateOf.eagerRecovery(
               applicationId = applicationId,
               groupId = groupId,
@@ -98,7 +104,8 @@ package object kafkapersistence {
                 tick = tick
               )
             ) withMetrics metrics.keyStateOfMetrics,
-            config = partitionFlowConfig
+            config = partitionFlowConfig,
+            filter = filter
           )
           partitionFlow <- partitionFlowOf(topicPartition, assignedAt, context)
         } yield partitionFlow

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/package.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/package.scala
@@ -40,7 +40,7 @@ package object kafkapersistence {
     *   val tick: TickOption[F, State] = ... // optional additional Tick to change state, use TickOption.id if not used
     *   val partitionFlowConfig: PartitionFlowConfig = ... // additional configuration for partition flow
     *   val metrics: FlowMetrics[F] = ... // internal metrics
-    *   val filter: FilterRecord[F] = ... // allows skipping some records, see the description in `PartitionFlowOf#apply`
+    *   val filter: Option[FilterRecord[F]] = ... // allows skipping some records, see the description in `PartitionFlowOf#apply`
     *
     *   val partitionFlowOf = kafkaEagerRecovery[F, State](
     *     kafkaPersistenceModuleOf  = persistenceModuleOf,
@@ -79,7 +79,7 @@ package object kafkapersistence {
     tick: TickOption[F, S],
     partitionFlowConfig: PartitionFlowConfig,
     metrics: FlowMetrics[F] = FlowMetrics.empty[F],
-    filter: FilterRecord[F]
+    filter: Option[FilterRecord[F]] = None
   ): PartitionFlowOf[F] =
     new PartitionFlowOf[F] {
       override def apply(


### PR DESCRIPTION
Micro-PoC that this filtering code works:
```scala
import cats.data.NonEmptyList
import cats.effect.IO
import cats.instances.all._
import cats.syntax.all._

import scala.collection.SortedMap
import scala.concurrent.ExecutionContext

implicit val cs = IO.contextShift(ExecutionContext.global)

val filterFun = (x: Int) => IO(x != 1)

val map1 =
  SortedMap("key1" -> NonEmptyList.of(1, 2, 3), "key2" -> NonEmptyList.of(1, 1, 1))
val map2 =
  SortedMap("key1" -> NonEmptyList.of(1, 1, 1))
val map3 =
  SortedMap("key1" -> NonEmptyList.of(1, 2, 3))

def filter(map: SortedMap[String, NonEmptyList[Int]]): List[(String, NonEmptyList[Int])] =
  map.toList
    .parTraverseFilter { case (key, records) =>
      records.toList.filterA(filterFun).map(filtered => NonEmptyList.fromList(filtered).map(nel => (key, nel)))
    }
    .unsafeRunSync()

filter(map1)
// val res0: List[(String, cats.data.NonEmptyList[Int])] = List((key1,NonEmptyList(2, 3)))

filter(map2)
// val res1: List[(String, cats.data.NonEmptyList[Int])] = List()

filter(map3)
// val res2: List[(String, cats.data.NonEmptyList[Int])] = List((key1,NonEmptyList(2, 3)))
```