### PR TITLE
Dealias kafka-journal's ConsRecord to skafka's ConsumerRecord

### DIFF
--- a/core-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/ShutdownSpec.scala
+++ b/core-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/ShutdownSpec.scala
@@ -5,11 +5,12 @@ import cats.effect.unsafe.IORuntime
 import cats.effect.{Deferred, IO, Ref, Resource}
 import cats.syntax.all._
 import com.evolutiongaming.catshelper.LogOf
-import com.evolutiongaming.kafka.journal.ConsRecords
 import com.evolutiongaming.retry.Retry
+import com.evolutiongaming.skafka.consumer.ConsumerRecords
 import com.evolutiongaming.skafka.producer.{ProducerConfig, ProducerRecord, RecordMetadata}
 import com.evolutiongaming.skafka.{CommonConfig, Offset, Partition}
 import com.evolutiongaming.sstream.Stream
+import scodec.bits.ByteVector
 
 import scala.concurrent.duration._
 
@@ -80,7 +81,7 @@ object ShutdownSpec {
     (_, _) =>
       Resource.pure[IO, TopicFlow[IO]] {
         new TopicFlow[IO] {
-          def apply(records: ConsRecords) = IO.unit
+          def apply(records: ConsumerRecords[String, ByteVector]) = IO.unit
           def add(partitionsAndOffsets: NonEmptySet[(Partition, Offset)]) = {
             val partitions = partitionsAndOffsets map (_._1)
             state update (_ ++ partitions.toList)

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/AdditionalStatePersistOf.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/AdditionalStatePersistOf.scala
@@ -3,7 +3,8 @@ package com.evolutiongaming.kafka.flow
 import cats.Applicative
 import cats.effect.{Clock, MonadCancelThrow, Ref}
 import com.evolutiongaming.kafka.flow.persistence.Persistence
-import com.evolutiongaming.kafka.journal.ConsRecord
+import com.evolutiongaming.skafka.consumer.ConsumerRecord
+import scodec.bits.ByteVector
 
 import scala.concurrent.duration.FiniteDuration
 
@@ -15,27 +16,27 @@ import scala.concurrent.duration.FiniteDuration
   */
 trait AdditionalStatePersistOf[F[_], S] {
   def apply(
-    persistence: Persistence[F, S, ConsRecord],
+    persistence: Persistence[F, S, ConsumerRecord[String, ByteVector]],
     keyContext: KeyContext[F]
-  ): F[AdditionalStatePersist[F, S, ConsRecord]]
+  ): F[AdditionalStatePersist[F, S, ConsumerRecord[String, ByteVector]]]
 }
 
 object AdditionalStatePersistOf {
   def empty[F[_]: Applicative, S]: AdditionalStatePersistOf[F, S] =
     new AdditionalStatePersistOf[F, S] {
       override def apply(
-        persistence: Persistence[F, S, ConsRecord],
+        persistence: Persistence[F, S, ConsumerRecord[String, ByteVector]],
         keyContext: KeyContext[F]
-      ): F[AdditionalStatePersist[F, S, ConsRecord]] =
-        Applicative[F].pure(AdditionalStatePersist.empty[F, S, ConsRecord])
+      ): F[AdditionalStatePersist[F, S, ConsumerRecord[String, ByteVector]]] =
+        Applicative[F].pure(AdditionalStatePersist.empty[F, S, ConsumerRecord[String, ByteVector]])
     }
 
   def of[F[_]: MonadCancelThrow: Ref.Make: Clock, S](cooldown: FiniteDuration): AdditionalStatePersistOf[F, S] = {
     new AdditionalStatePersistOf[F, S] {
       def apply(
-        persistence: Persistence[F, S, ConsRecord],
+        persistence: Persistence[F, S, ConsumerRecord[String, ByteVector]],
         keyContext: KeyContext[F]
-      ): F[AdditionalStatePersist[F, S, ConsRecord]] = {
+      ): F[AdditionalStatePersist[F, S, ConsumerRecord[String, ByteVector]]] = {
         AdditionalStatePersist.of(persistence, keyContext, cooldown)
       }
     }

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/ConsumerFlow.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/ConsumerFlow.scala
@@ -6,10 +6,10 @@ import cats.effect.Resource
 import cats.syntax.all._
 import com.evolutiongaming.catshelper.{Log, LogOf}
 import com.evolutiongaming.kafka.flow.kafka.Consumer
-import com.evolutiongaming.kafka.journal.ConsRecords
 import com.evolutiongaming.skafka.Topic
 import com.evolutiongaming.skafka.consumer.ConsumerRecords
 import com.evolutiongaming.sstream.Stream
+import scodec.bits.ByteVector
 
 /** Represents everything stateful happening on one `Consumer` */
 trait ConsumerFlow[F[_]] {
@@ -19,7 +19,7 @@ trait ConsumerFlow[F[_]] {
     * Note, that returned record does not guarantee that commit to Kafka happened, i.e. that the record will not be
     * processed for the second time.
     */
-  def stream: Stream[F, ConsRecords]
+  def stream: Stream[F, ConsumerRecords[String, ByteVector]]
 
 }
 object ConsumerFlow {

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/KafkaFlow.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/KafkaFlow.scala
@@ -6,12 +6,13 @@ import cats.effect.kernel.Outcome
 import cats.syntax.all._
 import com.evolutiongaming.catshelper.{BracketThrowable, LogOf}
 import com.evolutiongaming.kafka.flow.kafka.Consumer
-import com.evolutiongaming.kafka.journal.ConsRecords
 import com.evolutiongaming.random.Random
 import com.evolutiongaming.retry.{OnError, Retry, Sleep, Strategy}
 import com.evolutiongaming.sstream.Stream
 
 import scala.concurrent.duration._
+import scodec.bits.ByteVector
+import com.evolutiongaming.skafka.consumer.ConsumerRecords
 
 object KafkaFlow {
 
@@ -57,7 +58,7 @@ object KafkaFlow {
   def stream[F[_]: BracketThrowable: Retry](
     consumer: Resource[F, Consumer[F]],
     flowOf: ConsumerFlowOf[F]
-  ): Stream[F, ConsRecords] =
+  ): Stream[F, ConsumerRecords[String, ByteVector]] =
     for {
       _        <- Stream.around(Retry[F].toFunctionK)
       consumer <- Stream.fromResource(consumer)

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/KeyStateOf.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/KeyStateOf.scala
@@ -7,9 +7,10 @@ import com.evolutiongaming.kafka.flow.key.KeysOf
 import com.evolutiongaming.kafka.flow.persistence.{PersistenceOf, SnapshotPersistenceOf}
 import com.evolutiongaming.kafka.flow.registry.EntityRegistry
 import com.evolutiongaming.kafka.flow.timer.{TimerFlowOf, TimersOf, Timestamp}
-import com.evolutiongaming.kafka.journal.ConsRecord
 import com.evolutiongaming.skafka.TopicPartition
+import com.evolutiongaming.skafka.consumer.ConsumerRecord
 import com.evolutiongaming.sstream.Stream
+import scodec.bits.ByteVector
 
 trait KeyStateOf[F[_]] { self =>
 
@@ -19,7 +20,7 @@ trait KeyStateOf[F[_]] { self =>
     key: String,
     createdAt: Timestamp,
     context: KeyContext[F]
-  ): Resource[F, KeyState[F, ConsRecord]]
+  ): Resource[F, KeyState[F, ConsumerRecord[String, ByteVector]]]
 
   /** Restores a state for all keys present in persistence.
     *
@@ -39,9 +40,9 @@ object KeyStateOf {
     applicationId: String,
     groupId: String,
     timersOf: TimersOf[F, KafkaKey],
-    persistenceOf: PersistenceOf[F, KafkaKey, S, ConsRecord],
+    persistenceOf: PersistenceOf[F, KafkaKey, S, ConsumerRecord[String, ByteVector]],
     timerFlowOf: TimerFlowOf[F],
-    fold: FoldOption[F, S, ConsRecord],
+    fold: FoldOption[F, S, ConsumerRecord[String, ByteVector]],
     registry: EntityRegistry[F, KafkaKey, S],
   ): KeyStateOf[F] = lazyRecovery(
     applicationId = applicationId,
@@ -63,9 +64,9 @@ object KeyStateOf {
     applicationId: String,
     groupId: String,
     timersOf: TimersOf[F, KafkaKey],
-    persistenceOf: PersistenceOf[F, KafkaKey, S, ConsRecord],
+    persistenceOf: PersistenceOf[F, KafkaKey, S, ConsumerRecord[String, ByteVector]],
     timerFlowOf: TimerFlowOf[F],
-    fold: FoldOption[F, S, ConsRecord],
+    fold: FoldOption[F, S, ConsumerRecord[String, ByteVector]],
     tick: TickOption[F, S],
     registry: EntityRegistry[F, KafkaKey, S],
   ): KeyStateOf[F] = new KeyStateOf[F] {
@@ -104,9 +105,9 @@ object KeyStateOf {
     groupId: String,
     keysOf: KeysOf[F, KafkaKey],
     timersOf: TimersOf[F, KafkaKey],
-    persistenceOf: PersistenceOf[F, KafkaKey, S, ConsRecord],
+    persistenceOf: PersistenceOf[F, KafkaKey, S, ConsumerRecord[String, ByteVector]],
     timerFlowOf: TimerFlowOf[F],
-    fold: FoldOption[F, S, ConsRecord],
+    fold: FoldOption[F, S, ConsumerRecord[String, ByteVector]],
     registry: EntityRegistry[F, KafkaKey, S],
   ): KeyStateOf[F] = eagerRecovery(
     applicationId = applicationId,
@@ -130,9 +131,9 @@ object KeyStateOf {
     groupId: String,
     keysOf: KeysOf[F, KafkaKey],
     timersOf: TimersOf[F, KafkaKey],
-    persistenceOf: PersistenceOf[F, KafkaKey, S, ConsRecord],
+    persistenceOf: PersistenceOf[F, KafkaKey, S, ConsumerRecord[String, ByteVector]],
     timerFlowOf: TimerFlowOf[F],
-    fold: FoldOption[F, S, ConsRecord],
+    fold: FoldOption[F, S, ConsumerRecord[String, ByteVector]],
     tick: TickOption[F, S],
     registry: EntityRegistry[F, KafkaKey, S],
   ): KeyStateOf[F] = eagerRecovery(
@@ -156,8 +157,8 @@ object KeyStateOf {
     groupId: String,
     keysOf: KeysOf[F, KafkaKey],
     timersOf: TimersOf[F, KafkaKey],
-    persistenceOf: SnapshotPersistenceOf[F, KafkaKey, S, ConsRecord],
-    keyFlowOf: KeyFlowOf[F, S, ConsRecord],
+    persistenceOf: SnapshotPersistenceOf[F, KafkaKey, S, ConsumerRecord[String, ByteVector]],
+    keyFlowOf: KeyFlowOf[F, S, ConsumerRecord[String, ByteVector]],
     additionalPersistOf: AdditionalStatePersistOf[F, S],
     registry: EntityRegistry[F, KafkaKey, S],
   ): KeyStateOf[F] = eagerRecovery(
@@ -168,7 +169,7 @@ object KeyStateOf {
     persistenceOf       = persistenceOf,
     additionalPersistOf = additionalPersistOf,
     keyFlowOf           = keyFlowOf,
-    recover             = FoldOption.empty[F, S, ConsRecord],
+    recover             = FoldOption.empty[F, S, ConsumerRecord[String, ByteVector]],
     registry            = registry
   )
 
@@ -185,8 +186,8 @@ object KeyStateOf {
     groupId: String,
     keysOf: KeysOf[F, KafkaKey],
     timersOf: TimersOf[F, KafkaKey],
-    persistenceOf: SnapshotPersistenceOf[F, KafkaKey, S, ConsRecord],
-    keyFlowOf: KeyFlowOf[F, S, ConsRecord],
+    persistenceOf: SnapshotPersistenceOf[F, KafkaKey, S, ConsumerRecord[String, ByteVector]],
+    keyFlowOf: KeyFlowOf[F, S, ConsumerRecord[String, ByteVector]],
     registry: EntityRegistry[F, KafkaKey, S],
   ): KeyStateOf[F] = eagerRecovery(
     applicationId       = applicationId,
@@ -196,7 +197,7 @@ object KeyStateOf {
     persistenceOf       = persistenceOf,
     additionalPersistOf = AdditionalStatePersistOf.empty[F, S],
     keyFlowOf           = keyFlowOf,
-    recover             = FoldOption.empty[F, S, ConsRecord],
+    recover             = FoldOption.empty[F, S, ConsumerRecord[String, ByteVector]],
     registry            = registry
   )
 
@@ -209,10 +210,10 @@ object KeyStateOf {
     groupId: String,
     keysOf: KeysOf[F, KafkaKey],
     timersOf: TimersOf[F, KafkaKey],
-    persistenceOf: PersistenceOf[F, KafkaKey, S, ConsRecord],
+    persistenceOf: PersistenceOf[F, KafkaKey, S, ConsumerRecord[String, ByteVector]],
     additionalPersistOf: AdditionalStatePersistOf[F, S],
-    keyFlowOf: KeyFlowOf[F, S, ConsRecord],
-    recover: FoldOption[F, S, ConsRecord],
+    keyFlowOf: KeyFlowOf[F, S, ConsumerRecord[String, ByteVector]],
+    recover: FoldOption[F, S, ConsumerRecord[String, ByteVector]],
     registry: EntityRegistry[F, KafkaKey, S],
   ): KeyStateOf[F] = new KeyStateOf[F] {
 

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/journal/JournalFold.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/journal/JournalFold.scala
@@ -4,18 +4,18 @@ import cats.Monad
 import cats.syntax.all._
 import com.evolutiongaming.catshelper.LogOf
 import com.evolutiongaming.kafka.flow.FoldOption
-import com.evolutiongaming.kafka.flow.snapshot.KafkaSnapshot
-import com.evolutiongaming.kafka.flow.snapshot.SnapshotFold
-import com.evolutiongaming.kafka.journal.ConsRecord
+import com.evolutiongaming.kafka.flow.snapshot.{KafkaSnapshot, SnapshotFold}
 import com.evolutiongaming.kafka.journal.SeqNr
+import com.evolutiongaming.skafka.consumer.ConsumerRecord
+import scodec.bits.ByteVector
 
 /** Wraps state into `KafkaSnapshot` and deduplicates by sequence number in addition to offsets */
 object JournalFold {
 
   // TODO: introduce new state wrapper to not force library user to store `SeqNr` in state
   def explicitSeqNr[F[_]: Monad: JournalParser: LogOf, S](
-    fold: FoldOption[F, S, ConsRecord],
-  )(stateToSeqNr: S => SeqNr): F[FoldOption[F, KafkaSnapshot[S], ConsRecord]] =
+    fold: FoldOption[F, S, ConsumerRecord[String, ByteVector]],
+  )(stateToSeqNr: S => SeqNr): F[FoldOption[F, KafkaSnapshot[S], ConsumerRecord[String, ByteVector]]] =
     LogOf[F].apply(JournalFold.getClass) map { log =>
       SnapshotFold(fold) filterM { (snapshot, record) =>
         for {

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/package.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/package.scala
@@ -1,8 +1,9 @@
 package com.evolutiongaming.kafka
 
-import com.evolutiongaming.kafka.journal.ConsRecord
+import com.evolutiongaming.skafka.consumer.ConsumerRecord
+import scodec.bits.ByteVector
 
 package object flow {
-  type FoldCons[F[_], S]       = Fold[F, S, ConsRecord]
-  type FoldOptionCons[F[_], S] = FoldOption[F, S, ConsRecord]
+  type FoldCons[F[_], S]       = Fold[F, S, ConsumerRecord[String, ByteVector]]
+  type FoldOptionCons[F[_], S] = FoldOption[F, S, ConsumerRecord[String, ByteVector]]
 }

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotFold.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotFold.scala
@@ -3,15 +3,16 @@ package com.evolutiongaming.kafka.flow.snapshot
 import cats.Applicative
 import cats.syntax.all._
 import com.evolutiongaming.kafka.flow.FoldOption
-import com.evolutiongaming.kafka.journal.ConsRecord
+import com.evolutiongaming.skafka.consumer.ConsumerRecord
+import scodec.bits.ByteVector
 
 /** Wraps state into `KafkaSnapshot` and deduplicates by offset */
 object SnapshotFold {
 
   /** Creates `SnapshotFold` without metrics */
   def apply[F[_]: Applicative, S](
-    fold: FoldOption[F, S, ConsRecord]
-  ): FoldOption[F, KafkaSnapshot[S], ConsRecord] =
+    fold: FoldOption[F, S, ConsumerRecord[String, ByteVector]]
+  ): FoldOption[F, KafkaSnapshot[S], ConsumerRecord[String, ByteVector]] =
     fold
       .transformState[KafkaSnapshot[S]](_.value) { (state, record) =>
         KafkaSnapshot(value = state, offset = record.offset)

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/RebalanceListenerSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/RebalanceListenerSpec.scala
@@ -5,10 +5,10 @@ import cats.syntax.all._
 import com.evolutiongaming.catshelper.LogOf
 import com.evolutiongaming.kafka.flow.RebalanceListenerSpec._
 import com.evolutiongaming.kafka.flow.kafka.Consumer
-import com.evolutiongaming.kafka.journal.ConsRecords
 import com.evolutiongaming.skafka._
-import com.evolutiongaming.skafka.consumer.{RebalanceListener1 => SRebalanceListener}
+import com.evolutiongaming.skafka.consumer.{ConsumerRecords, RebalanceListener1 => SRebalanceListener}
 import munit.FunSuite
+import scodec.bits.ByteVector
 
 import scala.concurrent.duration.FiniteDuration
 import scala.util.Try
@@ -108,12 +108,12 @@ object RebalanceListenerSpec {
 
     val consumer: Consumer[F] = new Consumer[F] {
       def subscribe(topics: NonEmptySet[Topic], listener: SRebalanceListener[F]): F[Unit] = ().pure[F]
-      def poll(timeout: FiniteDuration): F[ConsRecords]                                   = ConsRecords.empty.pure[F]
-      def commit(offsets: NonEmptyMap[TopicPartition, OffsetAndMetadata]): F[Unit]        = ().pure[F]
+      def poll(timeout: FiniteDuration): F[ConsumerRecords[String, ByteVector]]    = ConsumerRecords.empty.pure[F]
+      def commit(offsets: NonEmptyMap[TopicPartition, OffsetAndMetadata]): F[Unit] = ().pure[F]
     }
 
     def flow(topic: String) = new TopicFlow[F] {
-      def apply(records: ConsRecords): F[Unit] = ().pure[F]
+      def apply(records: ConsumerRecords[String, ByteVector]): F[Unit] = ().pure[F]
       def add(partitions: NonEmptySet[(Partition, Offset)]): F[Unit] =
         StateT.modify(_.add(topic, Action.Add(partitions)))
       def remove(partitions: NonEmptySet[Partition]): F[Unit] =

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/journal/JournalFoldSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/journal/JournalFoldSpec.scala
@@ -4,26 +4,14 @@ import cats.syntax.option._
 import com.evolutiongaming.catshelper.LogOf
 import com.evolutiongaming.kafka.flow.FoldOption
 import com.evolutiongaming.kafka.flow.snapshot.KafkaSnapshot
-import com.evolutiongaming.kafka.journal.ActionHeader
-import com.evolutiongaming.kafka.journal.ConsRecord
-import com.evolutiongaming.kafka.journal.HeaderMetadata
-import com.evolutiongaming.kafka.journal.JsonCodec
-import com.evolutiongaming.kafka.journal.PayloadType
-import com.evolutiongaming.kafka.journal.SeqNr
-import com.evolutiongaming.kafka.journal.SeqRange
-import com.evolutiongaming.kafka.journal.ToBytes
-import com.evolutiongaming.kafka.journal.Version
-import com.evolutiongaming.skafka.Header
-import com.evolutiongaming.skafka.Offset
-import com.evolutiongaming.skafka.TimestampAndType
-import com.evolutiongaming.skafka.TimestampType
-import com.evolutiongaming.skafka.TopicPartition
-import com.evolutiongaming.skafka.consumer.WithSize
-import java.time.Instant
+import com.evolutiongaming.kafka.journal._
+import com.evolutiongaming.skafka.consumer.{ConsumerRecord, WithSize}
+import com.evolutiongaming.skafka.{Header, Offset, TimestampAndType, TimestampType, TopicPartition}
 import munit.FunSuite
-import scala.util.Success
-import scala.util.Try
 import scodec.bits.ByteVector
+
+import java.time.Instant
+import scala.util.{Success, Try}
 
 import JournalFoldSpec._
 
@@ -127,7 +115,7 @@ object JournalFoldSpec {
           metadata    = HeaderMetadata.empty
         )
       )
-      record = ConsRecord(
+      record = ConsumerRecord[String, ByteVector](
         topicPartition = TopicPartition.empty,
         offset         = offset,
         timestampAndType = Some(

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/journal/JournalParserSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/journal/JournalParserSpec.scala
@@ -1,29 +1,15 @@
 package com.evolutiongaming.kafka.flow.journal
 
 import cats.syntax.option._
-import com.evolutiongaming.kafka.journal.ActionHeader
-import com.evolutiongaming.kafka.journal.ConsRecord
-import com.evolutiongaming.kafka.journal.HeaderMetadata
-import com.evolutiongaming.kafka.journal.JsonCodec
-import com.evolutiongaming.kafka.journal.PayloadType
-import com.evolutiongaming.kafka.journal.SeqNr
-import com.evolutiongaming.kafka.journal.SeqRange
-import com.evolutiongaming.kafka.journal.ToBytes
-import com.evolutiongaming.kafka.journal.Version
-import com.evolutiongaming.skafka.Header
-import com.evolutiongaming.skafka.Offset
-import com.evolutiongaming.skafka.TimestampAndType
-import com.evolutiongaming.skafka.TimestampType
-import com.evolutiongaming.skafka.TopicPartition
-import com.evolutiongaming.skafka.consumer.WithSize
-import java.time.Instant
+import com.evolutiongaming.kafka.journal._
+import com.evolutiongaming.skafka.consumer.{ConsumerRecord, WithSize}
+import com.evolutiongaming.skafka.{Header, Offset, TimestampAndType, TimestampType, TopicPartition}
 import munit.FunSuite
-import play.api.libs.json.Json
-import play.api.libs.json.Reads
-import scala.util.Failure
-import scala.util.Success
-import scala.util.Try
+import play.api.libs.json.{Json, Reads}
 import scodec.bits.ByteVector
+
+import java.time.Instant
+import scala.util.{Failure, Success, Try}
 
 import JournalParserSpec._
 
@@ -112,7 +98,7 @@ object JournalParserSpec {
       )
     )
 
-    def record(payload: ByteVector) = ConsRecord(
+    def record(payload: ByteVector) = ConsumerRecord[String, ByteVector](
       topicPartition = TopicPartition.empty,
       offset         = Offset.unsafe(21398),
       timestampAndType = Some(

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotFoldSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotFoldSpec.scala
@@ -2,10 +2,10 @@ package com.evolutiongaming.kafka.flow.snapshot
 
 import cats.Id
 import com.evolutiongaming.kafka.flow.FoldOption
-import com.evolutiongaming.kafka.journal.ConsRecord
-import com.evolutiongaming.skafka.Offset
-import com.evolutiongaming.skafka.TopicPartition
+import com.evolutiongaming.skafka.consumer.ConsumerRecord
+import com.evolutiongaming.skafka.{Offset, TopicPartition}
 import munit.FunSuite
+import scodec.bits.ByteVector
 
 import SnapshotFoldSpec._
 
@@ -15,7 +15,7 @@ class SnapshotFoldSpec extends FunSuite {
     val f = new ConstFixture
     val state = f.fold(
       s = None,
-      a = ConsRecord(TopicPartition.empty, Offset.unsafe(1), None)
+      a = ConsumerRecord[String, ByteVector](TopicPartition.empty, Offset.unsafe(1), None)
     )
     assert(state == Some(KafkaSnapshot(offset = Offset.unsafe(1), value = 100)))
   }
@@ -24,7 +24,7 @@ class SnapshotFoldSpec extends FunSuite {
     val f = new ConstFixture
     val state = f.fold(
       s = Some(KafkaSnapshot(offset = Offset.unsafe(1), value = 100)),
-      a = ConsRecord(TopicPartition.empty, Offset.unsafe(2), None)
+      a = ConsumerRecord[String, ByteVector](TopicPartition.empty, Offset.unsafe(2), None)
     )
     assert(state == Some(KafkaSnapshot(offset = Offset.unsafe(2), value = 200)))
   }
@@ -33,11 +33,11 @@ class SnapshotFoldSpec extends FunSuite {
     val f = new ConstFixture
     val state1 = f.fold(
       s = None,
-      a = ConsRecord(TopicPartition.empty, Offset.unsafe(1), None)
+      a = ConsumerRecord[String, ByteVector](TopicPartition.empty, Offset.unsafe(1), None)
     )
     val state2 = f.fold(
       s = state1,
-      a = ConsRecord(TopicPartition.empty, Offset.unsafe(1), None)
+      a = ConsumerRecord[String, ByteVector](TopicPartition.empty, Offset.unsafe(1), None)
     )
     assert(state1 == Some(KafkaSnapshot(offset = Offset.unsafe(1), value = 100)))
     assert(state2 == state1)

--- a/metrics/src/main/scala/com/evolutiongaming/kafka/flow/FlowMetrics.scala
+++ b/metrics/src/main/scala/com/evolutiongaming/kafka/flow/FlowMetrics.scala
@@ -16,17 +16,18 @@ import com.evolutiongaming.kafka.flow.persistence.PersistenceModule
 import com.evolutiongaming.kafka.flow.persistence.compression.Compressor
 import com.evolutiongaming.kafka.flow.snapshot.SnapshotDatabase
 import com.evolutiongaming.kafka.flow.snapshot.SnapshotDatabaseMetrics._
-import com.evolutiongaming.kafka.journal.ConsRecord
+import com.evolutiongaming.skafka.consumer.ConsumerRecord
 import com.evolutiongaming.smetrics.CollectorRegistry
+import scodec.bits.ByteVector
 
 trait FlowMetrics[F[_]] {
 
   implicit def keyDatabaseMetrics: Metrics[KeyDatabase[F, KafkaKey]]
-  implicit def journalDatabaseMetrics: Metrics[JournalDatabase[F, KafkaKey, ConsRecord]]
+  implicit def journalDatabaseMetrics: Metrics[JournalDatabase[F, KafkaKey, ConsumerRecord[String, ByteVector]]]
   implicit def snapshotDatabaseMetrics: MetricsK[SnapshotDatabase[F, KafkaKey, *]]
   implicit def persistenceModuleMetrics: MetricsK[PersistenceModule[F, *]]
-  implicit def foldOptionMetrics: MetricsK[FoldOption[F, *, ConsRecord]]
-  implicit def enhancedFoldMetrics: MetricsK[EnhancedFold[F, *, ConsRecord]]
+  implicit def foldOptionMetrics: MetricsK[FoldOption[F, *, ConsumerRecord[String, ByteVector]]]
+  implicit def enhancedFoldMetrics: MetricsK[EnhancedFold[F, *, ConsumerRecord[String, ByteVector]]]
   implicit def keyStateOfMetrics: Metrics[KeyStateOf[F]]
   implicit def partitionFlowOfMetrics: Metrics[PartitionFlowOf[F]]
   implicit def topicFlowOfMetrics: Metrics[TopicFlowOf[F]]
@@ -68,15 +69,15 @@ object FlowMetrics {
   }
 
   def empty[F[_]]: FlowMetrics[F] = new FlowMetrics[F] {
-    def keyDatabaseMetrics                                           = Metrics.empty
-    def journalDatabaseMetrics                                       = Metrics.empty
-    def snapshotDatabaseMetrics                                      = MetricsK.empty[SnapshotDatabase[F, KafkaKey, *]]
-    def persistenceModuleMetrics                                     = MetricsK.empty[PersistenceModule[F, *]]
-    def foldOptionMetrics                                            = MetricsK.empty[FoldOption[F, *, ConsRecord]]
-    def enhancedFoldMetrics                                          = MetricsK.empty[EnhancedFold[F, *, ConsRecord]]
-    def keyStateOfMetrics                                            = Metrics.empty
-    def partitionFlowOfMetrics                                       = Metrics.empty
-    def topicFlowOfMetrics                                           = Metrics.empty
+    def keyDatabaseMetrics       = Metrics.empty
+    def journalDatabaseMetrics   = Metrics.empty
+    def snapshotDatabaseMetrics  = MetricsK.empty[SnapshotDatabase[F, KafkaKey, *]]
+    def persistenceModuleMetrics = MetricsK.empty[PersistenceModule[F, *]]
+    def foldOptionMetrics        = MetricsK.empty[FoldOption[F, *, ConsumerRecord[String, ByteVector]]]
+    def enhancedFoldMetrics      = MetricsK.empty[EnhancedFold[F, *, ConsumerRecord[String, ByteVector]]]
+    def keyStateOfMetrics        = Metrics.empty
+    def partitionFlowOfMetrics   = Metrics.empty
+    def topicFlowOfMetrics       = Metrics.empty
     def compressorMetrics(component: String): Metrics[Compressor[F]] = Metrics.empty
   }
 

--- a/metrics/src/main/scala/com/evolutiongaming/kafka/flow/PartitionFlowMetrics.scala
+++ b/metrics/src/main/scala/com/evolutiongaming/kafka/flow/PartitionFlowMetrics.scala
@@ -6,13 +6,11 @@ import com.evolutiongaming.catshelper.MeasureDuration
 import com.evolutiongaming.kafka.flow.kafka.ScheduleCommit
 import com.evolutiongaming.kafka.flow.metrics.MetricsOf
 import com.evolutiongaming.kafka.flow.metrics.syntax._
-import com.evolutiongaming.kafka.journal.ConsRecord
-import com.evolutiongaming.skafka.Offset
-import com.evolutiongaming.skafka.TopicPartition
-import com.evolutiongaming.smetrics.LabelNames
+import com.evolutiongaming.skafka.consumer.ConsumerRecord
+import com.evolutiongaming.skafka.{Offset, TopicPartition}
 import com.evolutiongaming.smetrics.MetricsHelper._
-import com.evolutiongaming.smetrics.Quantile
-import com.evolutiongaming.smetrics.Quantiles
+import com.evolutiongaming.smetrics.{LabelNames, Quantile, Quantiles}
+import scodec.bits.ByteVector
 
 object PartitionFlowMetrics {
 
@@ -32,7 +30,7 @@ object PartitionFlowMetrics {
       )
     } yield { partitionFlow =>
       new PartitionFlow[F] {
-        def apply(records: List[ConsRecord]) = {
+        def apply(records: List[ConsumerRecord[String, ByteVector]]) = {
           val processRecords = partitionFlow(records)
           // if there are no records incoming, we are triggering timers
           records.headOption map { head =>

--- a/metrics/src/main/scala/com/evolutiongaming/kafka/flow/TopicFlowMetrics.scala
+++ b/metrics/src/main/scala/com/evolutiongaming/kafka/flow/TopicFlowMetrics.scala
@@ -5,14 +5,12 @@ import cats.data.NonEmptySet
 import com.evolutiongaming.catshelper.MeasureDuration
 import com.evolutiongaming.kafka.flow.metrics.MetricsOf
 import com.evolutiongaming.kafka.flow.metrics.syntax._
-import com.evolutiongaming.kafka.journal.ConsRecords
-import com.evolutiongaming.skafka.Offset
-import com.evolutiongaming.skafka.Partition
-import com.evolutiongaming.smetrics.LabelNames
+import com.evolutiongaming.skafka.consumer.ConsumerRecords
+import com.evolutiongaming.skafka.{Offset, Partition, Topic}
 import com.evolutiongaming.smetrics.MetricsHelper._
-import com.evolutiongaming.smetrics.Quantile
-import com.evolutiongaming.smetrics.Quantiles
-import com.evolutiongaming.skafka.Topic
+import com.evolutiongaming.smetrics.{LabelNames, Quantile, Quantiles}
+import scodec.bits.ByteVector
+
 import kafka.Consumer
 
 object TopicFlowMetrics {
@@ -33,7 +31,7 @@ object TopicFlowMetrics {
       )
     } yield { topicFlow =>
       new TopicFlow[F] {
-        def apply(records: ConsRecords) =
+        def apply(records: ConsumerRecords[String, ByteVector]) =
           topicFlow.apply(records) measureDuration { duration =>
             applySummary.observe(duration.toNanos.nanosToSeconds)
           }

--- a/metrics/src/test/scala/com/evolutiongaming/kafka/flow/FoldMetricsSpec.scala
+++ b/metrics/src/test/scala/com/evolutiongaming/kafka/flow/FoldMetricsSpec.scala
@@ -1,11 +1,13 @@
 package com.evolutiongaming.kafka.flow
 
-import FoldMetrics._
 import com.evolutiongaming.catshelper.MeasureDuration
-import com.evolutiongaming.kafka.journal.ConsRecord
+import com.evolutiongaming.skafka.consumer.ConsumerRecord
 import com.evolutiongaming.smetrics.CollectorRegistry
-import metrics.syntax._
 import munit.FunSuite
+import scodec.bits.ByteVector
+
+import FoldMetrics._
+import metrics.syntax._
 
 class FoldMetricsSpec extends FunSuite {
 
@@ -13,7 +15,7 @@ class FoldMetricsSpec extends FunSuite {
 
   test("having MetricsKOf enables withCollectorRegistry syntax") {
     implicit val measureDuration     = MeasureDuration.empty[F]
-    val fold: FoldOptionCons[F, Int] = FoldOption.empty[F, Int, ConsRecord]
+    val fold: FoldOptionCons[F, Int] = FoldOption.empty[F, Int, ConsumerRecord[String, ByteVector]]
     fold.withCollectorRegistry(CollectorRegistry.empty[F])
   }
 

--- a/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/FlowSpec.scala
+++ b/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/FlowSpec.scala
@@ -1,8 +1,8 @@
 package com.evolutiongaming.kafka.flow
 
 import cats.data.NonEmptyList
-import cats.effect.{IO, Ref, Resource}
 import cats.effect.unsafe.IORuntime
+import cats.effect.{IO, Ref, Resource}
 import com.evolutiongaming.catshelper.LogOf
 import com.evolutiongaming.kafka.flow.cassandra.{CassandraPersistence, ConsistencyOverrides}
 import com.evolutiongaming.kafka.flow.kafka.Consumer
@@ -10,10 +10,10 @@ import com.evolutiongaming.kafka.flow.key.CassandraKeys
 import com.evolutiongaming.kafka.flow.registry.EntityRegistry
 import com.evolutiongaming.kafka.flow.snapshot.KafkaSnapshot
 import com.evolutiongaming.kafka.flow.timer.{TimerFlowOf, TimersOf}
-import com.evolutiongaming.kafka.journal.ConsRecord
 import com.evolutiongaming.retry.Retry
+import com.evolutiongaming.skafka.consumer.{ConsumerRecord, ConsumerRecords, WithSize}
 import com.evolutiongaming.skafka.{Offset, TopicPartition}
-import com.evolutiongaming.skafka.consumer.{ConsumerRecords, WithSize}
+import scodec.bits.ByteVector
 
 import scala.concurrent.duration._
 
@@ -41,7 +41,7 @@ class FlowSpec extends CassandraSpec {
           maxIdle       = 30.minutes,
           flushOnRevoke = true
         ),
-        fold     = FoldOption.empty[IO, KafkaSnapshot[String], ConsRecord],
+        fold     = FoldOption.empty[IO, KafkaSnapshot[String], ConsumerRecord[String, ByteVector]],
         tick     = TickOption.id[IO, KafkaSnapshot[String]],
         registry = EntityRegistry.empty[IO, KafkaKey, KafkaSnapshot[String]]
       )
@@ -54,7 +54,7 @@ class FlowSpec extends CassandraSpec {
       )
       topicFlowOf = TopicFlowOf(partitionFlowOf)
       records = NonEmptyList.of(
-        ConsRecord(
+        ConsumerRecord[String, ByteVector](
           topicPartition   = TopicPartition.empty,
           offset           = Offset.min,
           timestampAndType = None,

--- a/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/journal/JournalSpec.scala
+++ b/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/journal/JournalSpec.scala
@@ -2,9 +2,8 @@ package com.evolutiongaming.kafka.flow.journal
 
 import cats.effect.{IO, Ref}
 import com.evolutiongaming.kafka.flow.{CassandraSessionStub, CassandraSpec, KafkaKey}
-import com.evolutiongaming.kafka.journal.ConsRecord
+import com.evolutiongaming.skafka.consumer.{ConsumerRecord, WithSize}
 import com.evolutiongaming.skafka.{Offset, TopicPartition}
-import com.evolutiongaming.skafka.consumer.WithSize
 import scodec.bits.ByteVector
 
 class JournalSpec extends CassandraSpec {
@@ -14,7 +13,7 @@ class JournalSpec extends CassandraSpec {
     val test: IO[Unit] = for {
       journals <- CassandraJournals.withSchema(cassandra().session, cassandra().sync)
       contents <- IO.fromEither(ByteVector.encodeUtf8("record-contents"))
-      record = ConsRecord(
+      record = ConsumerRecord[String, ByteVector](
         topicPartition   = TopicPartition.empty,
         offset           = Offset.min,
         timestampAndType = None,

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPartitionPersistence.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPartitionPersistence.scala
@@ -3,16 +3,15 @@ package com.evolutiongaming.kafka.flow.kafkapersistence
 import cats.implicits._
 import cats.{FlatMap, Monad, data}
 import com.evolutiongaming.catshelper.{BracketThrowable, Log}
-import com.evolutiongaming.kafka.journal.ConsRecord
 import com.evolutiongaming.kafka.journal.util.SkafkaHelper._
 import com.evolutiongaming.skafka._
 import com.evolutiongaming.skafka.consumer.AutoOffsetReset.Earliest
 import com.evolutiongaming.skafka.consumer.{
+  Consumer => SkafkaConsumer,
   ConsumerConfig,
   ConsumerOf,
   ConsumerRecord,
-  WithSize,
-  Consumer => SkafkaConsumer
+  WithSize
 }
 import scodec.bits.ByteVector
 
@@ -51,7 +50,7 @@ object KafkaPartitionPersistence {
 
   private[kafkapersistence] def processRecord(
     map: BytesByKey,
-    record: ConsRecord
+    record: ConsumerRecord[String, ByteVector]
   ): BytesByKey = record match {
     case ConsumerRecord(_, _, _, Some(WithSize(key, _)), Some(WithSize(value, _)), _) => map + (key -> value)
     case ConsumerRecord(_, _, _, Some(WithSize(key, _)), None, _)                     => map - key

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/package.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/package.scala
@@ -9,7 +9,7 @@ import com.evolutiongaming.kafka.flow.kafka.ScheduleCommit
 import com.evolutiongaming.kafka.flow.metrics.syntax._
 import com.evolutiongaming.kafka.flow.registry.EntityRegistry
 import com.evolutiongaming.kafka.flow.timer.{TimerFlowOf, TimersOf}
-import com.evolutiongaming.kafka.journal.ConsRecord
+import com.evolutiongaming.skafka.consumer.ConsumerRecord
 import com.evolutiongaming.skafka.{Offset, TopicPartition}
 import com.evolutiongaming.sstream.{FoldWhile, Stream}
 import scodec.bits.ByteVector
@@ -60,7 +60,7 @@ package object kafkapersistence {
     groupId: String,
     timersOf: TimersOf[F, KafkaKey],
     timerFlowOf: TimerFlowOf[F],
-    fold: FoldOption[F, S, ConsRecord],
+    fold: FoldOption[F, S, ConsumerRecord[String, ByteVector]],
     tick: TickOption[F, S],
     partitionFlowConfig: PartitionFlowConfig,
     metrics: FlowMetrics[F]         = FlowMetrics.empty[F],
@@ -126,7 +126,7 @@ package object kafkapersistence {
     groupId: String,
     timersOf: TimersOf[F, KafkaKey],
     timerFlowOf: TimerFlowOf[F],
-    fold: EnhancedFold[F, S, ConsRecord],
+    fold: EnhancedFold[F, S, ConsumerRecord[String, ByteVector]],
     tick: TickOption[F, S],
     partitionFlowConfig: PartitionFlowConfig,
     metrics: FlowMetrics[F],


### PR DESCRIPTION
A step towards https://github.com/evolution-gaming/kafka-flow/issues/592.  
- `ConsRecords` and `ConsRecord` from `kafka-journal` are simply dealiased to the original `ConsumerRecords` and `ConsumerRecord` from `skafka`
- drop unnecessary usage of `PartitionOffset `