### PR TITLE
Cassandra KeySchema improvements

### DIFF
--- a/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/key/KeySchemaSpec.scala
+++ b/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/key/KeySchemaSpec.scala
@@ -1,0 +1,108 @@
+package com.evolutiongaming.kafka.flow.key
+
+import cats.effect.IO
+import com.evolutiongaming.kafka.flow.CassandraSpec
+import com.evolutiongaming.scassandra.CassandraSession
+
+import scala.concurrent.duration._
+
+class KeySchemaSpec extends CassandraSpec {
+  override def munitTimeout = 2.minutes
+
+  test("table is created using scassandra session API") {
+    val session = cassandra().session.unsafe
+    val sync    = cassandra().sync
+
+    val keySchema = KeySchema.of(session, sync)
+
+    val test = for {
+      _ <- keySchema.create
+      _ <- validateTableExists(session)
+    } yield ()
+
+    test.unsafeRunSync()
+  }
+
+  test("table is created using kafka-journal session API") {
+    val session = cassandra().session
+    val sync    = cassandra().sync
+
+    val keySchema = KeySchema.apply(session, sync)
+
+    val test = for {
+      _ <- keySchema.create
+      _ <- validateTableExists(session.unsafe)
+    } yield ()
+
+    test.unsafeRunSync()
+  }
+
+  test("table is truncated using scassandra session API") {
+    val session = cassandra().session.unsafe
+    val sync    = cassandra().sync
+
+    val keySchema = KeySchema.of(session, sync)
+
+    val test = for {
+      _ <- keySchema.create
+      _ <- insertKey(session)
+      _ <- keySchema.truncate
+      _ <- validateTableIsEmpty(session)
+    } yield ()
+
+    test.unsafeRunSync()
+  }
+
+  test("table is truncated using kafka-journal session API") {
+    val session = cassandra().session
+    val sync    = cassandra().sync
+
+    val keySchema = KeySchema.apply(session, sync)
+
+    val test = for {
+      _ <- keySchema.create
+      _ <- insertKey(session.unsafe)
+      _ <- keySchema.truncate
+      _ <- validateTableIsEmpty(session.unsafe)
+    } yield ()
+
+    test.unsafeRunSync()
+  }
+
+  private def insertKey(session: CassandraSession[IO]): IO[Unit] = {
+    session
+      .execute(
+        """
+        INSERT INTO keys (application_id, group_id, segment, topic, partition, key, created, created_date, metadata) 
+        VALUES ('app', 'group', 1, 'topic', 1, 'key', toTimestamp(now()), toDate(now()), '{}')
+        """
+      )
+      .void
+  }
+
+  private def validateTableExists(session: CassandraSession[IO]): IO[Unit] = {
+    for {
+      resultSet <- session.execute(
+        "select table_name from system_schema.tables where table_name = 'keys' allow filtering"
+      )
+      maybeRow <- IO.delay(Option(resultSet.one()))
+      _ = maybeRow.fold(fail("Table 'keys' not found in system_schema.tables")) { row =>
+        val name = row.getString("table_name")
+        assert(name == "keys", s"Unexpected table name '$name' in system_schema.tables, expected 'keys'")
+      }
+    } yield ()
+  }
+
+  private def validateTableIsEmpty(session: CassandraSession[IO]): IO[Unit] = {
+    for {
+      resultSet <- session.execute("select count(*) from keys allow filtering")
+      row       <- IO.delay(resultSet.one())
+      count     <- IO.delay(row.getLong(0))
+      _          = assert(count == 0, s"Expected 0 rows in 'keys' table, found $count")
+    } yield ()
+  }
+
+  override def afterEach(context: AfterEach): Unit = {
+    cassandra().session.unsafe.execute("DROP TABLE IF EXISTS keys").void.unsafeRunSync()
+  }
+}

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/key/KeySchema.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/key/KeySchema.scala
@@ -4,6 +4,7 @@ import cats.Monad
 import cats.syntax.all._
 import com.evolutiongaming.cassandra.sync.CassandraSync
 import com.evolutiongaming.kafka.journal.eventual.cassandra.CassandraSession
+import com.evolutiongaming.scassandra
 
 private[key] trait KeySchema[F[_]] {
 
@@ -44,6 +45,39 @@ private[key] object KeySchema {
     }
     def truncate = synchronize("KeySchema") {
       session.execute("TRUNCATE keys").first.void
+    }
+  }
+
+  def of[F[_]: Monad](
+    session: scassandra.CassandraSession[F],
+    synchronize: CassandraSync[F]
+  ): KeySchema[F] = new KeySchema[F] {
+    def create = synchronize("KeySchema") {
+      session
+        .execute(
+          """CREATE TABLE IF NOT EXISTS keys(
+          |application_id TEXT,
+          |group_id TEXT,
+          |segment BIGINT,
+          |topic TEXT,
+          |partition INT,
+          |key TEXT,
+          |created TIMESTAMP,
+          |created_date DATE,
+          |metadata TEXT,
+          |PRIMARY KEY((application_id, group_id, segment), topic, partition, key)
+          |)
+          |""".stripMargin
+        ) >>
+        session
+          .execute(
+            "CREATE INDEX IF NOT EXISTS keys_created_date_idx ON keys(created_date)"
+          )
+          .void
+    }
+
+    def truncate = synchronize("KeySchema") {
+      session.execute("TRUNCATE keys").void
     }
   }
 


### PR DESCRIPTION
1. Add `scassandra`-based API to `KeySchema` to further drop `kafka-journal`-based one (https://github.com/evolution-gaming/kafka-flow/issues/592)
2. Add integration tests for `KeySchema` validating both old and new versions work as expected