### PR TITLE
remove _total suffix from compressor metrics

### DIFF
--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -51,8 +51,8 @@ for {
 of `FlowMetrics` API from `kafka-flow-metrics` module in form of `FlowMetrics#compressorMetrics(component)` 
 where `component` is the name of the label that will be used for metrics of this compressor.  
 The following metrics are reported:
-  - `compressor_raw_bytes_total` - the size of state before compressing
-  - `compressor_compressed_bytes_total` - the size of compressed state (including library-added meta-information)
+  - `compressor_raw_bytes` - the size of state before compressing
+  - `compressor_compressed_bytes` - the size of compressed state (including library-added meta-information)
 ```scala mdoc:silent
 import cats.effect.syntax.resource._
 import com.evolutiongaming.kafka.flow.FlowMetrics

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -53,6 +53,11 @@ where `component` is the name of the label that will be used for metrics of this
 The following metrics are reported:
   - `compressor_raw_bytes` - the size of state before compressing
   - `compressor_compressed_bytes` - the size of compressed state (including library-added meta-information)
+
+Note: these metrics had a `_total` suffix in earlier versions. 
+Starting with `prometheus-metrics` v1.0.0 this suffix is no longer allowed and has therefore been removed.
+Users of `simpleclient` forked version `0.9.999-evo1` will see a change in the metric name, since the `_total` suffix is not automatically added in that version.
+
 ```scala mdoc:silent
 import cats.effect.syntax.resource._
 import com.evolutiongaming.kafka.flow.FlowMetrics

--- a/metrics/src/main/scala/com/evolutiongaming/kafka/flow/compression/CompressorMetrics.scala
+++ b/metrics/src/main/scala/com/evolutiongaming/kafka/flow/compression/CompressorMetrics.scala
@@ -31,14 +31,14 @@ object CompressorMetrics {
 
   def compressorMetricsOf[F[_]: Monad](registry: CollectorRegistry[F]): Resource[F, CompressorMetricsOf[F]] = {
     val rawBytesSummary = registry.summary(
-      name      = "kafka_flow_compressor_raw_bytes_total",
+      name      = "kafka_flow_compressor_raw_bytes",
       help      = "Payload size in bytes before compression",
       quantiles = Quantiles(Quantile(value = 0.9, error = 0.05), Quantile(value = 0.99, error = 0.005)),
       labels    = LabelNames("component")
     )
 
     val compressedSummary = registry.summary(
-      name      = "kafka_flow_compressor_compressed_bytes_total",
+      name      = "kafka_flow_compressor_compressed_bytes",
       help      = "Payload size in bytes after compression",
       quantiles = Quantiles(Quantile(value = 0.9, error = 0.05), Quantile(value = 0.99, error = 0.005)),
       labels    = LabelNames("component")


### PR DESCRIPTION
Remove _total suffix from compressor metrics, this is not allowed in Prometheus >=1.0.0

When scraping metrics with the old name, an error is returned:

```
java.lang.IllegalArgumentException: 'kafka_flow_compressor_compressed_bytes_total': Illegal metric name. The metric name must not include the '_total' suffix. Call PrometheusNaming.sanitizeMetricName(name) to avoid this error.
```


The new name is the same as the outcome of `PrometheusNaming.sanitizeMetricName("kafka_flow_compressor_compressed_bytes_total")`