### PR TITLE
Update cats-helper, smetrics, scache, kafka-journal

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -95,7 +95,8 @@ lazy val `persistence-kafka` = (project in file("persistence-kafka"))
       Monocle.`macro`,
       kafkaLauncher % IntegrationTest,
       scribe % IntegrationTest,
-      weaver % IntegrationTest
+      weaver % IntegrationTest,
+      catsHelperLogback % IntegrationTest,
     ),
     Defaults.itSettings,
     IntegrationTest / testFrameworks += new TestFramework("weaver.framework.CatsEffect"),

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/TopicFlow.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/TopicFlow.scala
@@ -10,7 +10,7 @@ import com.evolutiongaming.catshelper.DataHelper._
 import com.evolutiongaming.catshelper.{Log, LogOf, Runtime}
 import com.evolutiongaming.kafka.flow.kafka.Consumer
 import com.evolutiongaming.kafka.journal.{ConsRecords, PartitionOffset}
-import com.evolutiongaming.scache.{Cache, Releasable}
+import com.evolutiongaming.scache.Cache
 import com.evolutiongaming.skafka._
 
 import scala.collection.immutable.SortedSet
@@ -115,8 +115,8 @@ object TopicFlow {
               pendingCommits + (TopicPartition(topic, partition) -> OffsetAndMetadata(offset))
             }
           }
-          cache.getOrUpdateReleasable(partition) {
-            Releasable.of(partitionFlowOf(TopicPartition(topic, partition), offset, context))
+          cache.getOrUpdateResource(partition) {
+            partitionFlowOf(TopicPartition(topic, partition), offset, context)
           }
         }
       }

--- a/persistence-cassandra/src/it/scala/com/evolutiongaming/kafka/flow/SharedResources.scala
+++ b/persistence-cassandra/src/it/scala/com/evolutiongaming/kafka/flow/SharedResources.scala
@@ -8,7 +8,6 @@ import com.evolutiongaming.catshelper.LogOf
 import com.evolutiongaming.kafka.flow.cassandra.CassandraConfig
 import com.evolutiongaming.kafka.flow.cassandra.CassandraModule
 import com.evolutiongaming.scassandra.{CassandraConfig => SCassandraConfig}
-import scala.concurrent.ExecutionContext
 import scala.util.Try
 import scribe.Level
 import scribe.Logger
@@ -24,7 +23,6 @@ object SharedResources extends GlobalResource {
 
   def sharedResources(store: GlobalWrite): Resource[IO, Unit] = {
 
-    implicit val executor = ExecutionContext.global
     implicit val log = LogOf.empty[IO]
 
     // we use default config here, because we will launch Cassandra locally

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/CassandraModule.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/CassandraModule.scala
@@ -11,7 +11,6 @@ import com.evolutiongaming.scassandra.CassandraClusterOf
 import com.evolutiongaming.scassandra.util.FromGFuture
 import com.google.common.util.concurrent.ListenableFuture
 
-import scala.concurrent.ExecutionContextExecutor
 
 trait CassandraModule[F[_]] {
   def session: SafeSession[F]
@@ -38,7 +37,7 @@ object CassandraModule {
     */
   def of[F[_]: Async: Parallel: LogOf](
     config: CassandraConfig
-  )(implicit executor: ExecutionContextExecutor): Resource[F, CassandraModule[F]] = {
+  ): Resource[F, CassandraModule[F]] = {
     for {
       log <- Resource.eval(log[F])
       // this is required to log all Cassandra errors before popping them up,
@@ -46,7 +45,7 @@ object CassandraModule {
       // while kafka-flow is accessing Cassandra in bracket/resource release
       // routine
       fromGFuture = new FromGFuture[F] {
-        val self = FromGFuture.lift[F]
+        val self = FromGFuture.lift1[F]
         def apply[A](future: => ListenableFuture[A]) = {
           self(future) onError { case e =>
             log.error("Cassandra request failed", e)

--- a/persistence-kafka/src/it/resources/logback-test.xml
+++ b/persistence-kafka/src/it/resources/logback-test.xml
@@ -1,0 +1,17 @@
+<configuration>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.apache.kafka" level="ERROR"/>
+    <logger name="org.apache.zookeeper" level="ERROR"/>
+    <logger name="kafka" level="ERROR"/>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+</configuration>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,10 +7,11 @@ object Dependencies {
   val weaver = "com.disneystreaming" %% "weaver-cats" % "0.7.11"
 
   val cassandraLauncher = "com.evolutiongaming" %% "cassandra-launcher" % "0.0.4"
-  val catsHelper = "com.evolutiongaming" %% "cats-helper" % "3.1.1"
+  val catsHelper = "com.evolutiongaming" %% "cats-helper" % "3.4.0"
+  val catsHelperLogback = "com.evolutiongaming" %% "cats-helper-logback" % "3.4.0"
   val kafkaLauncher = "com.evolutiongaming" %% "kafka-launcher" % "0.0.12"
-  val smetrics = "com.evolutiongaming" %% "smetrics" % "1.0.6"
-  val scache = "com.evolutiongaming" %% "scache" % "4.0.3"
+  val smetrics = "com.evolutiongaming" %% "smetrics" % "1.0.7"
+  val scache = "com.evolutiongaming" %% "scache" % "4.3.1"
   val skafka = "com.evolutiongaming" %% "skafka" % "14.1.3"
   val sstream = "com.evolutiongaming" %% "sstream" % "1.0.1"
 
@@ -24,7 +25,7 @@ object Dependencies {
   }
 
   object KafkaJournal {
-    private val version = "1.0.16"
+    private val version = "1.0.17"
     val journal = "com.evolutiongaming" %% "kafka-journal" % version
     val cassandra = "com.evolutiongaming" %% "kafka-journal-eventual-cassandra" % version
     val persistence = "com.evolutiongaming" %% "kafka-journal-persistence" % version


### PR DESCRIPTION
Please note that as of version 3.4.0 `cats-helper` doesn't have a dependency on logback. Thus, kafka-flow also doesn't force it now either (using only SLF4J API) and it has to be added manually via using `cats-helper-logback` library or any other way of adding logback.