### PR TITLE
Drop dependency on SkafkaHelper

### DIFF
--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/kafka/Codecs.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/kafka/Codecs.scala
@@ -1,0 +1,16 @@
+package com.evolutiongaming.kafka.flow.kafka
+
+import cats.Applicative
+import cats.syntax.all._
+import com.evolutiongaming.skafka.{FromBytes, ToBytes, Topic}
+import scodec.bits.ByteVector
+
+private[flow] object Codecs {
+  implicit def skafkaFromBytes[F[_]: Applicative]: FromBytes[F, ByteVector] = { (a: Array[Byte], _: Topic) =>
+    ByteVector.view(a).pure[F]
+  }
+
+  implicit def skafkaToBytes[F[_]: Applicative]: ToBytes[F, ByteVector] = { (a: ByteVector, _: Topic) =>
+    a.toArray.pure[F]
+  }
+}

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/kafka/KafkaModule.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/kafka/KafkaModule.scala
@@ -4,13 +4,13 @@ import cats.effect.{Async, Clock, Resource}
 import cats.syntax.all._
 import com.evolutiongaming.catshelper.{FromTry, LogOf, MeasureDuration, ToFuture, ToTry}
 import com.evolutiongaming.kafka.flow.LogResource
-import com.evolutiongaming.kafka.journal.util.SkafkaHelper._
+import com.evolutiongaming.kafka.flow.kafka.Codecs._
 import com.evolutiongaming.kafka.journal.{
   KafkaConfig,
-  KafkaHealthCheck,
-  RandomIdOf,
   KafkaConsumerOf => JournalConsumerOf,
-  KafkaProducerOf => JournalProducerOf
+  KafkaHealthCheck,
+  KafkaProducerOf => JournalProducerOf,
+  RandomIdOf
 }
 import com.evolutiongaming.skafka.consumer.{
   AutoOffsetReset,

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/kafka/OffsetToCommit.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/kafka/OffsetToCommit.scala
@@ -1,7 +1,6 @@
 package com.evolutiongaming.kafka.flow.kafka
 
 import cats.ApplicativeThrow
-import com.evolutiongaming.kafka.journal.util.SkafkaHelper._
 import com.evolutiongaming.skafka.Offset
 
 /** Constructs an offset to commit to Kafka.
@@ -11,6 +10,5 @@ import com.evolutiongaming.skafka.Offset
   */
 object OffsetToCommit {
 
-  def apply[F[_]: ApplicativeThrow](offset: Offset): F[Offset] = offset.inc[F]
-
+  def apply[F[_]: ApplicativeThrow](offset: Offset): F[Offset] = Offset.of[F](offset.value + 1)
 }

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/CassandraCodecs.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/CassandraCodecs.scala
@@ -1,14 +1,12 @@
 package com.evolutiongaming.kafka.flow.cassandra
 
 import com.datastax.driver.core.SettableData
-import com.evolutiongaming.scassandra.DecodeByName
-import com.evolutiongaming.scassandra.EncodeByName
-import com.evolutiongaming.skafka.TimestampType
-import scala.jdk.CollectionConverters._
+import com.evolutiongaming.scassandra.{DecodeByName, EncodeByName}
+import com.evolutiongaming.skafka.{Offset, Partition, TimestampType}
 import scodec.bits.ByteVector
-import com.evolutiongaming.skafka.Partition
+
+import scala.jdk.CollectionConverters._
 import scala.util.Try
-import com.evolutiongaming.skafka.Offset
 
 private[flow] object CassandraCodecs {
 

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/CassandraCodecs.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/CassandraCodecs.scala
@@ -6,6 +6,9 @@ import com.evolutiongaming.scassandra.EncodeByName
 import com.evolutiongaming.skafka.TimestampType
 import scala.jdk.CollectionConverters._
 import scodec.bits.ByteVector
+import com.evolutiongaming.skafka.Partition
+import scala.util.Try
+import com.evolutiongaming.skafka.Offset
 
 private[flow] object CassandraCodecs {
 
@@ -40,5 +43,13 @@ private[flow] object CassandraCodecs {
       }
     }
   }
+
+  implicit val encodeByNamePartition: EncodeByName[Partition] = EncodeByName[Int].contramap { a: Partition => a.value }
+
+  implicit val decodeByNamePartition: DecodeByName[Partition] = DecodeByName[Int].map { a => Partition.of[Try](a).get }
+
+  implicit val encodeByNameOffset: EncodeByName[Offset] = EncodeByName[Long].contramap { a: Offset => a.value }
+
+  implicit val decodeByNameOffset: DecodeByName[Offset] = DecodeByName[Long].map { a => Offset.of[Try](a).get }
 
 }

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/journal/CassandraJournals.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/journal/CassandraJournals.scala
@@ -15,7 +15,6 @@ import com.evolutiongaming.kafka.journal.conversions.TupleToHeader
 import com.evolutiongaming.kafka.journal.eventual.cassandra.CassandraHelper._
 import com.evolutiongaming.kafka.journal.eventual.cassandra.CassandraSession
 import com.evolutiongaming.kafka.journal.util.Fail
