### PR TITLE
Log state on additional state persist failure (cats-effect 2)

### DIFF
--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/AdditionalStatePersistOf.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/AdditionalStatePersistOf.scala
@@ -16,7 +16,7 @@ trait AdditionalStatePersistOf[F[_], S] {
   def apply(
     persistence: Persistence[F, S, ConsRecord],
     keyContext: KeyContext[F]
-  ): F[AdditionalStatePersist[F, ConsRecord]]
+  ): F[AdditionalStatePersist[F, S, ConsRecord]]
 }
 
 object AdditionalStatePersistOf {
@@ -25,7 +25,7 @@ object AdditionalStatePersistOf {
       override def apply(
         persistence: Persistence[F, S, ConsRecord],
         keyContext: KeyContext[F]
-      ): F[AdditionalStatePersist[F, ConsRecord]] = Applicative[F].pure(AdditionalStatePersist.empty[F, ConsRecord])
+      ): F[AdditionalStatePersist[F, S, ConsRecord]] = Applicative[F].pure(AdditionalStatePersist.empty[F, S, ConsRecord])
     }
 
   def of[F[_]: Sync: Clock, S](cooldown: FiniteDuration): AdditionalStatePersistOf[F, S] = {
@@ -33,7 +33,7 @@ object AdditionalStatePersistOf {
       def apply(
         persistence: Persistence[F, S, ConsRecord],
         keyContext: KeyContext[F]
-      ): F[AdditionalStatePersist[F, ConsRecord]] = {
+      ): F[AdditionalStatePersist[F, S, ConsRecord]] = {
         AdditionalStatePersist.of(persistence, keyContext, cooldown)
       }
     }

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/KeyFlow.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/KeyFlow.scala
@@ -29,11 +29,11 @@ object KeyFlow {
   }
 
   def of[F[_]: Sync: KeyContext, S, A](
-                                        fold: EnhancedFold[F, S, A],
-                                        tick: TickOption[F, S],
-                                        persistence: Persistence[F, S, A],
-                                        additionalPersist: AdditionalStatePersist[F, A],
-                                        timer: TimerFlow[F]
+    fold: EnhancedFold[F, S, A],
+    tick: TickOption[F, S],
+    persistence: Persistence[F, S, A],
+    additionalPersist: AdditionalStatePersist[F, S, A],
+    timer: TimerFlow[F]
   ): F[KeyFlow[F, A]] = Ref.of(none[S]) flatMap { storage =>
     of(storage.stateInstance, fold, tick, persistence, additionalPersist, timer)
   }
@@ -46,15 +46,15 @@ object KeyFlow {
     persistence: Persistence[F, S, A],
     timer: TimerFlow[F]
   ): F[KeyFlow[F, A]] =
-    of(storage, EnhancedFold.fromFold(fold), tick, persistence, AdditionalStatePersist.empty[F, A], timer)
+    of(storage, EnhancedFold.fromFold(fold), tick, persistence, AdditionalStatePersist.empty[F, S, A], timer)
 
   def of[F[_]: Monad: KeyContext, S, A](
-                                         storage: MonadState[F, Option[S]],
-                                         fold: EnhancedFold[F, S, A],
-                                         tick: TickOption[F, S],
-                                         persistence: Persistence[F, S, A],
-                                         additionalPersist: AdditionalStatePersist[F, A],
-                                         timer: TimerFlow[F]
+    storage: MonadState[F, Option[S]],
+    fold: EnhancedFold[F, S, A],
+    tick: TickOption[F, S],
+    persistence: Persistence[F, S, A],
+    additionalPersist: AdditionalStatePersist[F, S, A],
+    timer: TimerFlow[F]
   ): F[KeyFlow[F, A]] =
     for {
       state <- persistence.read(KeyContext[F].log)
@@ -71,7 +71,7 @@ object KeyFlow {
     }
 
   /** Does not save anything to the database */
-  def transient[F[_]: Sync: KeyContext: ReadTimestamps, K, S, A](
+  def transient[F[_]: Sync: KeyContext: ReadTimestamps, S, A](
     fold: FoldOption[F, S, A],
     tick: TickOption[F, S],
     timer: TimerFlow[F]

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/KeyFlowOf.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/KeyFlowOf.scala
@@ -12,7 +12,7 @@ trait KeyFlowOf[F[_], S, A] {
     context: KeyContext[F],
     persistence: Persistence[F, S, A],
     timers: TimerContext[F],
-    additionalPersist: AdditionalStatePersist[F, A]
+    additionalPersist: AdditionalStatePersist[F, S, A]
   ): Resource[F, KeyFlow[F, A]]
 
 }
@@ -41,9 +41,9 @@ object KeyFlowOf {
     * @param tick defines what to do when the timer ticks
     */
   def apply[F[_]: Sync, K, S, A](
-                                  timerFlowOf: TimerFlowOf[F],
-                                  fold: EnhancedFold[F, S, A],
-                                  tick: TickOption[F, S]
+    timerFlowOf: TimerFlowOf[F],
+    fold: EnhancedFold[F, S, A],
+    tick: TickOption[F, S]
   ): KeyFlowOf[F, S, A] = { (context, persistence, timers, additionalPersist) =>
     implicit val _context = context
     timerFlowOf(context, persistence, timers) evalMap { timerFlow =>


### PR DESCRIPTION
Motivation: we disable `ProducerLogging` when we tolerate and ignore persistence failures so it doesn't log records that failed to be produced on `ERROR` level as such errors are supposed to be expected.  
However, if `ProducerLogging` is disabled, there's no way to find out what the state was when it failed to be persisted additionally. This PR addresses it.