### PR TITLE
Add read write config support for cassandra persistence

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,9 @@ lazy val commonSettings = Seq(
     Resolver.bintrayRepo("evolutiongaming", "maven"),
     Resolver.sonatypeRepo("public")
   ),
+  libraryDependencySchemes ++= Seq(
+    "org.scala-lang.modules" %% "scala-java8-compat" % "always"
+  ),
   addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.13.0" cross CrossVersion.full)
 )
 
@@ -49,7 +52,7 @@ lazy val core = (project in file("core"))
       scribe % IntegrationTest,
       skafka,
       sstream,
-      weaver % IntegrationTest,
+      weaver % IntegrationTest
     ),
     Defaults.itSettings,
     IntegrationTest / testFrameworks += new TestFramework("weaver.framework.CatsEffect"),
@@ -74,7 +77,7 @@ lazy val `persistence-cassandra` = (project in file("persistence-cassandra"))
       KafkaJournal.cassandra,
       cassandraLauncher % IntegrationTest exclude ("ch.qos.logback", "logback-classic"),
       scribe % IntegrationTest,
-      weaver % IntegrationTest,
+      weaver % IntegrationTest
     ),
     Defaults.itSettings,
     IntegrationTest / testFrameworks += new TestFramework("weaver.framework.CatsEffect"),
@@ -92,7 +95,7 @@ lazy val `persistence-kafka` = (project in file("persistence-kafka"))
       Monocle.`macro`,
       kafkaLauncher % IntegrationTest,
       scribe % IntegrationTest,
-      weaver % IntegrationTest,
+      weaver % IntegrationTest
     ),
     Defaults.itSettings,
     IntegrationTest / testFrameworks += new TestFramework("weaver.framework.CatsEffect"),

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/FoldOption.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/FoldOption.scala
@@ -6,7 +6,7 @@ import cats.Functor
 import cats.Monad
 import cats.syntax.all._
 