-import com.evolutiongaming.kafka.journal.util.SkafkaHelper._
 import com.evolutiongaming.scassandra.syntax._
 import com.evolutiongaming.skafka.Offset
 import com.evolutiongaming.skafka.TimestampAndType

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/key/CassandraKeys.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/key/CassandraKeys.scala
@@ -7,12 +7,12 @@ import com.datastax.driver.core.{BoundStatement, Row}
 import com.evolutiongaming.cassandra.sync.CassandraSync
 import com.evolutiongaming.catshelper.ClockHelper._
 import com.evolutiongaming.kafka.flow.KafkaKey
+import com.evolutiongaming.kafka.flow.cassandra.CassandraCodecs._
 import com.evolutiongaming.kafka.flow.cassandra.ConsistencyOverrides
 import com.evolutiongaming.kafka.flow.cassandra.StatementHelper.StatementOps
 import com.evolutiongaming.kafka.flow.key.CassandraKeys.{Statements, rowToKey}
 import com.evolutiongaming.kafka.journal.eventual.cassandra.{CassandraSession, SegmentNr, Segments}
 import com.evolutiongaming.kafka.journal.util.Fail
-import com.evolutiongaming.kafka.journal.util.SkafkaHelper._
 import com.evolutiongaming.scassandra.syntax._
 import com.evolutiongaming.skafka.TopicPartition
 import com.evolutiongaming.sstream.Stream

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/CassandraSnapshots.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/CassandraSnapshots.scala
@@ -13,7 +13,6 @@ import com.evolutiongaming.kafka.journal.FromBytes.implicits._
 import com.evolutiongaming.kafka.journal.ToBytes
 import com.evolutiongaming.kafka.journal.ToBytes.implicits._
 import com.evolutiongaming.kafka.journal.eventual.cassandra.CassandraSession
-import com.evolutiongaming.kafka.journal.util.SkafkaHelper._
 import com.evolutiongaming.scassandra.syntax._
 import com.evolutiongaming.skafka.Offset
 import CassandraSnapshots._

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPartitionPersistence.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPartitionPersistence.scala
@@ -3,7 +3,7 @@ package com.evolutiongaming.kafka.flow.kafkapersistence
 import cats.implicits._
 import cats.{FlatMap, Monad, data}
 import com.evolutiongaming.catshelper.{BracketThrowable, Log}
-import com.evolutiongaming.kafka.journal.util.SkafkaHelper._
+import com.evolutiongaming.kafka.flow.kafka.Codecs._
 import com.evolutiongaming.skafka._
 import com.evolutiongaming.skafka.consumer.AutoOffsetReset.Earliest
 import com.evolutiongaming.skafka.consumer.{


### PR DESCRIPTION
Drop dependency on `com.evolutiongaming.kafka.journal.util.SkafkaHelper`, introducing used codecs locally.  
Another step towards https://github.com/evolution-gaming/kafka-flow/issues/592