### PR TITLE
Log state on additional state persist failure

### DIFF
--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/AdditionalStatePersist.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/AdditionalStatePersist.scala
@@ -14,7 +14,7 @@ import scala.concurrent.duration.FiniteDuration
 /** Internal API to handle user requests for additional persisting of a key's state.
   * One instance of this class is created per each key
   */
-trait AdditionalStatePersist[F[_], E] {
+trait AdditionalStatePersist[F[_], S, E] {
 
   /** Requests to persist a current state of the key. Calling this function doesn't guarantee that the state will be
     * persisted immediately; it's actually persisted only when `persistIfNeeded` is called after that
@@ -27,13 +27,13 @@ trait AdditionalStatePersist[F[_], E] {
     *
     * @param event currently processed record
     */
-  def persistIfNeeded(event: E): F[Unit]
+  def persistIfNeeded(event: E, state: S): F[Unit]
 }
 
 object AdditionalStatePersist {
-  def empty[F[_]: Applicative, E]: AdditionalStatePersist[F, E] = new AdditionalStatePersist[F, E] {
+  def empty[F[_]: Applicative, S, E]: AdditionalStatePersist[F, S, E] = new AdditionalStatePersist[F, S, E] {
     override def request: F[Unit] = Applicative[F].unit
-    override def persistIfNeeded(event: E): F[Unit] = Applicative[F].unit
+    override def persistIfNeeded(event: E, state: S): F[Unit] = Applicative[F].unit
   }
 
   /** Creates an instance of `AdditionalStatePersist` that allows additional persisting with the configurable cooldown.
@@ -48,7 +48,7 @@ object AdditionalStatePersist {
     persistence: Persistence[F, S, ConsRecord],
     keyContext: KeyContext[F],
     cooldown: FiniteDuration
-  ): F[AdditionalStatePersist[F, ConsRecord]] = {
+  ): F[AdditionalStatePersist[F, S, ConsRecord]] = {
     for {
       requestedRef <- Ref.of(false)
       lastPersistedRef <- Ref.of(none[Instant])
@@ -61,15 +61,17 @@ object AdditionalStatePersist {
     cooldown: FiniteDuration,
     requestedRef: Ref[F, Boolean],
     lastPersistedRef: Ref[F, Option[Instant]]
-  ): AdditionalStatePersist[F, ConsRecord] =
-    new AdditionalStatePersist[F, ConsRecord] {
+  ): AdditionalStatePersist[F, S, ConsRecord] =
+    new AdditionalStatePersist[F, S, ConsRecord] {
       private val F = MonadCancel[F, Throwable]
       private val cooldownMs = cooldown.toMillis
+      // TODO: make configurable, now it's too much code to rewrite at once
+      private val charsToPrint = 1024
 
       override def request: F[Unit] =
         requestedRef.set(true) >> keyContext.log.info("Additional persisting requested")
 
-      override def persistIfNeeded(record: ConsRecord): F[Unit] = {
+      override def persistIfNeeded(record: ConsRecord, state: S): F[Unit] = {
         for {
           requested <- requestedRef.get
           _ <- F.whenA(requested) {
@@ -78,7 +80,13 @@ object AdditionalStatePersist {
               lastPersisted <- lastPersistedRef.get
               _ <- F.whenA(lastPersisted.forall(ts => now - ts.toEpochMilli > cooldownMs)) {
                 for {
-                  _ <- persistence.flush.onError { case e => keyContext.log.error("Additional persisting failed", e) }
+                  _ <- persistence.flush.onError { case e =>
+                    val trimmedState = state.toString.take(charsToPrint)
+                    keyContext.log.error(
+                      s"Additional persisting failed, error: $e, first $charsToPrint chars of state: $trimmedState",
+                      e
+                    )
+                  }
                   _ <- OffsetToCommit[F](record.offset).flatMap(keyContext.hold)
                   _ <- lastPersistedRef.set(Instant.ofEpochMilli(now).some)
                   _ <- keyContext.log.info("Additional persisting success")

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/AdditionalStatePersistOf.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/AdditionalStatePersistOf.scala
@@ -16,7 +16,7 @@ trait AdditionalStatePersistOf[F[_], S] {
   def apply(
     persistence: Persistence[F, S, ConsRecord],
     keyContext: KeyContext[F]
-  ): F[AdditionalStatePersist[F, ConsRecord]]
+  ): F[AdditionalStatePersist[F, S, ConsRecord]]
 }
 
 object AdditionalStatePersistOf {
@@ -25,7 +25,7 @@ object AdditionalStatePersistOf {
       override def apply(
         persistence: Persistence[F, S, ConsRecord],
         keyContext: KeyContext[F]
-      ): F[AdditionalStatePersist[F, ConsRecord]] = Applicative[F].pure(AdditionalStatePersist.empty[F, ConsRecord])
+      ): F[AdditionalStatePersist[F, S, ConsRecord]] = Applicative[F].pure(AdditionalStatePersist.empty[F, S, ConsRecord])
     }
 
   def of[F[_]: MonadCancelThrow: Ref.Make: Clock, S](cooldown: FiniteDuration): AdditionalStatePersistOf[F, S] = {
@@ -33,7 +33,7 @@ object AdditionalStatePersistOf {
       def apply(
         persistence: Persistence[F, S, ConsRecord],
         keyContext: KeyContext[F]
-      ): F[AdditionalStatePersist[F, ConsRecord]] = {
+      ): F[AdditionalStatePersist[F, S, ConsRecord]] = {
         AdditionalStatePersist.of(persistence, keyContext, cooldown)
       }
     }

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/FoldToState.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/FoldToState.scala
@@ -29,7 +29,7 @@ object FoldToState {
     storage: Stateful[F, Option[S]],
     fold: FoldOption[F, S, E],
     persistence: Persistence[F, S, E]
-  ): FoldToState[F, E] = apply(storage, EnhancedFold.fromFold(fold), persistence, AdditionalStatePersist.empty[F, E])
+  ): FoldToState[F, E] = apply(storage, EnhancedFold.fromFold(fold), persistence, AdditionalStatePersist.empty[F, S, E])
 
   /** Uses `fold` to apply the records to a state stored inside of `storage`.
     *
@@ -41,7 +41,7 @@ object FoldToState {
     storage: Stateful[F, Option[S]],
     fold: EnhancedFold[F, S, E],
     persistence: Persistence[F, S, E],
-    additionalPersist: AdditionalStatePersist[F, E]
+    additionalPersist: AdditionalStatePersist[F, S, E]
   ): FoldToState[F, E] = new FoldToState[F, E] {
     private val keyFlowExtras = KeyFlowExtras.of(additionalPersist.request)
 
@@ -53,7 +53,7 @@ object FoldToState {
             for {
               _ <- persistence.appendEvent(record)
               _ <- state.traverse_ { state =>
-                persistence.replaceState(state) >> additionalPersist.persistIfNeeded(record)
+                persistence.replaceState(state) >> additionalPersist.persistIfNeeded(record, state)
               }
             } yield ()
           }

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/KeyFlow.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/KeyFlow.scala
@@ -29,7 +29,7 @@ object KeyFlow {
     fold: EnhancedFold[F, S, A],
     tick: TickOption[F, S],
     persistence: Persistence[F, S, A],
-    additionalPersist: AdditionalStatePersist[F, A],
+    additionalPersist: AdditionalStatePersist[F, S, A],
     timer: TimerFlow[F]
   ): F[KeyFlow[F, A]] = Ref.of[F, Option[S]](none[S]) flatMap { storage =>
     of(storage.stateInstance, fold, tick, persistence, additionalPersist, timer)
@@ -43,14 +43,14 @@ object KeyFlow {
     persistence: Persistence[F, S, A],
     timer: TimerFlow[F]
   ): F[KeyFlow[F, A]] =
-    of(storage, EnhancedFold.fromFold(fold), tick, persistence, AdditionalStatePersist.empty[F, A], timer)
+    of(storage, EnhancedFold.fromFold(fold), tick, persistence, AdditionalStatePersist.empty[F, S, A], timer)
 
   def of[F[_]: Monad: KeyContext, S, A](
     storage: Stateful[F, Option[S]],
     fold: EnhancedFold[F, S, A],
     tick: TickOption[F, S],
     persistence: Persistence[F, S, A],
-    additionalPersist: AdditionalStatePersist[F, A],
+    additionalPersist: AdditionalStatePersist[F, S, A],
     timer: TimerFlow[F]
   ): F[KeyFlow[F, A]] =
     for {

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/KeyFlowOf.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/KeyFlowOf.scala
@@ -11,7 +11,7 @@ trait KeyFlowOf[F[_], S, A] {
     context: KeyContext[F],
     persistence: Persistence[F, S, A],
     timers: TimerContext[F],
-    additionalPersist: AdditionalStatePersist[F, A]
+    additionalPersist: AdditionalStatePersist[F, S, A]
   ): Resource[F, KeyFlow[F, A]]
 
 }


### PR DESCRIPTION
Motivation: we disable `ProducerLogging` when we tolerate and ignore persistence failures so it doesn't log records that failed to be produced on `ERROR` level as such errors are supposed to be expected.  
However, if `ProducerLogging` is disabled, there's no way to find out what the state was when it failed to be persisted additionally. This PR addresses it.