-/** Convinience methods for using `Fold` with optional state */
+/** Convenience methods for using `Fold` with optional state */
 final case class FoldOption[F[_], S, A](value: Fold[F, Option[S], A]) {
 
   /** Alias for `run` */

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/persistence/PersistenceOf.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/persistence/PersistenceOf.scala
@@ -19,7 +19,7 @@ trait PersistenceOf[F[_], K, S, A] {
     *
     * @param key key for which the values are stored into database,
     * @param fold recovery function to use if the state is restored from journal,
-    * @param timerstamp service to register persistence events to.
+    * @param timestamps service to register persistence events to.
     */
   def apply(
     key: K,

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/KafkaSnapshot.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/KafkaSnapshot.scala
@@ -7,7 +7,7 @@ import com.evolutiongaming.skafka.Offset
   *
   * We want to have it parameterized by `T`, because of performance reasons.
   *
-  * I.e. we want to store snapshot metada on every step of our folds, but we do
+  * I.e. we want to store snapshot metadata on every step of our folds, but we do
   * not want to serialize it to `ByteVector` each time unless we actually decided
   * to save snapshot into persistence.
   */

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/timer/Timestamps.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/timer/Timestamps.scala
@@ -10,7 +10,7 @@ import com.olegpy.meow.effects._
 
 /** Contains timestamp related to a specific key.
   *
-  * I.e. when the key was persistted, processed etc.
+  * I.e. when the key was persisted, processed etc.
   */
 trait Timestamps[F[_]] extends ReadTimestamps[F] with WriteTimestamps[F]
 trait ReadTimestamps[F[_]] {

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/CassandraConfig.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/CassandraConfig.scala
@@ -1,5 +1,6 @@
 package com.evolutiongaming.kafka.flow.cassandra
 
+import com.evolutiongaming.kafka.journal.eventual.cassandra.EventualCassandraConfig.ConsistencyConfig
 import com.evolutiongaming.scassandra
 import pureconfig.ConfigReader
 import pureconfig.generic.semiauto.deriveReader
@@ -7,7 +8,8 @@ import pureconfig.generic.semiauto.deriveReader
 final case class CassandraConfig(
   schema: CassandraConfig.Schema = CassandraConfig.Schema.default,
   retries: Int = 100,
-  client: scassandra.CassandraConfig
+  client: scassandra.CassandraConfig,
+  consistencyConfig: Option[ConsistencyConfig] = None
 )
 
 object CassandraConfig {

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/CassandraConfig.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/CassandraConfig.scala
@@ -10,17 +10,7 @@ final case class CassandraConfig(
   retries: Int = 100,
   client: scassandra.CassandraConfig,
   consistencyConfig: Option[ConsistencyConfig] = None
-) {
-  val consistency: ConsistencyConfig =
-    consistencyConfig match {
-      case Some(conf) => conf
-      case None =>
-        val fallback = client.query.consistency
-        val (fallbackRead, fallbackWrite) = (ConsistencyConfig.Read(fallback), ConsistencyConfig.Write(fallback))
-
-        ConsistencyConfig(fallbackRead, fallbackWrite)
-    }
-}
+)
 
 object CassandraConfig {
 

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/CassandraConfig.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/CassandraConfig.scala
@@ -1,6 +1,5 @@
 package com.evolutiongaming.kafka.flow.cassandra
 
-import com.evolutiongaming.kafka.journal.eventual.cassandra.EventualCassandraConfig.ConsistencyConfig
 import com.evolutiongaming.scassandra
 import pureconfig.ConfigReader
 import pureconfig.generic.semiauto.deriveReader
@@ -9,7 +8,7 @@ final case class CassandraConfig(
   schema: CassandraConfig.Schema = CassandraConfig.Schema.default,
   retries: Int = 100,
   client: scassandra.CassandraConfig,
-  consistencyConfig: Option[ConsistencyConfig] = None
+  consistencyOverrides: ConsistencyOverrides = ConsistencyOverrides.default
 )
 
 object CassandraConfig {

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/CassandraConfig.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/CassandraConfig.scala
@@ -1,6 +1,5 @@
 package com.evolutiongaming.kafka.flow.cassandra
 
-import com.evolutiongaming.kafka.journal.eventual.cassandra.EventualCassandraConfig.ConsistencyConfig
 import com.evolutiongaming.scassandra
 import pureconfig.ConfigReader
 import pureconfig.generic.semiauto.deriveReader
@@ -8,8 +7,7 @@ import pureconfig.generic.semiauto.deriveReader
 final case class CassandraConfig(
   schema: CassandraConfig.Schema = CassandraConfig.Schema.default,
   retries: Int = 100,
-  client: scassandra.CassandraConfig,
-  consistencyConfig: Option[ConsistencyConfig] = None
+  client: scassandra.CassandraConfig
 )
 
 object CassandraConfig {

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/CassandraConfig.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/CassandraConfig.scala
@@ -10,7 +10,17 @@ final case class CassandraConfig(
   retries: Int = 100,
   client: scassandra.CassandraConfig,
   consistencyConfig: Option[ConsistencyConfig] = None
-)
+) {
+  val consistency: ConsistencyConfig =
+    consistencyConfig match {
+      case Some(conf) => conf
+      case None =>
+        val fallback = client.query.consistency
+        val (fallbackRead, fallbackWrite) = (ConsistencyConfig.Read(fallback), ConsistencyConfig.Write(fallback))
+
+        ConsistencyConfig(fallbackRead, fallbackWrite)
+    }
+}
 
 object CassandraConfig {
 

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/CassandraConfig.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/CassandraConfig.scala
@@ -1,5 +1,6 @@
 package com.evolutiongaming.kafka.flow.cassandra
 
+import com.evolutiongaming.kafka.journal.eventual.cassandra.EventualCassandraConfig.ConsistencyConfig
 import com.evolutiongaming.scassandra
 import pureconfig.ConfigReader
 import pureconfig.generic.semiauto.deriveReader
@@ -7,16 +8,15 @@ import pureconfig.generic.semiauto.deriveReader
 final case class CassandraConfig(
   schema: CassandraConfig.Schema = CassandraConfig.Schema.default,
   retries: Int = 100,
-  client: scassandra.CassandraConfig)
+  client: scassandra.CassandraConfig,
+  consistencyConfig: Option[ConsistencyConfig] = None
+)
 
 object CassandraConfig {
 
   implicit val cassandraConfigReader: ConfigReader[CassandraConfig] = deriveReader
 
-
-  final case class Schema(
-    keyspace: Keyspace = Keyspace.default,
-    autoCreate: Boolean = true)
+  final case class Schema(keyspace: Keyspace = Keyspace.default, autoCreate: Boolean = true)
 
   object Schema {
 
@@ -25,10 +25,7 @@ object CassandraConfig {
     val default: Schema = Schema()
   }
 
-
-  final case class Keyspace(
-    name: String = "kafka_flow",
-    autoCreate: Boolean = true)
+  final case class Keyspace(name: String = "kafka_flow", autoCreate: Boolean = true)
 
   object Keyspace {
 

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/CassandraConfig.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/CassandraConfig.scala
@@ -8,7 +8,7 @@ final case class CassandraConfig(
   schema: CassandraConfig.Schema = CassandraConfig.Schema.default,
   retries: Int = 100,
   client: scassandra.CassandraConfig,
-  consistencyOverrides: ConsistencyOverrides = ConsistencyOverrides.default
+  consistencyOverrides: ConsistencyOverrides = ConsistencyOverrides.none
 )
 
 object CassandraConfig {

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/CassandraModule.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/CassandraModule.scala
@@ -5,16 +5,19 @@ import cats.effect.Resource
 import cats.effect.Sync
 import cats.effect.Timer
 import cats.syntax.all._
+import com.datastax.driver.core.ConsistencyLevel
 import com.evolutiongaming.cassandra.sync.AutoCreate
 import com.evolutiongaming.cassandra.sync.CassandraSync
 import com.evolutiongaming.catshelper.Log
 import com.evolutiongaming.catshelper.LogOf
 import com.evolutiongaming.kafka.flow.LogResource
 import com.evolutiongaming.kafka.journal.eventual.cassandra.CassandraHealthCheck
+import com.evolutiongaming.kafka.journal.eventual.cassandra.EventualCassandraConfig.ConsistencyConfig
 import com.evolutiongaming.kafka.journal.eventual.cassandra.{CassandraSession => SafeSession}
 import com.evolutiongaming.scassandra.CassandraClusterOf
 import com.evolutiongaming.scassandra.util.FromGFuture
 import com.google.common.util.concurrent.ListenableFuture
+
 import scala.concurrent.ExecutionContextExecutor
 
 trait CassandraModule[F[_]] {
@@ -34,23 +37,24 @@ object CassandraModule {
   }
 
   /** Creates connection, synchronization and health check routines
-   *
-   * @param config Connection parameters.
-   * @param executor Executor to run Cassandra requests on. It requires
-   * `ExecutionContextExecutor` rather than `ContextShift` because we need it
-   * to convert `ListenableFuture` to `F[_]`.
-   */
+    *
+    * @param config Connection parameters.
+    * @param executor Executor to run Cassandra requests on. It requires
+    * `ExecutionContextExecutor` rather than `ContextShift` because we need it
+    * to convert `ListenableFuture` to `F[_]`.
+    */
   def of[F[_]: Concurrent: Timer: LogOf](
     config: CassandraConfig
   )(implicit executor: ExecutionContextExecutor): Resource[F, CassandraModule[F]] = {
+    val config1 = fillConsistencyConfig(config)
 
     for {
-      log             <- Resource.eval(log[F])
+      log <- Resource.eval(log[F])
       // this is required to log all Cassandra errors before popping them up,
       // which is useful because popped up errors might be lost in some cases
       // while kafka-flow is accessing Cassandra in bracket/resource release
       // routine
-      fromGFuture     = new FromGFuture[F] {
+      fromGFuture = new FromGFuture[F] {
         val self = FromGFuture.lift[F]
         def apply[A](future: => ListenableFuture[A]) = {
           self(future) onError { case e =>
@@ -58,20 +62,20 @@ object CassandraModule {
           }
         }
       }
-      clusterOf       <- Resource.eval(clusterOf[F](fromGFuture))
-      cluster         <- clusterOf(config.client)
-      keyspace        = config.schema.keyspace
-      globalSession   = {
+      clusterOf <- Resource.eval(clusterOf[F](fromGFuture))
+      cluster <- clusterOf(config1.client)
+      keyspace = config1.schema.keyspace
+      globalSession = {
         LogResource[F](CassandraModule.getClass, "CassandraGlobal") *>
-        cluster.connect
+          cluster.connect
       }
       keyspaceSession = {
         LogResource[F](CassandraModule.getClass, "Cassandra") *>
-        cluster.connect(keyspace.name)
+          cluster.connect(keyspace.name)
       }
-      // we need globally scoped session as connecting with non-existend keyspace will fail
-      syncSession     <- if (keyspace.autoCreate) globalSession else keyspaceSession
-      _sync           <- Resource.eval(
+      // we need globally scoped session as connecting with non-existing keyspace will fail
+      syncSession <- if (keyspace.autoCreate) globalSession else keyspaceSession
+      _sync <- Resource.eval(
         CassandraSync.of[F](
           session = syncSession,
           keyspace = keyspace.name,
@@ -80,15 +84,27 @@ object CassandraModule {
       )
       // `syncSession` is `keyspaceSession` if `autoCreate` was disabled,
       // no need to reconnect
-      unsafeSession   <- if (keyspace.autoCreate) keyspaceSession else Resource.eval(syncSession.pure[F])
-      _session        <- SafeSession.of(unsafeSession)
-      _healthCheck    <- CassandraHealthCheckOf(unsafeSession, config)
+      unsafeSession <- if (keyspace.autoCreate) keyspaceSession else Resource.eval(syncSession.pure[F])
+      _session <- SafeSession.of(unsafeSession)
+      _healthCheck <- CassandraHealthCheckOf(unsafeSession, config1)
     } yield new CassandraModule[F] {
-      def session  = _session
+      def session = _session
       def sync = _sync
       def healthCheck = _healthCheck
     }
 
   }
 
+  /*
+    if consistencyLevel is Some— do nothing, otherwise infer it from client consistency level
+   */
+  private def fillConsistencyConfig(config: CassandraConfig): CassandraConfig = {
+    val fallback: ConsistencyLevel = config.client.query.consistency
+    val (fallbackRead, fallbackWrite) = (ConsistencyConfig.Read(fallback), ConsistencyConfig.Write(fallback))
+
+    config.consistencyConfig match {
+      case Some(_) => config
+      case None    => config.copy(consistencyConfig = Some(ConsistencyConfig(fallbackRead, fallbackWrite)))
+    }
+  }
 }

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/CassandraPersistence.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/CassandraPersistence.scala
@@ -55,7 +55,11 @@ object CassandraPersistence {
     withSchemaF(session, sync)
   }
 
-  def withSchemaAndConsistencyConfig[F[_]: MonadThrow: Clock, S](
+  /** Same as withSchema(session, sync) but applies
+    * ConsistencyConfig.Read for all read queries and
+    * ConsistencyConfig.Write for all the mutations
+    */
+  def withSchema[F[_]: MonadThrow: Clock, S](
     session: CassandraSession[F],
     sync: CassandraSync[F],
     consistencyConfig: ConsistencyConfig
@@ -68,9 +72,9 @@ object CassandraPersistence {
     implicit val _toBytes = toBytes mapK fromTry
 
     for {
-      keys_ <- CassandraKeys.withSchemaAndConsistencyConfig(session, sync, consistencyConfig)
-      journals_ <- CassandraJournals.withSchemaAndConsistencyConfig(session, sync, consistencyConfig)
-      snapshots_ <- CassandraSnapshots.withSchemaAndConsistencyConfig(session, sync, consistencyConfig)
+      keys_ <- CassandraKeys.withSchema(session, sync, consistencyConfig)
+      journals_ <- CassandraJournals.withSchema(session, sync, consistencyConfig)
+      snapshots_ <- CassandraSnapshots.withSchema(session, sync, consistencyConfig)
     } yield new CassandraPersistence[F, S] {
       def keys: KeyDatabase[F, KafkaKey] = keys_
 

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/CassandraPersistence.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/CassandraPersistence.scala
@@ -63,7 +63,7 @@ object CassandraPersistence {
     session: CassandraSession[F],
     sync: CassandraSync[F],
     consistencyConfig: ConsistencyConfig
-  )(
+  )(implicit
     fromBytes: FromBytes[Try, S],
     toBytes: ToBytes[Try, S]
   ): F[PersistenceModule[F, S]] = {

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/CassandraPersistence.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/CassandraPersistence.scala
@@ -6,13 +6,15 @@ import cats.arrow.FunctionK
 import cats.effect.Clock
 import cats.syntax.all._
 import com.evolutiongaming.cassandra.sync.CassandraSync
-import com.evolutiongaming.kafka.flow.journal.CassandraJournals
-import com.evolutiongaming.kafka.flow.key.CassandraKeys
+import com.evolutiongaming.kafka.flow.KafkaKey
+import com.evolutiongaming.kafka.flow.journal.{CassandraJournals, JournalDatabase}
+import com.evolutiongaming.kafka.flow.key.{CassandraKeys, KeyDatabase}
 import com.evolutiongaming.kafka.flow.persistence.PersistenceModule
-import com.evolutiongaming.kafka.flow.snapshot.CassandraSnapshots
-import com.evolutiongaming.kafka.journal.FromBytes
-import com.evolutiongaming.kafka.journal.ToBytes
+import com.evolutiongaming.kafka.flow.snapshot.{CassandraSnapshots, KafkaSnapshot, SnapshotDatabase}
+import com.evolutiongaming.kafka.journal.{ConsRecord, FromBytes, ToBytes}
 import com.evolutiongaming.kafka.journal.eventual.cassandra.CassandraSession
+import com.evolutiongaming.kafka.journal.eventual.cassandra.EventualCassandraConfig.ConsistencyConfig
+
 import scala.util.Try
 
 trait CassandraPersistence[F[_], S] extends PersistenceModule[F, S]
@@ -26,8 +28,8 @@ object CassandraPersistence {
     fromBytes: FromBytes[F, S],
     toBytes: ToBytes[F, S]
   ): F[PersistenceModule[F, S]] = for {
-    _keys      <- CassandraKeys.withSchema(session, sync)
-    _journals  <- CassandraJournals.withSchema(session, sync)
+    _keys <- CassandraKeys.withSchema(session, sync)
+    _journals <- CassandraJournals.withSchema(session, sync)
     _snapshots <- CassandraSnapshots.withSchema[F, S](session, sync)
   } yield new CassandraPersistence[F, S] {
     def keys = _keys
@@ -53,13 +55,38 @@ object CassandraPersistence {
     withSchemaF(session, sync)
   }
 
+  def withSchemaAndConsistencyConfig[F[_]: MonadThrow: Clock, S](
+    session: CassandraSession[F],
+    sync: CassandraSync[F],
+    consistencyConfig: ConsistencyConfig
+  )(
+    fromBytes: FromBytes[Try, S],
+    toBytes: ToBytes[Try, S]
+  ): F[PersistenceModule[F, S]] = {
+    val fromTry = FunctionK.liftFunction[Try, F](MonadThrow[F].fromTry)
+    implicit val _fromBytes = fromBytes mapK fromTry
+    implicit val _toBytes = toBytes mapK fromTry
+
+    for {
+      keys_ <- CassandraKeys.withSchemaAndConsistencyConfig(session, sync, consistencyConfig)
+      journals_ <- CassandraJournals.withSchemaAndConsistencyConfig(session, sync, consistencyConfig)
+      snapshots_ <- CassandraSnapshots.withSchemaAndConsistencyConfig(session, sync, consistencyConfig)
+    } yield new CassandraPersistence[F, S] {
+      def keys: KeyDatabase[F, KafkaKey] = keys_
+
+      def journals: JournalDatabase[F, KafkaKey, ConsRecord] = journals_
+
+      def snapshots: SnapshotDatabase[F, KafkaKey, KafkaSnapshot[S]] = snapshots_
+    }
+  }
+
   /** Deletes all data in Cassandra */
   def truncate[F[_]: Monad](
     session: CassandraSession[F],
     sync: CassandraSync[F]
   ): F[Unit] =
     CassandraKeys.truncate(session, sync) *>
-    CassandraJournals.truncate(session, sync) *>
-    CassandraSnapshots.truncate(session, sync)
+      CassandraJournals.truncate(session, sync) *>
+      CassandraSnapshots.truncate(session, sync)
 
 }

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/CassandraPersistence.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/CassandraPersistence.scala
@@ -22,7 +22,7 @@ object CassandraPersistence {
   def withSchemaF[F[_]: MonadThrow: Clock, S](
     session: CassandraSession[F],
     sync: CassandraSync[F],
-    consistencyOverrides: ConsistencyOverrides = ConsistencyOverrides.default
+    consistencyOverrides: ConsistencyOverrides = ConsistencyOverrides.none
   )(implicit
     fromBytes: FromBytes[F, S],
     toBytes: ToBytes[F, S]
@@ -47,7 +47,7 @@ object CassandraPersistence {
   def withSchema[F[_]: MonadThrow: Clock, S](
     session: CassandraSession[F],
     sync: CassandraSync[F],
-    consistencyOverrides: ConsistencyOverrides = ConsistencyOverrides.default
+    consistencyOverrides: ConsistencyOverrides = ConsistencyOverrides.none
   )(implicit
     fromBytes: FromBytes[Try, S],
     toBytes: ToBytes[Try, S]

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/ConsistencyOverrides.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/ConsistencyOverrides.scala
@@ -10,7 +10,7 @@ final case class ConsistencyOverrides(
 )
 
 object ConsistencyOverrides {
-  val none: ConsistencyOverrides = ConsistencyOverrides()
+  val none: ConsistencyOverrides = ConsistencyOverrides(None, None)
 
   implicit val configReader: ConfigReader[ConsistencyOverrides] = deriveReader
 }

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/ConsistencyOverrides.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/ConsistencyOverrides.scala
@@ -1,0 +1,16 @@
+package com.evolutiongaming.kafka.flow.cassandra
+
+import com.datastax.driver.core.ConsistencyLevel
+import pureconfig.ConfigReader
+import pureconfig.generic.semiauto.deriveReader
+
+final case class ConsistencyOverrides(
+  read: Option[ConsistencyLevel] = None,
+  write: Option[ConsistencyLevel] = None
+)
+
+object ConsistencyOverrides {
+  val default: ConsistencyOverrides = ConsistencyOverrides()
+
+  implicit val configReader: ConfigReader[ConsistencyOverrides] = deriveReader
+}

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/ConsistencyOverrides.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/ConsistencyOverrides.scala
@@ -10,7 +10,7 @@ final case class ConsistencyOverrides(
 )
 
 object ConsistencyOverrides {
-  val default: ConsistencyOverrides = ConsistencyOverrides()
+  val none: ConsistencyOverrides = ConsistencyOverrides()
 
   implicit val configReader: ConfigReader[ConsistencyOverrides] = deriveReader
 }

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/StatementHelper.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/StatementHelper.scala
@@ -1,0 +1,10 @@
+package com.evolutiongaming.kafka.flow.cassandra
+
+import com.datastax.driver.core.{ConsistencyLevel, Statement}
+
+object StatementHelper {
+  implicit final class StatementOps(val self: Statement) extends AnyVal {
+    def withConsistencyLevel(level: Option[ConsistencyLevel]): Statement =
+      level.map(self.setConsistencyLevel).getOrElse(self)
+  }
+}

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/journal/CassandraJournals.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/journal/CassandraJournals.scala
@@ -32,7 +32,7 @@ import scodec.bits.ByteVector
 
 class CassandraJournals[F[_]: MonadThrow: Clock](
   session: CassandraSession[F],
-  consistencyOverrides: ConsistencyOverrides = ConsistencyOverrides.default
+  consistencyOverrides: ConsistencyOverrides = ConsistencyOverrides.none
 ) extends JournalDatabase[F, KafkaKey, ConsRecord] {
 
   def persist(key: KafkaKey, event: ConsRecord): F[Unit] =
@@ -70,7 +70,7 @@ object CassandraJournals {
   def withSchema[F[_]: MonadThrow: Clock](
     session: CassandraSession[F],
     sync: CassandraSync[F],
-    consistencyOverrides: ConsistencyOverrides = ConsistencyOverrides.default
+    consistencyOverrides: ConsistencyOverrides = ConsistencyOverrides.none
   ): F[JournalDatabase[F, KafkaKey, ConsRecord]] =
     JournalSchema(session, sync).create as new CassandraJournals(session, consistencyOverrides)
 

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/journal/CassandraJournals.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/journal/CassandraJournals.scala
@@ -24,6 +24,7 @@ import com.evolutiongaming.skafka.TimestampAndType
 import com.evolutiongaming.skafka.TimestampType
 import com.evolutiongaming.skafka.consumer.WithSize
 import com.evolutiongaming.sstream.Stream
+import CassandraJournals._
 
 import java.time.Instant
 import scodec.bits.ByteVector
@@ -31,7 +32,6 @@ import scodec.bits.ByteVector
 class CassandraJournals[F[_]: MonadThrow: Clock](
   session: CassandraSession[F]
 ) extends JournalDatabase[F, KafkaKey, ConsRecord] {
-  import CassandraJournals._
 
   def persist(key: KafkaKey, event: ConsRecord): F[Unit] =
     for {

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/key/CassandraKeys.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/key/CassandraKeys.scala
@@ -26,7 +26,7 @@ import java.time.ZoneOffset
 
 class CassandraKeys[F[_]: Monad: Fail: Clock](
   session: CassandraSession[F],
-  consistencyOverrides: ConsistencyOverrides = ConsistencyOverrides.default
+  consistencyOverrides: ConsistencyOverrides = ConsistencyOverrides.none
 ) extends KeyDatabase[F, KafkaKey] {
 
   def persist(key: KafkaKey): F[Unit] =
@@ -91,7 +91,7 @@ object CassandraKeys {
   def withSchema[F[_]: MonadThrow: Clock](
     session: CassandraSession[F],
     sync: CassandraSync[F],
-    consistencyOverrides: ConsistencyOverrides = ConsistencyOverrides.default
+    consistencyOverrides: ConsistencyOverrides = ConsistencyOverrides.none
   ): F[KeyDatabase[F, KafkaKey]] = {
     implicit val fail = Fail.lift
     KeySchema(session, sync).create as new CassandraKeys(session, consistencyOverrides)

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/key/CassandraKeys.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/key/CassandraKeys.scala
@@ -4,7 +4,7 @@ import cats.Monad
 import cats.MonadThrow
 import cats.effect.Clock
 import cats.syntax.all._
-import com.datastax.driver.core.{BoundStatement, ConsistencyLevel, Row}
+import com.datastax.driver.core.{BoundStatement, Row}
 import com.evolutiongaming.cassandra.sync.CassandraSync
 import com.evolutiongaming.catshelper.ClockHelper._
 import com.evolutiongaming.kafka.flow.KafkaKey
@@ -28,20 +28,20 @@ class CassandraKeys[F[_]: Monad: Fail: Clock](
   consistencyConfigOpt: Option[ConsistencyConfig] = None
 ) extends KeyDatabase[F, KafkaKey] {
 
-  private val writeConsistency = consistencyConfigOpt.fold(Option.empty[ConsistencyLevel])(c => Some(c.write.value))
-  private val readConsistency = consistencyConfigOpt.fold(Option.empty[ConsistencyLevel])(c => Some(c.read.value))
+  private val writeConsistency = consistencyConfigOpt.map(_.write.value)
+  private val readConsistency = consistencyConfigOpt.map(_.read.value)
 
   def persist(key: KafkaKey): F[Unit] =
     for {
       boundStatement <- Statements.persist(session, key)
-      statement = boundStatement.setConsistencyLevel(writeConsistency.getOrElse(boundStatement.getConsistencyLevel))
+      statement = writeConsistency.map(boundStatement.setConsistencyLevel).getOrElse(boundStatement)
       _ <- session.execute(statement).first.void
     } yield ()
 
   def delete(key: KafkaKey): F[Unit] =
     for {
       boundStatement <- Statements.delete(session, key)
-      statement = boundStatement.setConsistencyLevel(writeConsistency.getOrElse(boundStatement.getConsistencyLevel))
+      statement = writeConsistency.map(boundStatement.setConsistencyLevel).getOrElse(boundStatement)
       _ <- session.execute(statement).first.void
     } yield ()
 
@@ -55,7 +55,7 @@ class CassandraKeys[F[_]: Monad: Fail: Clock](
   def all(applicationId: String, groupId: String, segment: SegmentNr): Stream[F, KafkaKey] = {
     val boundStatement = Statements
       .all(session, applicationId, groupId, segment)
-      .map(statement => statement.setConsistencyLevel(readConsistency.getOrElse(statement.getConsistencyLevel)))
+      .map(statement => readConsistency.map(statement.setConsistencyLevel).getOrElse(statement))
 
     Stream.lift(boundStatement) flatMap session.execute map { row =>
       KafkaKey(
@@ -79,7 +79,7 @@ class CassandraKeys[F[_]: Monad: Fail: Clock](
   ): Stream[F, KafkaKey] = {
     val boundStatement = Statements
       .all(session, applicationId, groupId, segment, topicPartition)
-      .map(statement => statement.setConsistencyLevel(readConsistency.getOrElse(statement.getConsistencyLevel)))
+      .map(statement => readConsistency.map(statement.setConsistencyLevel).getOrElse(statement))
 
     Stream
       .lift(boundStatement)

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/CassandraSnapshots.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/CassandraSnapshots.scala
@@ -23,7 +23,7 @@ import scodec.bits.ByteVector
 
 class CassandraSnapshots[F[_]: MonadThrow: Clock, T](
   session: CassandraSession[F],
-  consistencyOverrides: ConsistencyOverrides = ConsistencyOverrides.default
+  consistencyOverrides: ConsistencyOverrides = ConsistencyOverrides.none
 )(implicit fromBytes: FromBytes[F, T], toBytes: ToBytes[F, T])
     extends SnapshotDatabase[F, KafkaKey, KafkaSnapshot[T]] {
 
@@ -56,7 +56,7 @@ object CassandraSnapshots {
   def withSchema[F[_]: MonadThrow: Clock, T](
     session: CassandraSession[F],
     sync: CassandraSync[F],
-    consistencyOverrides: ConsistencyOverrides = ConsistencyOverrides.default
+    consistencyOverrides: ConsistencyOverrides = ConsistencyOverrides.none
   )(implicit fromBytes: FromBytes[F, T], toBytes: ToBytes[F, T]): F[SnapshotDatabase[F, KafkaKey, KafkaSnapshot[T]]] =
     SnapshotSchema(session, sync).create as new CassandraSnapshots(session, consistencyOverrides)
 

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/CassandraSnapshots.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/CassandraSnapshots.scala
@@ -17,13 +17,14 @@ import com.evolutiongaming.kafka.journal.eventual.cassandra.EventualCassandraCon
 import com.evolutiongaming.kafka.journal.util.SkafkaHelper._
 import com.evolutiongaming.scassandra.syntax._
 import com.evolutiongaming.skafka.Offset
+import CassandraSnapshots._
+
 import scodec.bits.ByteVector
 
 class CassandraSnapshots[F[_]: MonadThrow: Clock, T](
   session: CassandraSession[F]
 )(implicit fromBytes: FromBytes[F, T], toBytes: ToBytes[F, T])
     extends SnapshotDatabase[F, KafkaKey, KafkaSnapshot[T]] {
-  import CassandraSnapshots._
 
   def persist(key: KafkaKey, snapshot: KafkaSnapshot[T]): F[Unit] =
     for {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.9
+sbt.version=1.6.2

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.5.3-SNAPSHOT"
+ThisBuild / version := "0.5.3-B"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.5.3-B"
+ThisBuild / version := "0.5.3-SNAPSHOT"


### PR DESCRIPTION
Currently there is not way to tune consistency level for read/write queries in cassandra-persistence as that level that is provided in `CassandraConfig.client` will be applied for both. My case is to increase consistency level for writes to EACH_QUORUM which will cause a huge performance penalty for reads.
Suggested fix 

- take ConsistencyConfig from kafka-journal
- add new factory method CassandraPersistence.withSchema(session, sync, consistencyConfig) which does the same as `withSchema(session, sync)` but also adds `setConsistencyLevel` on the level of `PreparedStatement` construction.
- move `PreparedStatement` construction to a separate companion as the queries to be referenced from 2 places.

Sample usage on the application side
```
evolutiongaming.appname.cassandra {
  consistency-config {
    read  = ${?CASSANDRA_READ_CONSISTENCY_LEVEL}
    write = ${?CASSANDRA_WRITE_CONSISTENCY_LEVEL}
  }
}
```

and just replace 
```
CassandraPersistence.withSchema(session, sync) to CassandraPersistence.withSchema(session, sync, consistencyConfig)
```

