### PR TITLE
Improve logging for Kafka-based persistence

### DIFF
--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/KafkaKey.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/KafkaKey.scala
@@ -11,5 +11,6 @@ final case class KafkaKey(
 )
 
 object KafkaKey {
-  implicit val hashKafkaKey: Hash[KafkaKey] = Hash.fromUniversalHashCode
+  implicit val hashKafkaKey: Hash[KafkaKey]   = Hash.fromUniversalHashCode
+  implicit val logPrefix: LogPrefix[KafkaKey] = LogPrefix.function(key => s"${key.topicPartition} ${key.key}")
 }

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/LogPrefix.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/LogPrefix.scala
@@ -1,0 +1,16 @@
+package com.evolutiongaming.kafka.flow
+
+/** Extract a common prefix from `A` that is suitable for being logged in order to correlate a specific log message
+  * with `A`
+  */
+trait LogPrefix[A] {
+  def extract(value: A): String
+}
+
+object LogPrefix {
+  def apply[A](implicit instance: LogPrefix[A]): LogPrefix[A] = instance
+
+  def function[A](f: A => String): LogPrefix[A] = value => f(value)
+
+  implicit val stringPrefix: LogPrefix[String] = function(identity)
+}

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotDatabase.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotDatabase.scala
@@ -5,6 +5,7 @@ import cats.mtl.Stateful
 import cats.syntax.all._
 import cats.{Applicative, Functor, Monad}
 import com.evolutiongaming.catshelper.LogOf
+import com.evolutiongaming.kafka.flow.LogPrefix
 import com.evolutiongaming.kafka.flow.effect.CatsEffectMtlInstances._
 
 trait SnapshotDatabase[F[_], K, S] extends SnapshotReadDatabase[F, K, S] with SnapshotWriteDatabase[F, K, S]
@@ -78,7 +79,11 @@ object SnapshotDatabase {
     val self: SnapshotDatabase[F, K, KafkaSnapshot[S]]
   ) extends AnyVal {
 
-    def snapshotsOf(implicit F: Sync[F], logOf: LogOf[F]): F[SnapshotsOf[F, K, KafkaSnapshot[S]]] =
+    def snapshotsOf(
+      implicit F: Sync[F],
+      logOf: LogOf[F],
+      logPrefix: LogPrefix[K]
+    ): F[SnapshotsOf[F, K, KafkaSnapshot[S]]] =
       logOf(SnapshotDatabase.getClass) map { implicit log => key => Snapshots.of(key, self) }
 
   }

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotDatabase.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotDatabase.scala
@@ -3,7 +3,7 @@ package com.evolutiongaming.kafka.flow.snapshot
 import cats.effect.{Ref, Sync}
 import cats.mtl.Stateful
 import cats.syntax.all._
-import cats.{Applicative, Functor}
+import cats.{Applicative, Functor, Monad}
 import com.evolutiongaming.catshelper.LogOf
 import com.evolutiongaming.kafka.flow.effect.CatsEffectMtlInstances._
 
