### PR TITLE
Upgrade to cats-effect 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,11 +39,11 @@ lazy val core = (project in file("core"))
     name := "kafka-flow",
     libraryDependencies ++= Seq(
       Cats.core,
+      Cats.mtl,
       Cats.effect,
-      Cats.effectLaws % Test,
+      Cats.effectTestkit % Test,
       KafkaJournal.journal,
       KafkaJournal.persistence,
-      MeowMtl.effects,
       Monocle.`macro` % Test,
       Monocle.core % Test,
       catsHelper,

--- a/core/src/it/scala/com/evolutiongaming/kafka/flow/SharedResources.scala
+++ b/core/src/it/scala/com/evolutiongaming/kafka/flow/SharedResources.scala
@@ -1,14 +1,14 @@
 package com.evolutiongaming.kafka.flow
 
-import cats.effect.Blocker
 import cats.effect.IO
 import cats.effect.Resource
+import cats.effect.unsafe.IORuntime
 import com.evolutiongaming.catshelper.LogOf
 import com.evolutiongaming.kafka.StartKafka
 import com.evolutiongaming.kafka.flow.kafka.KafkaModule
 import com.evolutiongaming.skafka.consumer.ConsumerConfig
 import com.evolutiongaming.smetrics.CollectorRegistry
-import scala.concurrent.ExecutionContext
+
 import scala.util.Try
 import scribe.Level
 import scribe.Logger
@@ -24,9 +24,7 @@ object SharedResources extends GlobalResource {
 
   def sharedResources(store: GlobalWrite): Resource[IO, Unit] = {
 
-    implicit val executor = ExecutionContext.global
-    implicit val contextShift = IO.contextShift(executor)
-    implicit val timer = IO.timer(executor)
+    implicit val ioRuntime = IORuntime.global
 
     // we use default config here, because we will launch Kafka locally
     val config = ConsumerConfig()
@@ -43,9 +41,8 @@ object SharedResources extends GlobalResource {
     }
     for {
       _ <- Resource.make(start) { shutdown => IO(shutdown()) }
-      blocker <- Blocker[IO]
       kafka <- Resource.eval(LogOf.slf4j[IO]) flatMap { implicit logOf =>
-        KafkaModule.of[IO]("SharedResources", config, CollectorRegistry.empty, blocker)
+        KafkaModule.of[IO]("SharedResources", config, CollectorRegistry.empty)
       }
       _ <- store.putR(kafka)
     } yield ()

--- a/core/src/it/scala/com/evolutiongaming/kafka/flow/ShutdownSpec.scala
+++ b/core/src/it/scala/com/evolutiongaming/kafka/flow/ShutdownSpec.scala
@@ -4,8 +4,8 @@ import ShutdownSpec._
 import cats.data.NonEmptySet
 import cats.effect.IO
 import cats.effect.Resource
-import cats.effect.concurrent.Deferred
-import cats.effect.concurrent.Ref
+import cats.effect.Deferred
+import cats.effect.Ref
 import cats.syntax.all._
 import com.evolutiongaming.catshelper.LogOf
 import com.evolutiongaming.kafka.journal.ConsRecords
@@ -16,7 +16,6 @@ import com.evolutiongaming.skafka.Partition
 import com.evolutiongaming.skafka.producer.ProducerConfig
 import com.evolutiongaming.skafka.producer.ProducerRecord
 import com.evolutiongaming.sstream.Stream
-import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import weaver.GlobalRead
 
@@ -83,7 +82,6 @@ object ShutdownSpec {
   def topicFlowOf(state: Ref[IO, Set[Partition]]): TopicFlowOf[IO] =
     (_, _) => Resource.pure[IO, TopicFlow[IO]] {
       new TopicFlow[IO] {
-        implicit val timer = IO.timer(ExecutionContext.global)
         def apply(records: ConsRecords) = IO.unit
         def add(partitionsAndOffsets: NonEmptySet[(Partition, Offset)]) = {
           val partitions = partitionsAndOffsets map (_._1)

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/AdditionalStatePersistOf.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/AdditionalStatePersistOf.scala
@@ -1,7 +1,7 @@
 package com.evolutiongaming.kafka.flow
 
 import cats.Applicative
-import cats.effect.{Clock, Sync}
+import cats.effect.{Clock, MonadCancelThrow, Ref}
 import com.evolutiongaming.kafka.flow.persistence.Persistence
 import com.evolutiongaming.kafka.journal.ConsRecord
 
@@ -28,7 +28,7 @@ object AdditionalStatePersistOf {
       ): F[AdditionalStatePersist[F, ConsRecord]] = Applicative[F].pure(AdditionalStatePersist.empty[F, ConsRecord])
     }
 
-  def of[F[_]: Sync: Clock, S](cooldown: FiniteDuration): AdditionalStatePersistOf[F, S] = {
+  def of[F[_]: MonadCancelThrow: Ref.Make: Clock, S](cooldown: FiniteDuration): AdditionalStatePersistOf[F, S] = {
     new AdditionalStatePersistOf[F, S] {
       def apply(
         persistence: Persistence[F, S, ConsRecord],

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/KafkaFlow.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/KafkaFlow.scala
@@ -1,19 +1,17 @@
 package com.evolutiongaming.kafka.flow
 
-import cats.effect.Concurrent
-import cats.effect.Resource
-import cats.effect.Timer
+import cats.effect.{Concurrent, Resource}
 import cats.effect.implicits._
+import cats.effect.kernel.Outcome
 import cats.syntax.all._
-import com.evolutiongaming.catshelper.BracketThrowable
-import com.evolutiongaming.catshelper.LogOf
+import com.evolutiongaming.catshelper.{BracketThrowable, LogOf}
+import com.evolutiongaming.kafka.flow.kafka.Consumer
 import com.evolutiongaming.kafka.journal.ConsRecords
 import com.evolutiongaming.random.Random
-import com.evolutiongaming.retry.OnError
-import com.evolutiongaming.retry.Retry
-import com.evolutiongaming.retry.Strategy
+import com.evolutiongaming.retry.{OnError, Retry, Sleep, Strategy}
 import com.evolutiongaming.sstream.Stream
-import kafka.Consumer
+
+import scala.concurrent.CancellationException
 import scala.concurrent.duration._
 
 object KafkaFlow {
@@ -29,23 +27,21 @@ object KafkaFlow {
     * WARNING: Do not forget to `flatMap` returned `F[Unit]` or the
     * potential errors may be lost.
     */
-  def retryOnError[F[_]: Concurrent: Timer: LogOf](
+  def retryOnError[F[_]: Concurrent: Sleep: LogOf](
     consumer: Resource[F, Consumer[F]],
-    flowOf: ConsumerFlowOf[F],
+    flowOf: ConsumerFlowOf[F]
   ): Resource[F, F[Unit]] = {
 
     val retry = for {
       random <- Random.State.fromClock[F]()
       log <- LogOf[F].apply(KafkaFlow.getClass)
     } yield Retry(
-      strategy =
-        Strategy
+      strategy = Strategy
         .exponential(100.millis)
         .jitter(random)
         .cap(1.minute)
         .resetAfter(5.minutes),
-      onError =
-        OnError.fromLog(log)
+      onError = OnError.fromLog(log)
     )
 
     Resource.eval(retry) flatMap { implicit retry =>
@@ -64,13 +60,13 @@ object KafkaFlow {
     */
   def stream[F[_]: BracketThrowable: Retry](
     consumer: Resource[F, Consumer[F]],
-    flowOf: ConsumerFlowOf[F],
+    flowOf: ConsumerFlowOf[F]
   ): Stream[F, ConsRecords] =
     for {
-      _        <- Stream.around(Retry[F].toFunctionK)
+      _ <- Stream.around(Retry[F].toFunctionK)
       consumer <- Stream.fromResource(consumer)
-      flow     <- Stream.fromResource(flowOf(consumer))
-      records  <- flow.stream
+      flow <- Stream.fromResource(flowOf(consumer))
+      records <- flow.stream
     } yield records
 
   /** Process records from consumer with given flow and retry strategy
@@ -82,8 +78,12 @@ object KafkaFlow {
     */
   def resource[F[_]: Concurrent: Retry](
     consumer: Resource[F, Consumer[F]],
-    flowOf: ConsumerFlowOf[F],
+    flowOf: ConsumerFlowOf[F]
   ): Resource[F, F[Unit]] =
-    stream(consumer, flowOf).drain.background
+    stream(consumer, flowOf).drain.background.map(_.flatMap {
+      case Outcome.Succeeded(fa) => fa
+      case Outcome.Errored(e)    => e.raiseError[F, Unit]
+      case Outcome.Canceled()    => new CancellationException().raiseError[F, Unit]
+    })
 
 }

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/KeyContext.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/KeyContext.scala
@@ -1,15 +1,12 @@
 package com.evolutiongaming.kafka.flow
 
-import cats.Applicative
-import cats.Monad
-import cats.effect.Resource
-import cats.effect.Sync
-import cats.effect.concurrent.Ref
-import cats.mtl.MonadState
+import cats.effect.{Ref, Resource}
+import cats.mtl.Stateful
 import cats.syntax.all._
+import cats.{Applicative, Monad}
 import com.evolutiongaming.catshelper.Log
+import com.evolutiongaming.kafka.flow.effect.CatsEffectMtlInstances._
 import com.evolutiongaming.skafka.Offset
-import com.olegpy.meow.effects._
 
 /** Key specific metainformation inside of parititon.
   *
@@ -33,13 +30,13 @@ object KeyContext {
     def remove = ().pure[F]
   }
 
-  def of[F[_]: Sync: Log](removeFromCache: F[Unit]): F[KeyContext[F]] =
+  def of[F[_]: Ref.Make: Monad: Log](removeFromCache: F[Unit]): F[KeyContext[F]] =
     Ref.of[F, Option[Offset]](None) map { storage =>
       KeyContext(storage.stateInstance, removeFromCache)
     }
 
   def apply[F[_]: Monad: Log](
-    storage: MonadState[F, Option[Offset]],
+    storage: Stateful[F, Option[Offset]],
     removeFromCache: F[Unit]
   ): KeyContext[F] = new KeyContext[F] {
     def holding = storage.get
@@ -48,7 +45,7 @@ object KeyContext {
     def log = Log[F]
   }
 
-  def resource[F[_]: Sync](
+  def resource[F[_]: Ref.Make: Monad](
     removeFromCache: F[Unit],
     log: Log[F]
   ): Resource[F, KeyContext[F]] = {

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/KeyFlowOf.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/KeyFlowOf.scala
@@ -1,10 +1,9 @@
 package com.evolutiongaming.kafka.flow
 
-import cats.effect.Resource
-import cats.effect.Sync
-import com.evolutiongaming.kafka.flow.timer.TimerFlowOf
-import persistence.Persistence
-import timer.TimerContext
+import cats.Monad
+import cats.effect.{Ref, Resource}
+import com.evolutiongaming.kafka.flow.persistence.Persistence
+import com.evolutiongaming.kafka.flow.timer.{TimerContext, TimerFlowOf}
 
 trait KeyFlowOf[F[_], S, A] {
 
@@ -26,7 +25,7 @@ object KeyFlowOf {
     * @param fold defines how to change the state on incoming records.
     * @param tick defines what to do when the timer ticks.
     */
-  def apply[F[_]: Sync, K, S, A](
+  def apply[F[_]: Monad: Ref.Make, S, A](
     timerFlowOf: TimerFlowOf[F],
     fold: FoldOption[F, S, A],
     tick: TickOption[F, S]
@@ -40,10 +39,10 @@ object KeyFlowOf {
     * @param fold defines how to change the state on incoming records
     * @param tick defines what to do when the timer ticks
     */
-  def apply[F[_]: Sync, K, S, A](
-                                  timerFlowOf: TimerFlowOf[F],
-                                  fold: EnhancedFold[F, S, A],
-                                  tick: TickOption[F, S]
+  def apply[F[_]: Monad: Ref.Make, S, A](
+    timerFlowOf: TimerFlowOf[F],
+    fold: EnhancedFold[F, S, A],
+    tick: TickOption[F, S]
   ): KeyFlowOf[F, S, A] = { (context, persistence, timers, additionalPersist) =>
     implicit val _context = context
     timerFlowOf(context, persistence, timers) evalMap { timerFlow =>

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/KeyStateOf.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/KeyStateOf.scala
@@ -1,5 +1,6 @@
 package com.evolutiongaming.kafka.flow
 
+import cats.Applicative
 import cats.effect.Resource
 import cats.effect.Sync
 import cats.syntax.all._
@@ -154,7 +155,7 @@ object KeyStateOf {
     * This version allows one to construct a custom `KeyFlowOf`
     * for snapshot persistence.
     */
-  def eagerRecovery[F[_]: Sync, S](
+  def eagerRecovery[F[_]: Applicative, S](
     applicationId: String,
     groupId: String,
     keysOf: KeysOf[F, KafkaKey],
@@ -182,7 +183,7 @@ object KeyStateOf {
     * that was constructed using `EnhancedFold`. In this case, please use another version that expects `AdditionalStatePersistOf`
     * as an argument.
     */
-  def eagerRecovery[F[_]: Sync, S](
+  def eagerRecovery[F[_]: Applicative, S](
     applicationId: String,
     groupId: String,
     keysOf: KeysOf[F, KafkaKey],
@@ -205,7 +206,7 @@ object KeyStateOf {
     * This version allows one to construct a custom `KeyFlowOf`
     * for generic persistence.
     */
-  def eagerRecovery[F[_]: Sync, S](
+  def eagerRecovery[F[_], S](
     applicationId: String,
     groupId: String,
     keysOf: KeysOf[F, KafkaKey],

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/PartitionContext.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/PartitionContext.scala
@@ -1,16 +1,15 @@
 package com.evolutiongaming.kafka.flow
 
-import cats.Applicative
-import cats.effect.Resource
-import cats.effect.Sync
-import cats.effect.concurrent.Ref
+import cats.effect.{Ref, Resource, Sync}
 import cats.syntax.all._
+import cats.{Applicative, Monad}
 import com.evolutiongaming.catshelper.Log
+import com.evolutiongaming.kafka.flow.effect.CatsEffectMtlInstances._
 import com.evolutiongaming.skafka.Offset
-import com.olegpy.meow.effects._
 
 /** Partition specific metainformation inside of topic */
 trait PartitionContext[F[_]] {
+
   /** Request a commit to partition */
   def scheduleCommit(offset: Offset): F[Unit]
 }
@@ -22,7 +21,7 @@ object PartitionContext {
     def scheduleCommit(offset: Offset) = ().pure[F]
   }
 
-  def of[F[_]: Sync: Log](removeFromCache: F[Unit]): F[KeyContext[F]] =
+  def of[F[_]: Ref.Make: Monad: Log](removeFromCache: F[Unit]): F[KeyContext[F]] =
     Ref.of[F, Option[Offset]](None) map { storage =>
       KeyContext(storage.stateInstance, removeFromCache)
     }

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/PartitionFlowOf.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/PartitionFlowOf.scala
@@ -1,8 +1,9 @@
 package com.evolutiongaming.kafka.flow
 
 import cats.Parallel
-import cats.effect.{Concurrent, Resource, Timer}
-import com.evolutiongaming.catshelper.LogOf
+import cats.effect.kernel.Clock
+import cats.effect.{Concurrent, Resource}
+import com.evolutiongaming.catshelper.{LogOf, Runtime}
 import com.evolutiongaming.kafka.flow.PartitionFlow.FilterRecord
 import com.evolutiongaming.skafka.{Offset, TopicPartition}
 
@@ -25,7 +26,7 @@ object PartitionFlowOf {
     *               It doesn't affect committing consumer offsets, thus, even if all records in a batch are skipped,
     *               new offsets will still be committed if necessary
     */
-  def apply[F[_]: Concurrent: Timer: Parallel: LogOf, S](
+  def apply[F[_]: Concurrent: Runtime: Clock: Parallel: LogOf](
     keyStateOf: KeyStateOf[F],
     config: PartitionFlowConfig = PartitionFlowConfig(),
     filter: Option[FilterRecord[F]] = None

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/TopicFlow.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/TopicFlow.scala
@@ -45,7 +45,7 @@ object TopicFlow {
     safeguard(
       for {
         cache <- Cache.loading[F, Partition, PartitionFlow[F]]
-        pendingCommits <- Resource.eval(Ref.of(Map.empty[TopicPartition, OffsetAndMetadata]))
+        pendingCommits <- Resource.eval(Ref.of[F, Map[TopicPartition, OffsetAndMetadata]](Map.empty))
         flow <- LogResource[F](getClass, topic) flatMap { implicit log =>
           of(consumer, topic, partitionFlowOf, cache, pendingCommits)
         }
@@ -154,7 +154,7 @@ object TopicFlow {
     // coz it simply won't be executed, as execution chain would be cancelled
     val r =
       for {
-        closed <- Ref.of(false)
+        closed <- Ref.of[F, Boolean](false)
         semaphore <- Semaphore(1)
         xx <- a.allocated
         (topicFlow, release) = xx

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/TopicFlow.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/TopicFlow.scala
@@ -2,19 +2,16 @@ package com.evolutiongaming.kafka.flow
 
 import cats.Parallel
 import cats.data.NonEmptySet
-import cats.effect.concurrent.{Ref, Semaphore}
-import cats.effect.{Concurrent, Resource}
+import cats.effect.std.Semaphore
 import cats.effect.syntax.all._
+import cats.effect.{Concurrent, Ref, Resource}
 import cats.syntax.all._
 import com.evolutiongaming.catshelper.DataHelper._
-import com.evolutiongaming.catshelper.Log
-import com.evolutiongaming.catshelper.LogOf
-import com.evolutiongaming.kafka.journal.ConsRecords
-import com.evolutiongaming.kafka.journal.PartitionOffset
-import com.evolutiongaming.scache.Cache
-import com.evolutiongaming.scache.Releasable
-import com.evolutiongaming.skafka.{Offset, OffsetAndMetadata, Partition, Topic, TopicPartition}
-import kafka.Consumer
+import com.evolutiongaming.catshelper.{Log, LogOf, Runtime}
+import com.evolutiongaming.kafka.flow.kafka.Consumer
+import com.evolutiongaming.kafka.journal.{ConsRecords, PartitionOffset}
+import com.evolutiongaming.scache.{Cache, Releasable}
+import com.evolutiongaming.skafka._
 
 import scala.collection.immutable.SortedSet
 
@@ -40,7 +37,7 @@ trait TopicFlow[F[_]] {
 }
 object TopicFlow {
 
-  def of[F[_]: Concurrent: Parallel: LogOf](
+  def of[F[_]: Concurrent: Runtime: Parallel: LogOf](
     consumer: Consumer[F],
     topic: Topic,
     partitionFlowOf: PartitionFlowOf[F]
@@ -163,13 +160,13 @@ object TopicFlow {
         (topicFlow, release) = xx
         safeTopicFlow = new TopicFlow[F] {
           def apply(records: ConsRecords): F[Unit] =
-            semaphore.withPermit { closed.get.ifM(().pure[F], topicFlow.apply(records)) }.uncancelable
+            semaphore.permit.use { _ => closed.get.ifM(().pure[F], topicFlow.apply(records)) }.uncancelable
           def add(partitions: NonEmptySet[(Partition, Offset)]): F[Unit] =
-            semaphore.withPermit { closed.get.ifM(().pure[F], topicFlow.add(partitions)) }.uncancelable
+            semaphore.permit.use { _ => closed.get.ifM(().pure[F], topicFlow.add(partitions)) }.uncancelable
           def remove(partitions: NonEmptySet[Partition]): F[Unit] =
-            semaphore.withPermit { closed.get.ifM(().pure[F], topicFlow.remove(partitions)) }.uncancelable
+            semaphore.permit.use { _ => closed.get.ifM(().pure[F], topicFlow.remove(partitions)) }.uncancelable
         }
-        safeRelease = semaphore.withPermit { closed.set(true) *> release }.uncancelable
+        safeRelease = semaphore.permit.use { _ => closed.set(true) *> release }.uncancelable
       } yield (safeTopicFlow, safeRelease)
     Resource(r.uncancelable)
   }

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/TopicFlowOf.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/TopicFlowOf.scala
@@ -1,11 +1,10 @@
 package com.evolutiongaming.kafka.flow
 
 import cats.Parallel
-import cats.effect.Concurrent
-import cats.effect.Resource
-import com.evolutiongaming.catshelper.LogOf
+import cats.effect.{Concurrent, Resource}
+import com.evolutiongaming.catshelper.{LogOf, Runtime}
+import com.evolutiongaming.kafka.flow.kafka.Consumer
 import com.evolutiongaming.skafka.Topic
-import kafka.Consumer
 
 trait TopicFlowOf[F[_]] {
 
@@ -14,7 +13,7 @@ trait TopicFlowOf[F[_]] {
 }
 object TopicFlowOf {
 
-  def apply[F[_]: Concurrent: Parallel: LogOf](
+  def apply[F[_]: Concurrent: Runtime: Parallel: LogOf](
     partitionFlowOf: PartitionFlowOf[F]
   ): TopicFlowOf[F] = { (consumer, topic) =>
     TopicFlow.of(consumer, topic, partitionFlowOf)

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/effect/CatsEffectMtlInstances.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/effect/CatsEffectMtlInstances.scala
@@ -1,0 +1,21 @@
+package com.evolutiongaming.kafka.flow.effect
+
+import cats.Monad
+import cats.effect.Ref
+import cats.mtl.Stateful
+import cats.syntax.functor._
+
+/** meow-mtl library is not updated and supported anymore, this is just a straight copypasta from there */
+private[flow] object CatsEffectMtlInstances {
+  implicit class RefEffects[F[_], A](val self: Ref[F, A]) extends AnyVal {
+    def stateInstance(implicit F: Monad[F]): Stateful[F, A] = new RefStateful[F, A](self)
+  }
+
+  class RefStateful[F[_], S](ref: Ref[F, S])(implicit F: Monad[F]) extends Stateful[F, S] {
+    val monad: Monad[F] = F
+    def get: F[S] = ref.get
+    def set(s: S): F[Unit] = ref.set(s)
+    override def inspect[A](f: S => A): F[A] = ref.get.map(f)
+    override def modify(f: S => S): F[Unit] = ref.update(f)
+  }
+}

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/kafka/Consumer.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/kafka/Consumer.scala
@@ -1,12 +1,12 @@
 package com.evolutiongaming.kafka.flow.kafka
 
+import cats.MonadThrow
 import cats.data.{NonEmptyList, NonEmptyMap, NonEmptySet}
-import cats.effect.Sync
-import cats.effect.concurrent.Ref
+import cats.effect.Ref
 import cats.syntax.all._
 import com.evolutiongaming.kafka.journal.ConsRecords
 import com.evolutiongaming.skafka.consumer.{Consumer => KafkaConsumer, _}
-import com.evolutiongaming.skafka.{Offset, OffsetAndMetadata, PartitionInfo, Topic, TopicPartition}
+import com.evolutiongaming.skafka._
 import scodec.bits.ByteVector
 
 import java.time.Instant
@@ -45,7 +45,7 @@ object Consumer {
   }
 
   /** Does not call Kafka, returns specified records on every poll */
-  def repeat[F[_]: Sync](
+  def repeat[F[_]: MonadThrow: Ref.Make](
     records: ConsRecords
   ): F[Consumer[F]] = Ref.of(Set.empty[RebalanceListener1[F]]) map { listeners =>
     new Consumer[F] {

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/kafka/KafkaModule.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/kafka/KafkaModule.scala
@@ -1,28 +1,14 @@
 package com.evolutiongaming.kafka.flow.kafka
 
-import cats.effect.Blocker
-import cats.effect.Clock
-import cats.effect.ConcurrentEffect
-import cats.effect.ContextShift
-import cats.effect.Resource
-import cats.effect.Timer
+import cats.effect.{Async, Clock, Resource}
 import cats.syntax.all._
-import com.evolutiongaming.catshelper.FromTry
-import com.evolutiongaming.catshelper.LogOf
-import com.evolutiongaming.catshelper.ToFuture
-import com.evolutiongaming.catshelper.ToTry
+import com.evolutiongaming.catshelper.{FromTry, LogOf, ToFuture, ToTry}
 import com.evolutiongaming.kafka.flow.LogResource
-import com.evolutiongaming.kafka.journal.KafkaConfig
-import com.evolutiongaming.kafka.journal.KafkaHealthCheck
-import com.evolutiongaming.kafka.journal.RandomIdOf
 import com.evolutiongaming.kafka.journal.util.SkafkaHelper._
-import com.evolutiongaming.kafka.journal.{KafkaConsumerOf => JournalConsumerOf}
-import com.evolutiongaming.kafka.journal.{KafkaProducerOf => JournalProducerOf}
-import com.evolutiongaming.skafka.consumer.AutoOffsetReset
-import com.evolutiongaming.skafka.consumer.{ConsumerConfig, ConsumerMetrics, ConsumerOf => RawConsumerOf}
+import com.evolutiongaming.kafka.journal.{KafkaConfig, KafkaHealthCheck, RandomIdOf, KafkaConsumerOf => JournalConsumerOf, KafkaProducerOf => JournalProducerOf}
+import com.evolutiongaming.skafka.consumer.{AutoOffsetReset, ConsumerConfig, ConsumerMetrics, ConsumerOf => RawConsumerOf}
 import com.evolutiongaming.skafka.producer.{ProducerConfig, ProducerMetrics, ProducerOf => RawProducerOf}
-import com.evolutiongaming.smetrics.CollectorRegistry
-import com.evolutiongaming.smetrics.MeasureDuration
+import com.evolutiongaming.smetrics.{CollectorRegistry, MeasureDuration}
 import scodec.bits.ByteVector
 
 trait KafkaModule[F[_]] {
@@ -35,18 +21,17 @@ trait KafkaModule[F[_]] {
 }
 object KafkaModule {
 
-  def of[F[_]: ConcurrentEffect: ContextShift: FromTry: ToTry: ToFuture: Timer: LogOf](
+  def of[F[_]: Async: FromTry: ToTry: ToFuture: LogOf](
     applicationId: String,
     config: ConsumerConfig,
-    registry: CollectorRegistry[F],
-    blocker: Blocker
+    registry: CollectorRegistry[F]
   ): Resource[F, KafkaModule[F]] = {
     implicit val measureDuration = MeasureDuration.fromClock[F](Clock[F])
     for {
       producerMetrics      <- ProducerMetrics.of(registry)
       consumerMetrics      <- ConsumerMetrics.of(registry)
-      _producerOf            = RawProducerOf.apply1[F](blocker.blockingContext, producerMetrics(applicationId).some)
-      _consumerOf            = RawConsumerOf[F](blocker.blockingContext, consumerMetrics(applicationId).some)
+      _producerOf            = RawProducerOf.apply1[F](producerMetrics(applicationId).some)
+      _consumerOf            = RawConsumerOf.apply1[F](consumerMetrics(applicationId).some)
       _healthCheck          <- {
         implicit val randomIdOf = RandomIdOf.uuid[F]
         implicit val journalProducerOf = JournalProducerOf[F](_producerOf)

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/key/KeyDatabase.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/key/KeyDatabase.scala
@@ -1,14 +1,13 @@
 package com.evolutiongaming.kafka.flow.key
 
-import cats.{Applicative, Monad}
-import cats.effect.Sync
-import cats.effect.concurrent.Ref
+import cats.effect.{Ref, Sync}
+import cats.mtl.Stateful
 import cats.syntax.all._
-import cats.mtl.MonadState
+import cats.{Applicative, Monad}
 import com.evolutiongaming.catshelper.LogOf
+import com.evolutiongaming.kafka.flow.effect.CatsEffectMtlInstances._
 import com.evolutiongaming.skafka.TopicPartition
 import com.evolutiongaming.sstream.Stream
-import com.olegpy.meow.effects._
 
 trait KeyDatabase[F[_], K] {
 
@@ -33,7 +32,7 @@ object KeyDatabase {
     }
 
   /** Creates in-memory database implementation */
-  def memory[F[_]: Monad, K](storage: MonadState[F, Set[K]]): KeyDatabase[F, K] =
+  def memory[F[_]: Monad, K](storage: Stateful[F, Set[K]]): KeyDatabase[F, K] =
     new KeyDatabase[F, K] {
 
       def persist(key: K) =

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotDatabase.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotDatabase.scala
@@ -1,12 +1,11 @@
 package com.evolutiongaming.kafka.flow.snapshot
 
-import cats.{Applicative, Functor}
-import cats.effect.Sync
-import cats.effect.concurrent.Ref
-import cats.mtl.MonadState
+import cats.effect.{Ref, Sync}
+import cats.mtl.Stateful
 import cats.syntax.all._
+import cats.{Applicative, Functor}
 import com.evolutiongaming.catshelper.LogOf
-import com.olegpy.meow.effects._
+import com.evolutiongaming.kafka.flow.effect.CatsEffectMtlInstances._
 
 trait SnapshotDatabase[F[_], K, S] extends SnapshotReadDatabase[F, K, S] with SnapshotWriteDatabase[F, K, S]
 
@@ -41,7 +40,7 @@ object SnapshotDatabase {
     * The data will survive destruction of specific `Snapshots` instance,
     * but will not survive destruction of specific `SnapshotDatabase` instance.
     */
-  def memory[F[_]: Functor, K, S](storage: MonadState[F, Map[K, S]]): SnapshotDatabase[F, K, S] =
+  def memory[F[_]: Functor, K, S](storage: Stateful[F, Map[K, S]]): SnapshotDatabase[F, K, S] =
     new SnapshotDatabase[F, K, S] {
 
       def persist(key: K, snapshot: S) =

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/Snapshots.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/Snapshots.scala
@@ -1,13 +1,11 @@
 package com.evolutiongaming.kafka.flow.snapshot
 
-import cats.Applicative
-import cats.Monad
-import cats.effect.Sync
-import cats.effect.concurrent.Ref
+import cats.{Applicative, Monad}
+import cats.effect.{Ref, Sync}
+import cats.mtl.Stateful
 import cats.syntax.all._
-import cats.mtl.MonadState
 import com.evolutiongaming.catshelper.Log
-import com.olegpy.meow.effects._
+import com.evolutiongaming.kafka.flow.effect.CatsEffectMtlInstances._
 
 trait Snapshots[F[_], S] extends SnapshotReader[F, S] with SnapshotWriter[F, S]
 
@@ -54,7 +52,7 @@ object Snapshots {
   private[flow] def apply[F[_]: Monad: Log, K, S](
     key: K,
     database: SnapshotDatabase[F, K, S],
-    buffer: MonadState[F, Option[Snapshot[S]]]
+    buffer: Stateful[F, Option[Snapshot[S]]]
   ): Snapshots[F, S] = new Snapshots[F, S] {
 
     def read = database.get(key)

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/timer/TimerDatabase.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/timer/TimerDatabase.scala
@@ -1,14 +1,12 @@
 package com.evolutiongaming.kafka.flow.timer
 
-import cats.Applicative
-import cats.Monad
-import cats.effect.Sync
-import cats.effect.concurrent.Ref
+import cats.{Applicative, Monad}
+import cats.effect.{Ref, Sync}
+import cats.mtl.Stateful
 import cats.syntax.all._
-import cats.mtl.MonadState
 import com.evolutiongaming.catshelper.Log
+import com.evolutiongaming.kafka.flow.effect.CatsEffectMtlInstances._
 import com.evolutiongaming.sstream.Stream
-import com.olegpy.meow.effects._
 
 trait TimerDatabase[F[_], K, T] {
 
@@ -36,7 +34,7 @@ object TimerDatabase {
     * but will not survive destruction of specific `TimerDatabase` instance.
     */
   def memory[F[_]: Monad, K, T](
-    storage: MonadState[F, Map[K, Set[T]]]
+    storage: Stateful[F, Map[K, Set[T]]]
   ): TimerDatabase[F, K, T] = new TimerDatabase[F, K, T] {
 
     def persist(key: K, timer: T) = storage modify { storage =>

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/timer/Timers.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/timer/Timers.scala
@@ -1,14 +1,13 @@
 package com.evolutiongaming.kafka.flow.timer
 
-import cats.Applicative
-import cats.Monad
-import cats.effect.Sync
-import cats.effect.concurrent.Ref
+import cats.{Applicative, Monad}
+import cats.effect.{Ref, Sync}
+import cats.mtl.Stateful
 import cats.syntax.all._
-import cats.mtl.MonadState
 import com.evolutiongaming.catshelper.Log
+import com.evolutiongaming.kafka.flow.effect.CatsEffectMtlInstances._
 import com.evolutiongaming.skafka.Offset
-import com.olegpy.meow.effects._
+
 import java.time.Instant
 
 /** Contains the scheduled, optionally persistent, timers for the key. */
@@ -78,7 +77,7 @@ object Timers {
       of(key, database)
     }
 
-  def of[F[_]: Sync: ReadTimestamps: Log, K](
+  def of[F[_]: Monad: Ref.Make: ReadTimestamps: Log, K](
     key: K,
     database: TimerDatabase[F, K, KafkaTimer],
   ): F[Timers[F]] =
@@ -88,11 +87,11 @@ object Timers {
 
   /** Only stores timers in buffers, does not save anything to database */
   def transient[F[_]: Monad: ReadTimestamps: Log](
-    buffer: MonadState[F, TimerState]
+    buffer: Stateful[F, TimerState]
   ): Timers[F] = Timers((), TimerDatabase.empty, buffer)
 
   def transient[F[_]: Monad: Log](
-    buffer: MonadState[F, TimerState],
+    buffer: Stateful[F, TimerState],
     timestamps: ReadTimestamps[F]
   ): Timers[F] = {
     implicit val _timestamps = timestamps
@@ -102,7 +101,7 @@ object Timers {
   def apply[F[_]: Monad: ReadTimestamps: Log, K](
     key: K,
     database: TimerDatabase[F, K, KafkaTimer],
-    buffer: MonadState[F, TimerState]
+    buffer: Stateful[F, TimerState]
   ): Timers[F] = new Timers[F] {
 
     def registerWatermark(timestamp: Instant) =

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/timer/Timestamps.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/timer/Timestamps.scala
@@ -1,12 +1,10 @@
 package com.evolutiongaming.kafka.flow.timer
 
-import cats.Functor
-import cats.effect.Resource
-import cats.effect.Sync
-import cats.effect.concurrent.Ref
+import cats.{Functor, Monad}
+import cats.effect.{Ref, Resource, Sync}
+import cats.mtl.Stateful
 import cats.syntax.all._
-import cats.mtl.MonadState
-import com.olegpy.meow.effects._
+import com.evolutiongaming.kafka.flow.effect.CatsEffectMtlInstances._
 
 /** Contains timestamp related to a specific key.
   *
@@ -51,7 +49,7 @@ object Timestamps {
     *
     * @param createdAt Current timestamp at the time the key was encountered.
     */
-  def of[F[_]: Sync](createdAt: Timestamp): F[Timestamps[F]] =
+  def of[F[_]: Monad: Ref.Make](createdAt: Timestamp): F[Timestamps[F]] =
     Ref.of(TimestampState(createdAt)) map { storage =>
       Timestamps(storage.stateInstance)
     }
@@ -61,7 +59,7 @@ object Timestamps {
 
   /** Creates a timestamp storage for a key */
   def apply[F[_]: Functor](
-    storage: MonadState[F, TimestampState],
+    storage: Stateful[F, TimestampState]
   ): Timestamps[F] = new Timestamps[F] {
 
     def current = storage.get map (_.current)

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/FoldToStateSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/FoldToStateSpec.scala
@@ -1,17 +1,14 @@
 package com.evolutiongaming.kafka.flow
 
-import cats.data.NonEmptyList
-import cats.data.State
-import cats.mtl.MonadState
-import cats.mtl.implicits._
+import cats.data.{NonEmptyList, State}
+import cats.mtl.Stateful
 import com.evolutiongaming.catshelper.Log
+import com.evolutiongaming.kafka.flow.FoldToStateSpec._
 import com.evolutiongaming.kafka.flow.MonadStateHelper._
 import com.evolutiongaming.kafka.flow.persistence.Persistence
 import com.evolutiongaming.skafka.Offset
 import monocle.macros.GenLens
 import munit.FunSuite
-
-import FoldToStateSpec._
 
 class FoldToStateSpec extends FunSuite {
 
@@ -95,8 +92,8 @@ object FoldToStateSpec {
 
   class ConstFixture {
 
-    val storage: MonadState[F, Option[Int]] =
-      MonadState[F, Context] focus GenLens[Context](_.state)
+    val storage: Stateful[F, Option[Int]] =
+      Stateful[F, Context] focus GenLens[Context](_.state)
 
     /** Calculates number of events until `n` events are reached */
     def foldUntil(n: Int): FoldOption[F, Int, String] = FoldOption.of { (state, _) =>

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/KeyFlowSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/KeyFlowSpec.scala
@@ -2,7 +2,7 @@ package com.evolutiongaming.kafka.flow
 
 import cats.data.NonEmptyList
 import cats.effect.SyncIO
-import cats.effect.concurrent.Ref
+import cats.effect.Ref
 import cats.syntax.all._
 import com.evolutiongaming.catshelper.Log
 import com.evolutiongaming.kafka.flow.kafka.ToOffset

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/MonadStateHelper.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/MonadStateHelper.scala
@@ -1,15 +1,14 @@
 package com.evolutiongaming.kafka.flow
 
 import cats.Functor
+import cats.mtl.Stateful
 import cats.syntax.all._
-import cats.mtl.DefaultMonadState
-import cats.mtl.MonadState
 import monocle.Lens
 
 object MonadStateHelper {
 
-  implicit class MonadStateOps[F[_]: Functor, A, B](val self: MonadState[F, A]) {
-    def focus(lens: Lens[A, B]): MonadState[F, B] = new DefaultMonadState[F, B] {
+  implicit class MonadStateOps[F[_]: Functor, A, B](val self: Stateful[F, A]) {
+    def focus(lens: Lens[A, B]): Stateful[F, B] = new Stateful[F, B] {
       val monad = self.monad
       def get = self.get map lens.get
       def set(b: B) = self modify lens.set(b)

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/journal/JournalDatabaseSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/journal/JournalDatabaseSpec.scala
@@ -1,15 +1,14 @@
 package com.evolutiongaming.kafka.flow.journal
 
 import cats.data.State
+import cats.mtl.Stateful
 import cats.syntax.all._
-import cats.mtl.MonadState
-import cats.mtl.implicits._
+import com.evolutiongaming.kafka.flow.journal.JournalDatabaseSpec._
 import com.evolutiongaming.kafka.flow.kafka.ToOffset
 import com.evolutiongaming.skafka.Offset
 import munit.FunSuite
-import scala.collection.immutable.SortedMap
 
-import JournalDatabaseSpec._
+import scala.collection.immutable.SortedMap
 
 class JournalDatabaseSpec extends FunSuite {
 
@@ -97,7 +96,7 @@ object JournalDatabaseSpec {
   type Context = Map[K, SortedMap[Offset, E]]
 
   class ConstFixture {
-    val database = MonadState[F, Context]
+    val database = Stateful[F, Context]
   }
 
   implicit val withOffset: ToOffset[(Int, String)] = { case (offset, _) =>

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/journal/JournalsSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/journal/JournalsSpec.scala
@@ -1,18 +1,17 @@
 package com.evolutiongaming.kafka.flow.journal
 
 import cats.data.State
+import cats.mtl.Stateful
 import cats.syntax.all._
-import cats.mtl.MonadState
-import cats.mtl.implicits._
 import com.evolutiongaming.catshelper.Log
 import com.evolutiongaming.kafka.flow.MonadStateHelper._
+import com.evolutiongaming.kafka.flow.journal.JournalsSpec._
 import com.evolutiongaming.kafka.flow.kafka.ToOffset
 import com.evolutiongaming.skafka.Offset
 import monocle.macros.GenLens
 import munit.FunSuite
-import scala.collection.immutable.SortedMap
 
-import JournalsSpec._
+import scala.collection.immutable.SortedMap
 
 class JournalsSpec extends FunSuite {
 
@@ -136,8 +135,8 @@ object JournalsSpec {
   )
 
   class ConstFixture {
-    val database = MonadState[F, Context] focus GenLens[Context](_.database)
-    val buffer = MonadState[F, Context] focus GenLens[Context](_.buffer)
+    val database = Stateful[F, Context] focus GenLens[Context](_.database)
+    val buffer = Stateful[F, Context] focus GenLens[Context](_.buffer)
   }
 
   implicit val log: Log[F] = Log.empty[F]

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/key/KeysSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/key/KeysSpec.scala
@@ -1,12 +1,10 @@
 package com.evolutiongaming.kafka.flow.key
 
 import cats.data.State
-import cats.mtl.MonadState
-import cats.mtl.implicits._
+import cats.mtl.Stateful
 import com.evolutiongaming.catshelper.Log
+import com.evolutiongaming.kafka.flow.key.KeysSpec._
 import munit.FunSuite
-
-import KeysSpec._
 
 class KeysSpec extends FunSuite {
 
@@ -71,7 +69,7 @@ object KeysSpec {
   type F[T] = State[Set[String], T]
 
   class ConstFixture {
-    val database = MonadState[F, Set[String]]
+    val database = Stateful[F, Set[String]]
   }
 
   implicit val log: Log[F] = Log.empty[F]

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/persistence/PersistenceSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/persistence/PersistenceSpec.scala
@@ -1,19 +1,17 @@
 package com.evolutiongaming.kafka.flow.persistence
 
 import cats.data.State
-import cats.syntax.all._
 import cats.mtl._
-import cats.mtl.implicits._
+import cats.syntax.all._
 import com.evolutiongaming.kafka.flow.MonadStateHelper._
-import com.evolutiongaming.kafka.flow.timer.Timestamp
-import com.evolutiongaming.kafka.flow.timer.Timestamps
+import com.evolutiongaming.kafka.flow.persistence.PersistenceSpec._
+import com.evolutiongaming.kafka.flow.timer.{Timestamp, Timestamps}
 import com.evolutiongaming.kafka.flow.timer.Timestamps.TimestampState
 import com.evolutiongaming.skafka.Offset
-import java.time.Instant
 import monocle.macros.GenLens
 import munit.FunSuite
 
-import PersistenceSpec._
+import java.time.Instant
 
 class PersistenceSpec extends FunSuite {
 
@@ -118,7 +116,7 @@ object PersistenceSpec {
     )
 
     implicit val timestamps: Timestamps[F] = Timestamps(
-      MonadState[F, Context] focus GenLens[Context](_.timestamps)
+      Stateful[F, Context] focus GenLens[Context](_.timestamps)
     )
 
     val persistence: Persistence[F, Int, String] = Persistence(

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotsSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotsSpec.scala
@@ -1,8 +1,7 @@
 package com.evolutiongaming.kafka.flow.snapshot
 
 import cats.data.State
-import cats.mtl.MonadState
-import cats.mtl.implicits._
+import cats.mtl.Stateful
 import cats.syntax.all._
 import com.evolutiongaming.catshelper.Log
 import com.evolutiongaming.kafka.flow.MonadStateHelper._
@@ -142,8 +141,8 @@ object SnapshotsSpec {
   )
 
   class ConstFixture {
-    val database = MonadState[F, Context] focus GenLens[Context](_.database)
-    val buffer = MonadState[F, Context] focus GenLens[Context](_.buffer)
+    val database = Stateful[F, Context] focus GenLens[Context](_.database)
+    val buffer = Stateful[F, Context] focus GenLens[Context](_.buffer)
   }
 
   implicit val log: Log[F] = Log.empty[F]
@@ -154,7 +153,7 @@ object SnapshotsSpec {
     def persistsCounted: Int
   }
 
-  def countingSnapshotDb(storage: MonadState[F, Map[K, S]]): SnapshotDatabaseWithPersistCount = {
+  def countingSnapshotDb(storage: Stateful[F, Map[K, S]]): SnapshotDatabaseWithPersistCount = {
     new SnapshotDatabaseWithPersistCount {
       val db = SnapshotDatabase.memory(storage)
       var persistCounter = 0

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/timer/TimerFlowOfSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/timer/TimerFlowOfSpec.scala
@@ -1,23 +1,22 @@
 package com.evolutiongaming.kafka.flow.timer
 
-import Timers.TimerState
-import Timestamps.TimestampState
-import cats.data.StateT
-import cats.effect.SyncIO
-import cats.mtl.MonadState
-import cats.mtl.implicits._
+import cats.effect.IO
+import cats.effect.kernel.Ref
+import cats.effect.unsafe.implicits.global
 import cats.syntax.all._
 import com.evolutiongaming.catshelper.Log
 import com.evolutiongaming.kafka.flow.KeyContext
 import com.evolutiongaming.kafka.flow.MonadStateHelper._
 import com.evolutiongaming.kafka.flow.persistence.FlushBuffers
+import com.evolutiongaming.kafka.flow.timer.TimerFlowSpec._
+import com.evolutiongaming.kafka.flow.timer.Timers.TimerState
+import com.evolutiongaming.kafka.flow.timer.Timestamps.TimestampState
 import com.evolutiongaming.skafka.Offset
-import java.time.Instant
 import monocle.macros.GenLens
 import munit.FunSuite
-import scala.concurrent.duration._
 
-import TimerFlowSpec._
+import java.time.Instant
+import scala.concurrent.duration._
 
 class TimerFlowOfSpec extends FunSuite {
 
@@ -28,17 +27,22 @@ class TimerFlowOfSpec extends FunSuite {
     // Given("flow flushes after 3 messages accumulated")
     val startedAt = f.timestamp.copy(offset = Offset.unsafe(1234))
     val context = Context(timestamps = TimestampState(startedAt))
-    val flowOf = TimerFlowOf.unloadOrphaned[F](fireEvery = 0.minutes, maxOffsetDifference = 3)
-    val flow = flowOf(keyContext, flushBuffers, timerContext)
+    val flowOf = TimerFlowOf.unloadOrphaned[IO](fireEvery = 0.minutes, maxOffsetDifference = 3)
+    val flow = flowOf(f.keyContext, f.flushBuffers, f.timerContext)
 
     // When("flow is started")
-    val result = flow.allocated.runS(context).unsafeRunSync()
-
-    // Then("offset is being held")
-    assertEquals(result.holding, Some(Offset.unsafe(1234)))
-    assertEquals(result.flushed, 0)
-    assertEquals(result.removed, 0)
-
+    val testIO = for {
+      _ <- f.contextRef.set(context)
+      _ <- flow.use { _ => IO.unit }
+      result <- f.contextRef.get
+    } yield {
+      // Then("offset is being held")
+      assertEquals(result.holding, Some(Offset.unsafe(1234)))
+      assertEquals(result.flushed, 0)
+      assertEquals(result.removed, 0)
+    }
+    
+    testIO.unsafeRunSync()
   }
 
   test("unloadOrphaned does not flush immediately") {
@@ -47,19 +51,21 @@ class TimerFlowOfSpec extends FunSuite {
 
     // Given("flow flushes after 3 messages accumulated")
     val context = Context(timestamps = TimestampState(f.timestamp))
-    val flowOf = TimerFlowOf.unloadOrphaned[F](fireEvery = 0.minutes, maxOffsetDifference = 3)
-    val flow = flowOf(keyContext, flushBuffers, timerContext)
+    val flowOf = TimerFlowOf.unloadOrphaned[IO](fireEvery = 0.minutes, maxOffsetDifference = 3)
+    val flow = flowOf(f.keyContext, f.flushBuffers, f.timerContext)
 
     // When("timers trigger called")
-    val program = flow use { flow =>
-      timerContext.trigger(flow)
+    val testIO = for {
+      _ <- f.contextRef.set(context)
+      _ <- flow.use { flow => f.timerContext.trigger(flow) }
+      result <-  f.contextRef.get
+    } yield {
+      // Then("flush does not happen")
+      assertEquals(result.flushed, 0)
+      assertEquals(result.removed, 0)
     }
-    val result = program.runS(context).unsafeRunSync()
-
-    // Then("flush does not happen")
-    assertEquals(result.flushed, 0)
-    assertEquals(result.removed, 0)
-
+    
+    testIO.unsafeRunSync()
   }
 
   test("unloadOrphaned flushes after offset is reached") {
@@ -69,27 +75,33 @@ class TimerFlowOfSpec extends FunSuite {
     // Given("flow flushes after 3 messages accumulated")
     val startedAt = f.timestamp.copy(offset = Offset.unsafe(1000))
     val context = Context(timestamps = TimestampState(startedAt))
-    val flowOf = TimerFlowOf.unloadOrphaned[F](fireEvery = 0.minutes, maxOffsetDifference = 3)
-    val flow = flowOf(keyContext, flushBuffers, timerContext)
+    val flowOf = TimerFlowOf.unloadOrphaned[IO](fireEvery = 0.minutes, maxOffsetDifference = 3)
+    val flow = flowOf(f.keyContext, f.flushBuffers, f.timerContext)
 
     // When("timers trigger called")
     val program = flow use { flow =>
-      timerContext.set(f.timestamp.copy(offset = Offset.unsafe(1001))) *>
-      timerContext.trigger(flow) *>
-      timerContext.set(f.timestamp.copy(offset = Offset.unsafe(1002))) *>
-      timerContext.trigger(flow) *>
-      timerContext.set(f.timestamp.copy(offset = Offset.unsafe(1003))) *>
-      timerContext.trigger(flow) *>
-      timerContext.set(f.timestamp.copy(offset = Offset.unsafe(1004))) *>
-      timerContext.trigger(flow)
+      f.timerContext.set(f.timestamp.copy(offset = Offset.unsafe(1001))) *>
+        f.timerContext.trigger(flow) *>
+        f.timerContext.set(f.timestamp.copy(offset = Offset.unsafe(1002))) *>
+        f.timerContext.trigger(flow) *>
+        f.timerContext.set(f.timestamp.copy(offset = Offset.unsafe(1003))) *>
+        f.timerContext.trigger(flow) *>
+        f.timerContext.set(f.timestamp.copy(offset = Offset.unsafe(1004))) *>
+        f.timerContext.trigger(flow)
     }
-    val result = program.runS(context).unsafeRunSync()
-
-    // Then("flush happens and remove happens")
-    assertEquals(result.flushed, 1)
-    assertEquals(result.removed, 1)
+    
+    val testIO = for {
+      _ <- f.contextRef.set(context)
+      _ <- program
+      result <- f.contextRef.get
+    } yield {
+      // Then("flush happens and remove happens")
+      assertEquals(result.flushed, 1)
+      assertEquals(result.removed, 1)
+    }
+    
+    testIO.unsafeRunSync()
   }
-
 
   test("unloadOrphaned does not flush before offset is reached") {
 
@@ -98,24 +110,30 @@ class TimerFlowOfSpec extends FunSuite {
     // Given("flow flushes after 3 messages accumulated")
     val startedAt = f.timestamp.copy(offset = Offset.unsafe(1000))
     val context = Context(timestamps = TimestampState(startedAt))
-    val flowOf = TimerFlowOf.unloadOrphaned[F](fireEvery = 0.minutes, maxOffsetDifference = 3)
-    val flow = flowOf(keyContext, flushBuffers, timerContext)
+    val flowOf = TimerFlowOf.unloadOrphaned[IO](fireEvery = 0.minutes, maxOffsetDifference = 3)
+    val flow = flowOf(f.keyContext, f.flushBuffers, f.timerContext)
 
     // When("timers trigger called")
     val program = flow use { flow =>
-      timerContext.set(f.timestamp.copy(offset = Offset.unsafe(1001))) *>
-      timerContext.trigger(flow) *>
-      timerContext.set(f.timestamp.copy(offset = Offset.unsafe(1002))) *>
-      timerContext.trigger(flow) *>
-      timerContext.set(f.timestamp.copy(offset = Offset.unsafe(1003))) *>
-      timerContext.trigger(flow)
+      f.timerContext.set(f.timestamp.copy(offset = Offset.unsafe(1001))) *>
+        f.timerContext.trigger(flow) *>
+        f.timerContext.set(f.timestamp.copy(offset = Offset.unsafe(1002))) *>
+        f.timerContext.trigger(flow) *>
+        f.timerContext.set(f.timestamp.copy(offset = Offset.unsafe(1003))) *>
+        f.timerContext.trigger(flow)
     }
-    val result = program.runS(context).unsafeRunSync()
-
-    // Then("neither flush or remove happens")
-    assertEquals(result.flushed, 0)
-    assertEquals(result.removed, 0)
-
+    
+    val testIO = for {
+      _ <- f.contextRef.set(context)
+      _ <- program
+      result <- f.contextRef.get
+    } yield {
+      // Then("neither flush or remove happens")
+      assertEquals(result.flushed, 0)
+      assertEquals(result.removed, 0)
+    }
+    
+    testIO.unsafeRunSync()
   }
 
   test("unloadOrphaned does not flush if state was timely touched") {
@@ -125,27 +143,34 @@ class TimerFlowOfSpec extends FunSuite {
     // Given("flow flushes after 3 messages accumulated")
     val startedAt = f.timestamp.copy(offset = Offset.unsafe(1000))
     val context = Context(timestamps = TimestampState(startedAt))
-    val flowOf = TimerFlowOf.unloadOrphaned[F](fireEvery = 0.minutes, maxOffsetDifference = 3)
-    val flow = flowOf(keyContext, flushBuffers, timerContext)
+    val flowOf = TimerFlowOf.unloadOrphaned[IO](fireEvery = 0.minutes, maxOffsetDifference = 3)
+    val flow = flowOf(f.keyContext, f.flushBuffers, f.timerContext)
 
     // When("timers trigger called")
     val program = flow use { flow =>
-      timerContext.set(f.timestamp.copy(offset = Offset.unsafe(1001))) *>
-      timerContext.trigger(flow) *>
-      timerContext.set(f.timestamp.copy(offset = Offset.unsafe(1002))) *>
-      timerContext.trigger(flow) *>
-      timerContext.set(f.timestamp.copy(offset = Offset.unsafe(1003))) *>
-      timerContext.trigger(flow) *>
-      timerContext.set(f.timestamp.copy(offset = Offset.unsafe(1004))) *>
-      timerContext.onProcessed *>
-      timerContext.trigger(flow)
+      f.timerContext.set(f.timestamp.copy(offset = Offset.unsafe(1001))) *>
+        f.timerContext.trigger(flow) *>
+        f.timerContext.set(f.timestamp.copy(offset = Offset.unsafe(1002))) *>
+        f.timerContext.trigger(flow) *>
+        f.timerContext.set(f.timestamp.copy(offset = Offset.unsafe(1003))) *>
+        f.timerContext.trigger(flow) *>
+        f.timerContext.set(f.timestamp.copy(offset = Offset.unsafe(1004))) *>
+        f.timerContext.onProcessed *>
+        f.timerContext.trigger(flow)
     }
-    val result = program.runS(context).unsafeRunSync()
 
-    // Then("neither flush or remove happens")
-    assertEquals(result.flushed, 0)
-    assertEquals(result.removed, 0)
 
+    val testIO = for {
+      _ <- f.contextRef.set(context)
+      _ <- program
+      result <- f.contextRef.get
+    } yield {
+      // Then("neither flush or remove happens")
+      assertEquals(result.flushed, 0)
+      assertEquals(result.removed, 0)
+    }
+
+    testIO.unsafeRunSync()
   }
 
   test("unloadOrphaned flushes when resource is cancelled if configured to do so") {
@@ -154,16 +179,23 @@ class TimerFlowOfSpec extends FunSuite {
 
     // Given("flow is configured to flush on revoke")
     val context = Context(timestamps = TimestampState(f.timestamp))
-    val flowOf = TimerFlowOf.unloadOrphaned[F](flushOnRevoke = true)
-    val flow = flowOf(keyContext, flushBuffers, timerContext)
+    val flowOf = TimerFlowOf.unloadOrphaned[IO](flushOnRevoke = true)
+    val flow = flowOf(f.keyContext, f.flushBuffers, f.timerContext)
 
     // When("flow is started and cancelled")
-    val program = flow use { _ => ().pure[F] }
-    val result = program.runS(context).unsafeRunSync()
+    val program = flow use { _ => ().pure[IO] }
 
-    // Then("state is flushed and removed")
-    assertEquals(result.flushed, 1)
-    assertEquals(result.removed, 1)
+    val testIO = for {
+      _ <- f.contextRef.set(context)
+      _ <- program
+      result <- f.contextRef.get
+    } yield {
+      // Then("state is flushed and removed")
+      assertEquals(result.flushed, 1)
+      assertEquals(result.removed, 1)
+    }
+
+    testIO.unsafeRunSync()
 
   }
 
@@ -173,16 +205,23 @@ class TimerFlowOfSpec extends FunSuite {
 
     // Given("flow is configured to flush on revoke")
     val context = Context(timestamps = TimestampState(f.timestamp))
-    val flowOf = TimerFlowOf.unloadOrphaned[F](flushOnRevoke = false)
-    val flow = flowOf(keyContext, flushBuffers, timerContext)
+    val flowOf = TimerFlowOf.unloadOrphaned[IO](flushOnRevoke = false)
+    val flow = flowOf(f.keyContext, f.flushBuffers, f.timerContext)
 
     // When("flow is started and cancelled")
-    val program = flow use { _ => ().pure[F] }
-    val result = program.runS(context).unsafeRunSync()
+    val program = flow use { _ => ().pure[IO] }
 
-    // Then("neither flush or remove happens")
-    assertEquals(result.flushed, 0)
-    assertEquals(result.removed, 0)
+    val testIO = for {
+      _ <- f.contextRef.set(context)
+      _ <- program
+      result <- f.contextRef.get
+    } yield {
+      // Then("neither flush or remove happens")
+      assertEquals(result.flushed, 0)
+      assertEquals(result.removed, 0)
+    }
+
+    testIO.unsafeRunSync()
 
   }
 
@@ -193,33 +232,31 @@ class TimerFlowOfSpec extends FunSuite {
     // Given("flow flushes after 3 messages accumulated")
     val startedAt = f.timestamp.copy(offset = Offset.unsafe(1000))
     val context = Context(timestamps = TimestampState(startedAt))
-    val flowOf = TimerFlowOf.unloadOrphaned[F](
+    val flowOf = TimerFlowOf.unloadOrphaned[IO](
       fireEvery = 0.minutes,
       maxOffsetDifference = 3,
       flushOnRevoke = true
     )
-    val flow = flowOf(keyContext, flushBuffers, timerContext)
+    val flow = flowOf(f.keyContext, f.flushBuffers, f.timerContext)
 
     // When("timers trigger called")
-    val program = flow use { flow =>
-      timerContext.set(f.timestamp.copy(offset = Offset.unsafe(1001))) *>
-      timerContext.trigger(flow) *>
-      timerContext.set(f.timestamp.copy(offset = Offset.unsafe(1002))) *>
-      timerContext.trigger(flow) *>
-      timerContext.set(f.timestamp.copy(offset = Offset.unsafe(1003))) *>
-      timerContext.trigger(flow) *>
-      timerContext.set(f.timestamp.copy(offset = Offset.unsafe(1004))) *>
-      timerContext.trigger(flow) *>
-      // Then("flush happens and remove happens before resource is closed")
-      StateT.inspectF { context =>
-        SyncIO {
-          assertEquals(context.flushed, 1)
-          assertEquals(context.removed, 1)
-        }
-      }
+    val program = f.contextRef.set(context) >> flow.use { flow =>
+      f.timerContext.set(f.timestamp.copy(offset = Offset.unsafe(1001))) *>
+        f.timerContext.trigger(flow) *>
+        f.timerContext.set(f.timestamp.copy(offset = Offset.unsafe(1002))) *>
+        f.timerContext.trigger(flow) *>
+        f.timerContext.set(f.timestamp.copy(offset = Offset.unsafe(1003))) *>
+        f.timerContext.trigger(flow) *>
+        f.timerContext.set(f.timestamp.copy(offset = Offset.unsafe(1004))) *>
+        f.timerContext.trigger(flow) *>
+        // Then("flush happens and remove happens before resource is closed")
+        f.contextRef.get.flatMap(ctx => IO {
+          assertEquals(ctx.flushed, 1)
+          assertEquals(ctx.removed, 1)
+        })
     }
 
-    program.run(context).unsafeRunSync()
+    program.unsafeRunSync()
 
   }
 
@@ -230,16 +267,20 @@ class TimerFlowOfSpec extends FunSuite {
     // Given("flow persists every minute")
     val startedAt = f.timestamp.copy(offset = Offset.unsafe(1234))
     val context = Context(timestamps = TimestampState(startedAt))
-    val flowOf = TimerFlowOf.persistPeriodically[F](1.minute)
-    val flow = flowOf(keyContext, flushBuffers, timerContext)
+    val flowOf = TimerFlowOf.persistPeriodically[IO](1.minute)
+    val flow = flowOf(f.keyContext, f.flushBuffers, f.timerContext)
 
     // When("flow is started")
-    val result = flow.allocated.runS(context).unsafeRunSync()
+    val testIO = f.contextRef.set(context) >> flow.use { _ =>
+      f.contextRef.get.map { ctx =>
+        // Then("offset is being held")
+        assertEquals(ctx.holding, Some(Offset.unsafe(1234)))
+        assertEquals(ctx.flushed, 0)
+        assertEquals(ctx.removed, 0)
+      }
+    }
 
-    // Then("offset is being held")
-    assertEquals(result.holding, Some(Offset.unsafe(1234)))
-    assertEquals(result.flushed, 0)
-    assertEquals(result.removed, 0)
+    testIO.unsafeRunSync()
 
   }
 
@@ -249,19 +290,26 @@ class TimerFlowOfSpec extends FunSuite {
 
     // Given("flow persists every minute")
     val context = Context(timestamps = TimestampState(f.timestamp))
-    val flowOf = TimerFlowOf.persistPeriodically[F](1.minute)
-    val flow = flowOf(keyContext, flushBuffers, timerContext)
+    val flowOf = TimerFlowOf.persistPeriodically[IO](1.minute)
+    val flow = flowOf(f.keyContext, f.flushBuffers, f.timerContext)
 
     // When("timers trigger called")
     val program = flow use { flow =>
-      timerContext.trigger(flow)
+      f.timerContext.trigger(flow)
     }
-    val result = program.runS(context).unsafeRunSync()
 
-    // Then("flush does not happen")
-    assertEquals(result.flushed, 0)
-    assertEquals(result.removed, 0)
 
+    val testIO = for {
+      _ <- f.contextRef.set(context)
+      _ <- program
+      result <- f.contextRef.get
+    } yield {
+      // Then("flush does not happen")
+      assertEquals(result.flushed, 0)
+      assertEquals(result.removed, 0)
+    }
+
+    testIO.unsafeRunSync()
   }
 
   test("persistPeriodically flushes correct number of times") {
@@ -269,37 +317,52 @@ class TimerFlowOfSpec extends FunSuite {
     val f = new ConstFixture
 
     // Given("flow persists every minute")
-    val context = Context(timestamps = TimestampState(
-      f.timestamp.copy(clock = Instant.parse("2020-03-01T00:00:00.000Z"))
-    ))
-    val flowOf = TimerFlowOf.persistPeriodically[F](1.minute)
-    val flow = flowOf(keyContext, flushBuffers, timerContext)
+    val context = Context(timestamps =
+      TimestampState(
+        f.timestamp.copy(clock = Instant.parse("2020-03-01T00:00:00.000Z"))
+      )
+    )
+    val flowOf = TimerFlowOf.persistPeriodically[IO](1.minute)
+    val flow = flowOf(f.keyContext, f.flushBuffers, f.timerContext)
 
     // When("timers trigger called")
     val program = flow use { flow =>
-      timerContext.set(f.timestamp.copy(
-        offset = Offset.unsafe(101),
-        clock = Instant.parse("2020-03-01T00:01:00.000Z")
-      )) *>
-      timerContext.trigger(flow) *>
-      timerContext.set(f.timestamp.copy(
-        offset = Offset.unsafe(102),
-        clock = Instant.parse("2020-03-01T00:02:00.000Z")
-      )) *>
-      timerContext.trigger(flow) *>
-      timerContext.set(f.timestamp.copy(
-        offset = Offset.unsafe(103),
-        clock = Instant.parse("2020-03-01T00:03:00.000Z")
-      )) *>
-      timerContext.trigger(flow)
+      f.timerContext.set(
+        f.timestamp.copy(
+          offset = Offset.unsafe(101),
+          clock = Instant.parse("2020-03-01T00:01:00.000Z")
+        )
+      ) *>
+        f.timerContext.trigger(flow) *>
+        f.timerContext.set(
+          f.timestamp.copy(
+            offset = Offset.unsafe(102),
+            clock = Instant.parse("2020-03-01T00:02:00.000Z")
+          )
+        ) *>
+        f.timerContext.trigger(flow) *>
+        f.timerContext.set(
+          f.timestamp.copy(
+            offset = Offset.unsafe(103),
+            clock = Instant.parse("2020-03-01T00:03:00.000Z")
+          )
+        ) *>
+        f.timerContext.trigger(flow)
     }
-    val result = program.runS(context).unsafeRunSync()
 
-    // Then("flush happens 3 times, but remove never happens")
-    assertEquals(result.flushed, 3)
-    assertEquals(result.removed, 0)
-    // And("last state still being held")
-    assertEquals(result.holding, Some(Offset.unsafe(103)))
+    val testIO = for {
+      _ <- f.contextRef.set(context)
+      _ <- program
+      result <- f.contextRef.get
+    } yield {
+      // Then("flush happens 3 times, but remove never happens")
+      assertEquals(result.flushed, 3)
+      assertEquals(result.removed, 0)
+      // And("last state still being held")
+      assertEquals(result.holding, Some(Offset.unsafe(103)))
+    }
+
+    testIO.unsafeRunSync()
 
   }
 
@@ -309,17 +372,21 @@ class TimerFlowOfSpec extends FunSuite {
 
     // Given("flow is configured to flush on revoke")
     val context = Context(timestamps = TimestampState(f.timestamp))
-    val flowOf = TimerFlowOf.persistPeriodically[F](flushOnRevoke = true)
-    val flow = flowOf(keyContext, flushBuffers, timerContext)
+    val flowOf = TimerFlowOf.persistPeriodically[IO](flushOnRevoke = true)
+    val flow = flowOf(f.keyContext, f.flushBuffers, f.timerContext)
 
     // When("flow is started and cancelled")
-    val program = flow use { _ => ().pure[F] }
-    val result = program.runS(context).unsafeRunSync()
+    val testIO = for {
+      _ <- f.contextRef.set(context)
+      _ <- flow use { _ => IO.unit }
+      result <- f.contextRef.get
+    } yield {
+      // Then("state is flushed and removed")
+      assertEquals(result.flushed, 1)
+      assertEquals(result.removed, 1)
+    }
 
-    // Then("state is flushed and removed")
-    assertEquals(result.flushed, 1)
-    assertEquals(result.removed, 1)
-
+    testIO.unsafeRunSync()
   }
 
   test("persistPeriodically does not flush when resource is cancelled if not configured to do so") {
@@ -328,16 +395,21 @@ class TimerFlowOfSpec extends FunSuite {
 
     // Given("flow is configured to flush on revoke")
     val context = Context(timestamps = TimestampState(f.timestamp))
-    val flowOf = TimerFlowOf.persistPeriodically[F](flushOnRevoke = false)
-    val flow = flowOf(keyContext, flushBuffers, timerContext)
+    val flowOf = TimerFlowOf.persistPeriodically[IO](flushOnRevoke = false)
+    val flow = flowOf(f.keyContext, f.flushBuffers, f.timerContext)
 
     // When("flow is started and cancelled")
-    val program = flow use { _ => ().pure[F] }
-    val result = program.runS(context).unsafeRunSync()
+    val testIO = for {
+      _ <- f.contextRef.set(context)
+      _ <- flow use { _ => ().pure[IO] }
+      result <- f.contextRef.get
+    } yield {
+      // Then("neither flush or remove happens")
+      assertEquals(result.flushed, 0)
+      assertEquals(result.removed, 0)
+    }
 
-    // Then("neither flush or remove happens")
-    assertEquals(result.flushed, 0)
-    assertEquals(result.removed, 0)
+    testIO.unsafeRunSync()
 
   }
 
@@ -347,24 +419,23 @@ class TimerFlowOfSpec extends FunSuite {
 
     // Given("flow is configured to flush on revoke")
     val context = Context(timestamps = TimestampState(f.timestamp))
-    val flowOf = TimerFlowOf.persistPeriodically[F](
+    val flowOf = TimerFlowOf.persistPeriodically[IO](
       fireEvery = 0.seconds,
       persistEvery = 0.seconds,
       flushOnRevoke = true
     )
-    val flow = flowOf(keyContext, flushBuffers, timerContext)
+    val flow = flowOf(f.keyContext, f.flushBuffers, f.timerContext)
 
     // When("flow is started and cancelled")
-    val program = flow use { flow =>
-      flow.onTimer *>
-      // Then("flush happens before resource is closed")
-      StateT.inspectF { context =>
-        SyncIO {
-          assertEquals(context.flushed, 1)
-        }
-      }
+    val program = f.contextRef.set(context) >> flow.use { flow =>
+      for {
+        _ <- flow.onTimer
+        // Then("flush happens before resource is closed")
+        _ <- f.contextRef.get.flatMap(ctx => IO(assertEquals(ctx.flushed, 1)))
+      } yield ()
     }
-    program.run(context).unsafeRunSync()
+
+    program.unsafeRunSync()
 
   }
 
@@ -373,33 +444,39 @@ class TimerFlowOfSpec extends FunSuite {
     val f = new ConstFixture
 
     val testErr = new Exception("Test error")
-    val flushBuffersErr: FlushBuffers[F] = new FlushBuffers[F] {
-      def flush: F[Unit] = StateT.liftF(testErr.raiseError[SyncIO, Unit])
+    val flushBuffersErr: FlushBuffers[IO] = new FlushBuffers[IO] {
+      def flush: IO[Unit] = testErr.raiseError[IO, Unit]
     }
 
     // Given("flow persists with failure every minute")
-    val context = Context(timestamps = TimestampState(
-      f.timestamp.copy(clock = Instant.parse("2020-03-01T00:00:00.000Z"))
-    ))
-    val flowOf = TimerFlowOf.persistPeriodically[F](1.minute, ignorePersistErrors = false)
-    val flow = flowOf(keyContext, flushBuffersErr, timerContext)
+    val context = Context(timestamps =
+      TimestampState(
+        f.timestamp.copy(clock = Instant.parse("2020-03-01T00:00:00.000Z"))
+      )
+    )
+    val flowOf = TimerFlowOf.persistPeriodically[IO](1.minute, ignorePersistErrors = false)
+    val flow = flowOf(f.keyContext, flushBuffersErr, f.timerContext)
 
     // When("timers trigger called")
-    val program = flow use { flow =>
+    val program = f.contextRef.set(context) >> flow.use { flow =>
       for {
-        _ <- timerContext.set(f.timestamp.copy(
-          offset = Offset.unsafe(101),
-          clock = Instant.parse("2020-03-01T00:01:00.000Z")
-        ))
-        _ <- timerContext.trigger(flow)
-        _ <- timerContext.set(f.timestamp.copy(
-          offset = Offset.unsafe(102),
-          clock = Instant.parse("2020-03-01T00:02:00.000Z")
-        ))
-        _ <- timerContext.trigger(flow)
+        _ <- f.timerContext.set(
+          f.timestamp.copy(
+            offset = Offset.unsafe(101),
+            clock = Instant.parse("2020-03-01T00:01:00.000Z")
+          )
+        )
+        _ <- f.timerContext.trigger(flow)
+        _ <- f.timerContext.set(
+          f.timestamp.copy(
+            offset = Offset.unsafe(102),
+            clock = Instant.parse("2020-03-01T00:02:00.000Z")
+          )
+        )
+        _ <- f.timerContext.trigger(flow)
       } yield ()
     }
-    val result: Either[Throwable, Context] = program.runS(context).attempt.unsafeRunSync()
+    val result: Either[Throwable, Unit] = program.attempt.unsafeRunSync()
 
     // Then("timer flow fails with an error")
     result match {
@@ -413,46 +490,59 @@ class TimerFlowOfSpec extends FunSuite {
 
     val f = new ConstFixture
 
-    val flushBuffersErr: FlushBuffers[F] = new FlushBuffers[F] {
-      def flush: F[Unit] = StateT.liftF(new Exception("Test error").raiseError[SyncIO, Unit])
+    val flushBuffersErr: FlushBuffers[IO] = new FlushBuffers[IO] {
+      def flush: IO[Unit] = new Exception("Test error").raiseError[IO, Unit]
     }
 
     // Given("flow persists with failure every minute")
-    val context = Context(timestamps = TimestampState(
-      f.timestamp.copy(clock = Instant.parse("2020-03-01T00:00:00.000Z"))
-    ))
-    val flowOf = TimerFlowOf.persistPeriodically[F](1.minute, ignorePersistErrors = true)
-    val flow = flowOf(keyContext, flushBuffersErr, timerContext)
+    val context = Context(timestamps =
+      TimestampState(
+        f.timestamp.copy(clock = Instant.parse("2020-03-01T00:00:00.000Z"))
+      )
+    )
+    val flowOf = TimerFlowOf.persistPeriodically[IO](1.minute, ignorePersistErrors = true)
+    val flow = flowOf(f.keyContext, flushBuffersErr, f.timerContext)
 
     // When("timers trigger called")
     val program = flow use { flow =>
       for {
-        _ <- timerContext.set(f.timestamp.copy(
-          offset = Offset.unsafe(101),
-          clock = Instant.parse("2020-03-01T00:01:00.000Z")
-        ))
-        _ <- timerContext.trigger(flow)
-        _ <- timerContext.set(f.timestamp.copy(
-          offset = Offset.unsafe(102),
-          clock = Instant.parse("2020-03-01T00:02:00.000Z")
-        ))
-        _ <- timerContext.trigger(flow)
+        _ <- f.timerContext.set(
+          f.timestamp.copy(
+            offset = Offset.unsafe(101),
+            clock = Instant.parse("2020-03-01T00:01:00.000Z")
+          )
+        )
+        _ <- f.timerContext.trigger(flow)
+        _ <- f.timerContext.set(
+          f.timestamp.copy(
+            offset = Offset.unsafe(102),
+            clock = Instant.parse("2020-03-01T00:02:00.000Z")
+          )
+        )
+        _ <- f.timerContext.trigger(flow)
       } yield ()
     }
-    val result = program.runS(context).unsafeRunSync()
 
-    // Then("flush and remove never happen")
-    assertEquals(result.flushed, 0)
-    assertEquals(result.removed, 0)
-    // And("the offset of the last successful persist will be held")
-    assertEquals(result.holding, Some(Offset.unsafe(100)))
+    val testIO = for {
+      _ <- f.contextRef.set(context)
+      _ <- program
+      result <- f.contextRef.get
+    } yield {
+      // Then("flush and remove never happen")
+      assertEquals(result.flushed, 0)
+      assertEquals(result.removed, 0)
+      // And("the offset of the last successful persist will be held")
+      assertEquals(result.holding, Some(Offset.unsafe(100)))
+    }
+
+    testIO.unsafeRunSync()
 
   }
 
 }
 object TimerFlowSpec {
+  implicit val log: Log[IO] = Log.empty[IO]
 
-  type F[T] = StateT[SyncIO, Context, T]
   case class Context(
     holding: Option[Offset] = None,
     timers: TimerState = TimerState(),
@@ -461,7 +551,12 @@ object TimerFlowSpec {
     flushed: Int = 0
   )
 
+  object Context {
+    val lens: GenLens[Context] = GenLens[Context]
+  }
+
   class ConstFixture {
+    import com.evolutiongaming.kafka.flow.effect.CatsEffectMtlInstances._
 
     val timestamp: Timestamp = Timestamp(
       offset = Offset.unsafe(100),
@@ -469,38 +564,25 @@ object TimerFlowSpec {
       clock = Instant.parse("2020-03-01T00:00:00.000Z")
     )
 
-  }
+    val contextRef: Ref[IO, Context] =
+      Ref.unsafe[IO, Context](Context(timestamps = TimestampState(current = timestamp)))
 
-  val state: MonadState[F, Context] = implicitly
+    implicit val keyContext: KeyContext[IO] =
+      KeyContext(
+        storage = contextRef.stateInstance.focus(Context.lens(_.holding)),
+        removeFromCache = contextRef.update(ctx => ctx.copy(removed = ctx.removed + 1))
+      )
 
-  object Context {
-    val lens: GenLens[Context] = GenLens[Context]
-  }
+    implicit val timerContext: TimerContext[IO] = {
+      val timestamps =
+        Timestamps(contextRef.stateInstance.focus(Context.lens(_.timestamps)))
+      val timers =
+        Timers.transient(contextRef.stateInstance.focus(Context.lens(_.timers)), timestamps)
+      TimerContext(timers, timestamps)
+    }
 
-  implicit val log: Log[F] = Log.empty[F]
-
-  implicit val keyContext: KeyContext[F] =
-    KeyContext(
-      storage = state focus Context.lens(_.holding),
-      removeFromCache = StateT.modify { state =>
-        state.copy(removed = state.removed + 1)
-      }
-    )
-
-  implicit val timerContext: TimerContext[F] = {
-
-    val timestamps =
-      Timestamps(state focus Context.lens(_.timestamps))
-
-    val timers =
-      Timers.transient(state focus Context.lens(_.timers), timestamps)
-
-    TimerContext(timers, timestamps)
-  }
-
-  implicit val flushBuffers: FlushBuffers[F] = new FlushBuffers[F] {
-    def flush = timerContext.onPersisted *> StateT.modify { state =>
-      state.copy(flushed = state.flushed + 1)
+    implicit val flushBuffers: FlushBuffers[IO] = new FlushBuffers[IO] {
+      def flush: IO[Unit] = timerContext.onPersisted *> contextRef.update(ctx => ctx.copy(flushed = ctx.flushed + 1))
     }
   }
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -56,16 +56,12 @@ Saying that, the library is written and prepared for, so called, Tagless Final
 stype of programming. One does not have to use `IO` directly. Actually, the
 main "dog food" application is written in Tagless Final style.
 ```scala mdoc:silent
-import cats.effect.IO
-import com.evolutiongaming.catshelper.BracketThrowable
+import cats.effect.{IO, MonadCancelThrow}
 import com.evolutiongaming.catshelper.Log
 import com.evolutiongaming.catshelper.LogOf
 import com.evolutiongaming.smetrics.MeasureDuration
-import scala.concurrent.ExecutionContext
 
-implicit val contextShift = IO.contextShift(ExecutionContext.global)
-implicit val timer = IO.timer(ExecutionContext.global)
-implicit val bracketThrowable = BracketThrowable[IO]
+implicit val MT = MonadCancelThrow[IO]
 implicit val measureDuration = MeasureDuration.empty[IO]
 implicit val logOf = LogOf.empty[IO]
 implicit val log = Log.empty[IO]

--- a/metrics/src/main/scala/com/evolutiongaming/kafka/flow/metrics/Metrics.scala
+++ b/metrics/src/main/scala/com/evolutiongaming/kafka/flow/metrics/Metrics.scala
@@ -1,6 +1,5 @@
 package com.evolutiongaming.kafka.flow.metrics
 
-import cats.Applicative
 import cats.effect.Resource
 import com.evolutiongaming.smetrics.CollectorRegistry
 
@@ -30,7 +29,7 @@ trait MetricsOf[F[_], A] {
     * The signature makes it easier to pass metrics as implicit value.
     * I.e. run it as `metrics.transform { implicit metrics => b => ... }.
     */
-  def transform[B](f: Metrics[A] => B => B)(implicit F: Applicative[F]): MetricsOf[F, B] = { registry =>
+  def transform[B](f: Metrics[A] => B => B): MetricsOf[F, B] = { registry =>
     self(registry) map { metrics => b => f(metrics)(b) }
   }
 

--- a/metrics/src/main/scala/com/evolutiongaming/kafka/flow/metrics/MetricsK.scala
+++ b/metrics/src/main/scala/com/evolutiongaming/kafka/flow/metrics/MetricsK.scala
@@ -1,6 +1,5 @@
 package com.evolutiongaming.kafka.flow.metrics
 
-import cats.Applicative
 import cats.effect.Resource
 import cats.~>
 import com.evolutiongaming.smetrics.CollectorRegistry
@@ -36,7 +35,7 @@ trait MetricsKOf[F[_], G[_]] { self =>
     *
     * Useful to create metrics for factory classes.
     */
-  def transform[H[_]](f: MetricsK[G] => H ~> H)(implicit F: Applicative[F]): MetricsKOf[F, H] = { registry =>
+  def transform[H[_]](f: MetricsK[G] => H ~> H): MetricsKOf[F, H] = { registry =>
     self(registry) map { metrics =>
       new MetricsK[H] {
         def withMetrics[A](ha: H[A]) = f(metrics)(ha)

--- a/metrics/src/main/scala/com/evolutiongaming/kafka/flow/metrics/syntax/package.scala
+++ b/metrics/src/main/scala/com/evolutiongaming/kafka/flow/metrics/syntax/package.scala
@@ -1,13 +1,11 @@
 package com.evolutiongaming.kafka.flow.metrics
 
-import cats.Applicative
-import cats.FlatMap
-import cats.Monad
+import cats.{FlatMap, Monad}
 import cats.effect.Resource
 import cats.syntax.all._
-import com.evolutiongaming.smetrics.CollectorRegistry
-import com.evolutiongaming.smetrics.MeasureDuration
+import com.evolutiongaming.smetrics.{CollectorRegistry, MeasureDuration}
 import com.evolutiongaming.sstream.Stream
+
 import scala.concurrent.duration.FiniteDuration
 
 package object syntax {
@@ -17,7 +15,7 @@ package object syntax {
       metrics.withMetrics(a)
   }
   implicit class MetricsOfOps[F[_], A](a: A)(implicit metricsOf: MetricsOf[F, A]) {
-    def withCollectorRegistry(registry: CollectorRegistry[F])(implicit F: Applicative[F]): Resource[F, A] =
+    def withCollectorRegistry(registry: CollectorRegistry[F]): Resource[F, A] =
       metricsOf(registry) map { implicit metrics =>
         a.withMetrics
       }
@@ -27,7 +25,7 @@ package object syntax {
       metrics.withMetrics(fa)
   }
   implicit class MetricsKOfOps[F[_], G[_], A](ga: G[A])(implicit metricsOf: MetricsKOf[F, G]) {
-    def withCollectorRegistry(registry: CollectorRegistry[F])(implicit F: Applicative[F]): Resource[F, G[A]] =
+    def withCollectorRegistry(registry: CollectorRegistry[F]): Resource[F, G[A]] =
       metricsOf(registry) map { implicit metrics =>
         ga.withMetricsK
       }

--- a/persistence-cassandra/src/it/scala/com/evolutiongaming/kafka/flow/CassandraSessionStub.scala
+++ b/persistence-cassandra/src/it/scala/com/evolutiongaming/kafka/flow/CassandraSessionStub.scala
@@ -1,7 +1,7 @@
 package com.evolutiongaming.kafka.flow
 
 import cats.MonadThrow
-import cats.effect.concurrent.Ref
+import cats.effect.Ref
 import cats.syntax.all._
 import com.datastax.driver.core.Statement
 import com.evolutiongaming.kafka.journal.eventual.cassandra.CassandraSession

--- a/persistence-cassandra/src/it/scala/com/evolutiongaming/kafka/flow/FlowSpec.scala
+++ b/persistence-cassandra/src/it/scala/com/evolutiongaming/kafka/flow/FlowSpec.scala
@@ -3,7 +3,8 @@ package com.evolutiongaming.kafka.flow
 import cats.data.NonEmptyList
 import cats.effect.IO
 import cats.effect.Resource
-import cats.effect.concurrent.Ref
+import cats.effect.Ref
+import cats.effect.unsafe.IORuntime
 import com.evolutiongaming.catshelper.LogOf
 import com.evolutiongaming.kafka.flow.cassandra.CassandraPersistence
 import com.evolutiongaming.kafka.flow.kafka.Consumer
@@ -16,6 +17,7 @@ import com.evolutiongaming.skafka.Offset
 import com.evolutiongaming.skafka.TopicPartition
 import com.evolutiongaming.skafka.consumer.ConsumerRecords
 import com.evolutiongaming.skafka.consumer.WithSize
+
 import scala.concurrent.duration._
 import weaver.GlobalRead
 
@@ -78,6 +80,6 @@ class FlowSpec(val globalRead: GlobalRead) extends CassandraSpec {
 
   }
 
-  implicit val log: LogOf[IO] = LogOf.slf4j.unsafeRunSync()
+  implicit val log: LogOf[IO] = LogOf.slf4j.unsafeRunSync()(IORuntime.global)
 
 }

--- a/persistence-cassandra/src/it/scala/com/evolutiongaming/kafka/flow/SharedResources.scala
+++ b/persistence-cassandra/src/it/scala/com/evolutiongaming/kafka/flow/SharedResources.scala
@@ -25,8 +25,6 @@ object SharedResources extends GlobalResource {
   def sharedResources(store: GlobalWrite): Resource[IO, Unit] = {
 
     implicit val executor = ExecutionContext.global
-    implicit val contextShift = IO.contextShift(executor)
-    implicit val timer = IO.timer(executor)
     implicit val log = LogOf.empty[IO]
 
     // we use default config here, because we will launch Cassandra locally

--- a/persistence-cassandra/src/it/scala/com/evolutiongaming/kafka/flow/journal/JournalSpec.scala
+++ b/persistence-cassandra/src/it/scala/com/evolutiongaming/kafka/flow/journal/JournalSpec.scala
@@ -1,7 +1,7 @@
 package com.evolutiongaming.kafka.flow.journal
 
 import cats.effect.IO
-import cats.effect.concurrent.Ref
+import cats.effect.Ref
 import com.evolutiongaming.kafka.flow.CassandraSessionStub
 import com.evolutiongaming.kafka.flow.CassandraSpec
 import com.evolutiongaming.kafka.flow.KafkaKey

--- a/persistence-cassandra/src/it/scala/com/evolutiongaming/kafka/flow/key/KeySpec.scala
+++ b/persistence-cassandra/src/it/scala/com/evolutiongaming/kafka/flow/key/KeySpec.scala
@@ -1,6 +1,6 @@
 package com.evolutiongaming.kafka.flow.key
 
-import cats.effect.concurrent.Ref
+import cats.effect.Ref
 import cats.syntax.all._
 import com.evolutiongaming.kafka.flow.CassandraSessionStub
 import com.evolutiongaming.kafka.flow.CassandraSpec

--- a/persistence-cassandra/src/it/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotSpec.scala
+++ b/persistence-cassandra/src/it/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotSpec.scala
@@ -1,7 +1,7 @@
 package com.evolutiongaming.kafka.flow.snapshot
 
 import cats.effect.IO
-import cats.effect.concurrent.Ref
+import cats.effect.Ref
 import com.evolutiongaming.kafka.flow.CassandraSessionStub
 import com.evolutiongaming.kafka.flow.CassandraSpec
 import com.evolutiongaming.kafka.flow.KafkaKey

--- a/persistence-cassandra/src/it/scala/com/evolutiongaming/kafka/flow/timer/TimerSpec.scala
+++ b/persistence-cassandra/src/it/scala/com/evolutiongaming/kafka/flow/timer/TimerSpec.scala
@@ -1,6 +1,6 @@
 package com.evolutiongaming.kafka.flow.timer
 
-import cats.effect.concurrent.Ref
+import cats.effect.Ref
 import com.evolutiongaming.kafka.flow.CassandraSessionStub
 import com.evolutiongaming.kafka.flow.CassandraSpec
 import com.evolutiongaming.kafka.flow.KafkaKey

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/CassandraHealthCheckOf.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/CassandraHealthCheckOf.scala
@@ -1,6 +1,6 @@
 package com.evolutiongaming.kafka.flow.cassandra
 
-import cats.effect.{Concurrent, Resource, Timer}
+import cats.effect.{Async, Resource}
 import com.evolutiongaming.catshelper.LogOf
 import com.evolutiongaming.kafka.journal.eventual.cassandra.EventualCassandraConfig.ConsistencyConfig
 import com.evolutiongaming.kafka.journal.eventual.cassandra.{CassandraHealthCheck, CassandraSession => CassandraSession2}
@@ -9,11 +9,11 @@ import com.evolutiongaming.scassandra.util.FromGFuture
 
 private[cassandra] object CassandraHealthCheckOf {
 
-  def apply[F[_] : Concurrent : FromGFuture : Timer : LogOf](cassandraSession: CassandraSession[F], config: CassandraConfig): Resource[F, CassandraHealthCheck[F]] = {
+  def apply[F[_] : Async : FromGFuture : LogOf](cassandraSession: CassandraSession[F], config: CassandraConfig): Resource[F, CassandraHealthCheck[F]] = {
     for {
       cassandraSession     <- CassandraSession2.of[F](cassandraSession)
       cassandraSession2     = CassandraSession2[F](cassandraSession, config.retries)
-      cassandraHealthCheck <- CassandraHealthCheck.of(Resource.pure(cassandraSession2), ConsistencyConfig.default.read)
+      cassandraHealthCheck <- CassandraHealthCheck.of(Resource.pure[F, CassandraSession2[F]](cassandraSession2), ConsistencyConfig.default.read)
     } yield {
       cassandraHealthCheck
     }

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/CassandraModule.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/CassandraModule.scala
@@ -1,17 +1,11 @@
 package com.evolutiongaming.kafka.flow.cassandra
 
-import cats.effect.Concurrent
-import cats.effect.Resource
-import cats.effect.Sync
-import cats.effect.Timer
+import cats.effect.{Async, Resource, Sync}
 import cats.syntax.all._
-import com.evolutiongaming.cassandra.sync.AutoCreate
-import com.evolutiongaming.cassandra.sync.CassandraSync
-import com.evolutiongaming.catshelper.Log
-import com.evolutiongaming.catshelper.LogOf
+import com.evolutiongaming.cassandra.sync.{AutoCreate, CassandraSync}
+import com.evolutiongaming.catshelper.{Log, LogOf}
 import com.evolutiongaming.kafka.flow.LogResource
-import com.evolutiongaming.kafka.journal.eventual.cassandra.CassandraHealthCheck
-import com.evolutiongaming.kafka.journal.eventual.cassandra.{CassandraSession => SafeSession}
+import com.evolutiongaming.kafka.journal.eventual.cassandra.{CassandraHealthCheck, CassandraSession => SafeSession}
 import com.evolutiongaming.scassandra.CassandraClusterOf
 import com.evolutiongaming.scassandra.util.FromGFuture
 import com.google.common.util.concurrent.ListenableFuture
@@ -41,7 +35,7 @@ object CassandraModule {
     * `ExecutionContextExecutor` rather than `ContextShift` because we need it
     * to convert `ListenableFuture` to `F[_]`.
     */
-  def of[F[_]: Concurrent: Timer: LogOf](
+  def of[F[_]: Async: LogOf](
     config: CassandraConfig
   )(implicit executor: ExecutionContextExecutor): Resource[F, CassandraModule[F]] = {
     for {

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModule.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModule.scala
@@ -1,22 +1,21 @@
 package com.evolutiongaming.kafka.flow.kafkapersistence
 
-import cats.effect.concurrent.Ref
-import cats.effect.{Concurrent, Resource}
+import cats.effect.{Concurrent, Ref, Resource}
 import cats.syntax.all._
-import com.evolutiongaming.catshelper.{FromTry, Log, LogOf}
-import com.evolutiongaming.kafka.flow.{FlowMetrics, KafkaKey}
+import com.evolutiongaming.catshelper.{FromTry, Log, LogOf, Runtime}
+import com.evolutiongaming.kafka.flow.effect.CatsEffectMtlInstances._
 import com.evolutiongaming.kafka.flow.key.{Keys, KeysOf}
+import com.evolutiongaming.kafka.flow.metrics.syntax._
 import com.evolutiongaming.kafka.flow.persistence.{PersistenceOf, SnapshotPersistenceOf}
 import com.evolutiongaming.kafka.flow.snapshot.Snapshots.Snapshot
 import com.evolutiongaming.kafka.flow.snapshot.{SnapshotDatabase, Snapshots, SnapshotsOf}
-import com.evolutiongaming.kafka.flow.metrics.syntax._
+import com.evolutiongaming.kafka.flow.{FlowMetrics, KafkaKey}
 import com.evolutiongaming.kafka.journal.ConsRecord
 import com.evolutiongaming.scache.Cache
 import com.evolutiongaming.skafka.consumer.{ConsumerConfig, ConsumerOf}
 import com.evolutiongaming.skafka.producer.{Producer, ProducerConfig, ProducerOf}
 import com.evolutiongaming.skafka.{FromBytes, ToBytes, TopicPartition}
 import com.evolutiongaming.sstream.Stream
-import com.olegpy.meow.effects._
 import scodec.bits.ByteVector
 
 /** A module, necessary to create a Kafka snapshot persistence.
@@ -57,7 +56,7 @@ object KafkaPersistenceModule {
     * @see com.evolutiongaming.kafka.flow.KeyStateOf.eagerRecovery for implementation details of constructing com.evolutiongaming.kafka.flow.KeyState for a specific key
     * @see com.evolutiongaming.kafka.flow.KeyFlow.of for implementation details of state recovery for a specific key
     */
-  def caching[F[_]: LogOf: Concurrent: FromBytes[*[_], String]: ToBytes[*[_], S], S: FromBytes[F, *]](
+  def caching[F[_]: LogOf: Concurrent: Runtime: FromBytes[*[_], String]: ToBytes[*[_], S], S: FromBytes[F, *]](
     consumerOf: ConsumerOf[F],
     producerOf: ProducerOf[F],
     consumerConfig: ConsumerConfig,

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModuleOf.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModuleOf.scala
@@ -1,7 +1,7 @@
 package com.evolutiongaming.kafka.flow.kafkapersistence
 
 import cats.effect.{Concurrent, Resource}
-import com.evolutiongaming.catshelper.LogOf
+import com.evolutiongaming.catshelper.{LogOf, Runtime}
 import com.evolutiongaming.kafka.flow.FlowMetrics
 import com.evolutiongaming.skafka.consumer.{ConsumerConfig, ConsumerOf}
 import com.evolutiongaming.skafka.producer.{ProducerConfig, ProducerOf}
@@ -24,7 +24,7 @@ object KafkaPersistenceModuleOf {
     * @param snapshotTopic snapshot topic name (should be configured as a 'compacted' topic)
     * @param metrics instance of `FlowMetrics` for [[KafkaPersistenceModule]]
     */
-  def caching[F[_]: LogOf: Concurrent: FromBytes[*[_], String]: ToBytes[*[_], S], S: FromBytes[F, *]](
+  def caching[F[_]: LogOf: Concurrent: Runtime: FromBytes[*[_], String]: ToBytes[*[_], S], S: FromBytes[F, *]](
     consumerOf: ConsumerOf[F],
     producerOf: ProducerOf[F],
     consumerConfig: ConsumerConfig,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,34 +4,30 @@ object Dependencies {
 
   val munit  = "org.scalameta"       %% "munit"            % "0.7.22"
   val scribe = "com.outr"            %% "scribe-slf4j"     % "3.5.0"
-  val weaver = "com.disneystreaming" %% "weaver-cats"      % "0.6.0-M6"
+  val weaver = "com.disneystreaming" %% "weaver-cats"      % "0.7.11"
 
   val cassandraLauncher = "com.evolutiongaming" %% "cassandra-launcher" % "0.0.4"
-  val catsHelper        = "com.evolutiongaming" %% "cats-helper"        % "2.7.0"
+  val catsHelper        = "com.evolutiongaming" %% "cats-helper"        % "3.0.3"
   val kafkaLauncher     = "com.evolutiongaming" %% "kafka-launcher"     % "0.0.11"
-  val scache            = "com.evolutiongaming" %% "scache"             % "3.2.0"
-  val skafka            = "com.evolutiongaming" %% "skafka"             % "11.9.3"
-  val smetrics          = "com.evolutiongaming" %% "smetrics"           % "0.3.4"
-  val sstream           = "com.evolutiongaming" %% "sstream"            % "0.2.1"
+  val scache            = "com.evolutiongaming" %% "scache"             % "4.0.0"
+  val skafka            = "com.evolutiongaming" %% "skafka"             % "12.1.3"
+  val smetrics          = "com.evolutiongaming" %% "smetrics"           % "1.0.1"
+  val sstream           = "com.evolutiongaming" %% "sstream"            % "1.0.1"
 
   object Cats {
-    private val version = "2.6.1"
+    private val version = "2.7.0"
+    private val effectVersion = "3.3.7"
     val core   = "org.typelevel" %% "cats-core"   % version
-    val effect = "org.typelevel" %% "cats-effect" % "2.5.4"
-    val effectLaws = "org.typelevel" %% "cats-effect-laws" % "2.5.4"
+    val mtl   = "org.typelevel"  %% "cats-mtl"   % "1.2.1"
+    val effect = "org.typelevel" %% "cats-effect" % effectVersion
+    val effectTestkit = "org.typelevel" %% "cats-effect-testkit" % effectVersion
   }
 
   object KafkaJournal {
-    private val version = "0.0.174"
+    private val version = "1.0.2"
     val journal     = "com.evolutiongaming" %% "kafka-journal"                    % version
     val cassandra   = "com.evolutiongaming" %% "kafka-journal-eventual-cassandra" % version
     val persistence = "com.evolutiongaming" %% "kafka-journal-persistence"        % version
-  }
-
-  object MeowMtl {
-    private val version = "0.4.1"
-    val core    = "com.olegpy" %% "meow-mtl-core"    % version
-    val effects = "com.olegpy" %% "meow-mtl-effects" % version
   }
 
   object Monocle {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.6.2-SNAPSHOT"
+ThisBuild / version := "1.0.0-SNAPSHOT"


### PR DESCRIPTION
This brings in cats-effect 3 and all the updated libraries. 
The library version now starts with `1.x.x`. 
The "CE2" version is branched from the current `master` in `series/0.x` branch. All updates to it should not make the version higher than `0.x.x` as `1.x.x` and further is reserved for CE3 versions in the `master` branch.