### PR TITLE
Update cats-helper, smetrics, scache, kafka-journal [CE2]

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -95,7 +95,8 @@ lazy val `persistence-kafka` = (project in file("persistence-kafka"))
       Monocle.`macro`,
       kafkaLauncher % IntegrationTest,
       scribe % IntegrationTest,
-      weaver % IntegrationTest
+      weaver % IntegrationTest,
+      catsHelperLogback % IntegrationTest,
     ),
     Defaults.itSettings,
     IntegrationTest / testFrameworks += new TestFramework("weaver.framework.CatsEffect"),

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/PartitionFlow.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/PartitionFlow.scala
@@ -10,7 +10,7 @@ import com.evolutiongaming.catshelper.{Log, LogOf}
 import com.evolutiongaming.kafka.flow.kafka.OffsetToCommit
 import com.evolutiongaming.kafka.flow.timer.{TimerContext, Timestamp}
 import com.evolutiongaming.kafka.journal.ConsRecord
-import com.evolutiongaming.scache.{Cache, Releasable}
+import com.evolutiongaming.scache.Cache
 import com.evolutiongaming.skafka.{Offset, TopicPartition}
 
 import java.time.Instant
@@ -101,16 +101,14 @@ object PartitionFlow {
   ): Resource[F, PartitionFlow[F]] = {
 
     def stateOf(createdAt: Timestamp, key: String): F[PartitionKey[F]] =
-      cache.getOrUpdateReleasable(key) {
-        Releasable.of {
-          for {
-            context <- KeyContext.resource[F](
-              removeFromCache = cache.remove(key).flatten.void,
-              log = Log[F].prefixed(key)
-            )
-            keyState <- keyStateOf(topicPartition, key, createdAt, context)
-          } yield PartitionKey(keyState, context)
-        }
+      cache.getOrUpdateResource(key) {
+        for {
+          context <- KeyContext.resource[F](
+            removeFromCache = cache.remove(key).flatten.void,
+            log = Log[F].prefixed(key)
+          )
+          keyState <- keyStateOf(topicPartition, key, createdAt, context)
+        } yield PartitionKey(keyState, context)
       }
 
     val init = for {

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/TopicFlow.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/TopicFlow.scala
@@ -12,7 +12,6 @@ import com.evolutiongaming.catshelper.LogOf
 import com.evolutiongaming.kafka.journal.ConsRecords
 import com.evolutiongaming.kafka.journal.PartitionOffset
 import com.evolutiongaming.scache.Cache
-import com.evolutiongaming.scache.Releasable
 import com.evolutiongaming.skafka.{Offset, OffsetAndMetadata, Partition, Topic, TopicPartition}
 import kafka.Consumer
 
@@ -118,8 +117,8 @@ object TopicFlow {
               pendingCommits + (TopicPartition(topic, partition) -> OffsetAndMetadata(offset))
             }
           }
-          cache.getOrUpdateReleasable(partition) {
-            Releasable.of(partitionFlowOf(TopicPartition(topic, partition), offset, context))
+          cache.getOrUpdateResource(partition) {
+            partitionFlowOf(TopicPartition(topic, partition), offset, context)
           }
         }
       }

--- a/persistence-kafka/src/it/resources/logback-test.xml
+++ b/persistence-kafka/src/it/resources/logback-test.xml
@@ -1,0 +1,17 @@
+<configuration>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.apache.kafka" level="ERROR"/>
+    <logger name="org.apache.zookeeper" level="ERROR"/>
+    <logger name="kafka" level="ERROR"/>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+</configuration>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,13 +6,14 @@ object Dependencies {
   val scribe = "com.outr"            %% "scribe-slf4j"     % "3.5.0"
   val weaver = "com.disneystreaming" %% "weaver-cats"      % "0.6.15"
 
-  val cassandraLauncher = "com.evolutiongaming" %% "cassandra-launcher" % "0.0.4"
-  val catsHelper        = "com.evolutiongaming" %% "cats-helper"        % "2.7.7"
-  val kafkaLauncher     = "com.evolutiongaming" %% "kafka-launcher"     % "0.0.12"
-  val scache            = "com.evolutiongaming" %% "scache"             % "3.4.1"
-  val skafka            = "com.evolutiongaming" %% "skafka"             % "11.13.2"
-  val smetrics          = "com.evolutiongaming" %% "smetrics"           % "0.3.6"
-  val sstream           = "com.evolutiongaming" %% "sstream"            % "0.2.1"
+  val cassandraLauncher = "com.evolutiongaming" %% "cassandra-launcher"   % "0.0.4"
+  val catsHelper        = "com.evolutiongaming" %% "cats-helper"          % "2.10.0"
+  val catsHelperLogback = "com.evolutiongaming" %% "cats-helper-logback"  % "2.10.0"
+  val kafkaLauncher     = "com.evolutiongaming" %% "kafka-launcher"       % "0.0.12"
+  val scache            = "com.evolutiongaming" %% "scache"               % "3.6.0"
+  val skafka            = "com.evolutiongaming" %% "skafka"               % "11.13.2"
+  val smetrics          = "com.evolutiongaming" %% "smetrics"             % "0.3.7"
+  val sstream           = "com.evolutiongaming" %% "sstream"              % "0.2.1"
 
   object Cats {
     private val version = "2.8.0"
@@ -22,7 +23,7 @@ object Dependencies {
   }
 
   object KafkaJournal {
-    private val version = "0.0.187"
+    private val version = "0.0.188"
     val journal     = "com.evolutiongaming" %% "kafka-journal"                    % version
     val cassandra   = "com.evolutiongaming" %% "kafka-journal-eventual-cassandra" % version
     val persistence = "com.evolutiongaming" %% "kafka-journal-persistence"        % version


### PR DESCRIPTION
Please note that as of version 2.10.0 cats-helper doesn't have a dependency on logback. Thus, kafka-flow also doesn't force it now either (using only SLF4J API) and it has to be added manually via using cats-helper-logback library or any other way of adding logback.