@@ -32,10 +32,8 @@ object SnapshotDatabase {
     * The data will survive destruction of specific `Snapshots` instance,
     * but will not survive destruction of specific `SnapshotDatabase` instance.
     */
-  def memory[F[_]: Sync, K, S]: F[SnapshotDatabase[F, K, S]] =
-    Ref.of[F, Map[K, S]](Map.empty) map { storage =>
-      memory(storage.stateInstance)
-    }
+  def memory[F[_]: Ref.Make: Monad, K, S]: F[SnapshotDatabase[F, K, S]] =
+    Ref.of[F, Map[K, S]](Map.empty).map(storage => memory(storage.stateInstance))
 
   /** Creates in-memory database implementation.
     *

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/Snapshots.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/Snapshots.scala
@@ -5,6 +5,7 @@ import cats.mtl.Stateful
 import cats.syntax.all._
 import cats.{Applicative, Monad}
 import com.evolutiongaming.catshelper.Log
+import com.evolutiongaming.kafka.flow.LogPrefix
 import com.evolutiongaming.kafka.flow.effect.CatsEffectMtlInstances._
 
 trait Snapshots[F[_], S] extends SnapshotReader[F, S] with SnapshotWriter[F, S]
@@ -41,17 +42,18 @@ trait SnapshotWriter[F[_], S] {
 object Snapshots {
 
   /** Creates a buffer for a given writer */
-  private[flow] def of[F[_]: Ref.Make: Monad, K, S](
+  private[flow] def of[F[_]: Ref.Make: Monad, K: LogPrefix, S](
     key: K,
     database: SnapshotDatabase[F, K, S]
   )(implicit log: Log[F]): F[Snapshots[F, S]] =
     Ref.of[F, Option[Snapshot[S]]](None).map(buffer => Snapshots(key, database, buffer.stateInstance))
 
-  private[snapshot] def apply[F[_]: Monad, K, S](
+  private[snapshot] def apply[F[_]: Monad, K: LogPrefix, S](
     key: K,
     database: SnapshotDatabase[F, K, S],
     buffer: Stateful[F, Option[Snapshot[S]]]
   )(implicit log: Log[F]): Snapshots[F, S] = new Snapshots[F, S] {
+    private val prefixLog: Log[F] = log.prefixed(LogPrefix[K].extract(key))
 
     def read = database.get(key)
 
@@ -78,7 +80,7 @@ object Snapshots {
 
     def delete(persist: Boolean) = {
       val delete = if (persist) {
-        database.delete(key) *> log.info("deleted snapshot")
+        database.delete(key) *> prefixLog.info("deleted snapshot")
       } else {
         ().pure[F]
       }

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/Snapshots.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/Snapshots.scala
@@ -1,9 +1,9 @@
 package com.evolutiongaming.kafka.flow.snapshot
 
-import cats.{Applicative, Monad}
-import cats.effect.{Ref, Sync}
+import cats.effect.Ref
 import cats.mtl.Stateful
 import cats.syntax.all._
+import cats.{Applicative, Monad}
 import com.evolutiongaming.catshelper.Log
 import com.evolutiongaming.kafka.flow.effect.CatsEffectMtlInstances._
 
@@ -41,19 +41,17 @@ trait SnapshotWriter[F[_], S] {
 object Snapshots {
 
   /** Creates a buffer for a given writer */
-  private[snapshot] def of[F[_]: Sync: Log, K, S](
+  private[flow] def of[F[_]: Ref.Make: Monad, K, S](
     key: K,
     database: SnapshotDatabase[F, K, S]
-  ): F[Snapshots[F, S]] =
-    Ref.of[F, Option[Snapshot[S]]](None) map { buffer =>
-      Snapshots(key, database, buffer.stateInstance)
-    }
+  )(implicit log: Log[F]): F[Snapshots[F, S]] =
+    Ref.of[F, Option[Snapshot[S]]](None).map(buffer => Snapshots(key, database, buffer.stateInstance))
 
-  private[flow] def apply[F[_]: Monad: Log, K, S](
+  private[snapshot] def apply[F[_]: Monad, K, S](
     key: K,
     database: SnapshotDatabase[F, K, S],
     buffer: Stateful[F, Option[Snapshot[S]]]
-  ): Snapshots[F, S] = new Snapshots[F, S] {
+  )(implicit log: Log[F]): Snapshots[F, S] = new Snapshots[F, S] {
 
     def read = database.get(key)
 
@@ -80,8 +78,7 @@ object Snapshots {
 
     def delete(persist: Boolean) = {
       val delete = if (persist) {
-        database.delete(key) *>
-          Log[F].info("deleted snapshot")
+        database.delete(key) *> log.info("deleted snapshot")
       } else {
         ().pure[F]
       }

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotsOf.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotsOf.scala
@@ -1,6 +1,7 @@
 package com.evolutiongaming.kafka.flow.snapshot
 
-import cats.effect.Sync
+import cats.Monad
+import cats.effect.Ref
 import cats.syntax.all._
 import com.evolutiongaming.catshelper.Log
 
@@ -11,12 +12,10 @@ trait SnapshotsOf[F[_], K, S] {
 }
 object SnapshotsOf {
 
-  def memory[F[_]: Sync: Log, K, S]: F[SnapshotsOf[F, K, S]] =
-    SnapshotDatabase.memory[F, K, S] map { database =>
-      backedBy(database)
-    }
+  def memory[F[_]: Ref.Make: Monad: Log, K, S]: F[SnapshotsOf[F, K, S]] =
+    SnapshotDatabase.memory[F, K, S].map(database => backedBy(database))
 
-  def backedBy[F[_]: Sync: Log, K, S](db: SnapshotDatabase[F, K, S]): SnapshotsOf[F, K, S] = { key =>
+  def backedBy[F[_]: Ref.Make: Monad: Log, K, S](db: SnapshotDatabase[F, K, S]): SnapshotsOf[F, K, S] = { key =>
     Snapshots.of(key, db)
   }
 

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotsOf.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotsOf.scala
@@ -4,6 +4,7 @@ import cats.Monad
 import cats.effect.Ref
 import cats.syntax.all._
 import com.evolutiongaming.catshelper.Log
+import com.evolutiongaming.kafka.flow.LogPrefix
 
 trait SnapshotsOf[F[_], K, S] {
 
@@ -12,11 +13,12 @@ trait SnapshotsOf[F[_], K, S] {
 }
 object SnapshotsOf {
 
-  def memory[F[_]: Ref.Make: Monad: Log, K, S]: F[SnapshotsOf[F, K, S]] =
+  def memory[F[_]: Ref.Make: Monad: Log, K: LogPrefix, S]: F[SnapshotsOf[F, K, S]] =
     SnapshotDatabase.memory[F, K, S].map(database => backedBy(database))
 
-  def backedBy[F[_]: Ref.Make: Monad: Log, K, S](db: SnapshotDatabase[F, K, S]): SnapshotsOf[F, K, S] = { key =>
-    Snapshots.of(key, db)
+  def backedBy[F[_]: Ref.Make: Monad: Log, K: LogPrefix, S](db: SnapshotDatabase[F, K, S]): SnapshotsOf[F, K, S] = {
+    key =>
+      Snapshots.of(key, db)
   }
 
 }

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModule.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModule.scala
@@ -1,14 +1,12 @@
 package com.evolutiongaming.kafka.flow.kafkapersistence
 
 import cats.Parallel
-import cats.effect.{Concurrent, Ref, Resource}
+import cats.effect.{Concurrent, Resource}
 import cats.syntax.all._
 import com.evolutiongaming.catshelper.{FromTry, Log, LogOf, Runtime}
-import com.evolutiongaming.kafka.flow.effect.CatsEffectMtlInstances._
 import com.evolutiongaming.kafka.flow.key.{Keys, KeysOf}
 import com.evolutiongaming.kafka.flow.metrics.syntax._
 import com.evolutiongaming.kafka.flow.persistence.{PersistenceOf, SnapshotPersistenceOf}
-import com.evolutiongaming.kafka.flow.snapshot.Snapshots.Snapshot
 import com.evolutiongaming.kafka.flow.snapshot.{SnapshotDatabase, Snapshots, SnapshotsOf}
 import com.evolutiongaming.kafka.flow.{FlowMetrics, KafkaKey}
 import com.evolutiongaming.kafka.journal.ConsRecord
@@ -138,22 +136,23 @@ object KafkaPersistenceModule {
       cache: Cache[F, String, ByteVector],
       producer: Producer[F]
     ): F[SnapshotPersistenceOf[F, KafkaKey, S, ConsRecord]] = {
-      LogOf[F].apply(classOf[SnapshotPersistenceOf[F, KafkaKey, S, ConsRecord]]).map { implicit log =>
-        implicit val producer_ = producer
-        val read               = KafkaSnapshotReadDatabase.of[F, S](snapshotTopicPartition.topic, key => cache.remove(key).flatten)
+      LogOf[F].apply(classOf[KafkaPersistenceModule[F, S]]).map { log =>
+        val read =
+          KafkaSnapshotReadDatabase.of[F, S](snapshotTopicPartition.topic, getState = key => cache.remove(key).flatten)
 
-        val snapshotsOf = new SnapshotsOf[F, KafkaKey, S] {
-          override def apply(key: KafkaKey): F[Snapshots[F, S]] =
-            for {
-              buffer <- Ref.of(none[Snapshot[S]]).map(_.stateInstance)
-            } yield Snapshots(
-              key = key,
-              database = SnapshotDatabase(
-                read  = read,
-                write = KafkaSnapshotWriteDatabase.of[F, S](snapshotTopicPartition)
-              ) withMetricsK metrics.snapshotDatabaseMetrics,
-              buffer = buffer
-            )
+        // A manual overriding of SnapshotsOf is required to pass a custom prefixed Log.
+        // Since both `SnapshotsOf.backedBy` and `Snapshots.of` are parameterized by a generic K (`KafkaKey` here),
+        // they would log the whole KafkaKey if Log.prefixed was to be called from inside.
+        val snapshotsOf: SnapshotsOf[F, KafkaKey, S] = {
+          val snapshotDatabase = SnapshotDatabase(
+            read  = read,
+            write = KafkaSnapshotWriteDatabase.of[F, S](snapshotTopicPartition, producer)
+          ).withMetricsK(metrics.snapshotDatabaseMetrics)
+
+          (key: KafkaKey) => {
+            implicit val prefixedLog: Log[F] = log.prefixed(s"${key.topicPartition} ${key.key}")
+            Snapshots.of(key, snapshotDatabase)
+          }
         }
 
         PersistenceOf.snapshotsOnly[F, KafkaKey, S, ConsRecord](

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaSnapshotWriteDatabase.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaSnapshotWriteDatabase.scala
@@ -9,8 +9,9 @@ import com.evolutiongaming.skafka.producer.{Producer, ProducerRecord}
 import com.evolutiongaming.skafka.{ToBytes, TopicPartition}
 
 object KafkaSnapshotWriteDatabase {
-  def of[F[_]: FromTry: Monad: Producer, S: ToBytes[F, *]](
-    snapshotTopicPartition: TopicPartition
+  def of[F[_]: FromTry: Monad, S: ToBytes[F, *]](
+    snapshotTopicPartition: TopicPartition,
+    producer: Producer[F],
   ): SnapshotWriteDatabase[F, KafkaKey, S] = new SnapshotWriteDatabase[F, KafkaKey, S] {
     override def persist(key: KafkaKey, snapshot: S): F[Unit] = produce(key, snapshot.some)
 
@@ -24,7 +25,7 @@ object KafkaSnapshotWriteDatabase {
         value     = snapshot
       )
 
-      Producer[F].send(record).flatten.void
+      producer.send(record).flatten.void
     }
   }
 }


### PR DESCRIPTION
- minor refactorings
- ensure that persistence-related log messages (`"deleted snapshot"`) are logged with a prefix (format: `"<topic>-<partition> <key>"`)