### PR TITLE
Cassandra SnapshotSchema improvements

### DIFF
--- a/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotSchemaSpec.scala
+++ b/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotSchemaSpec.scala
@@ -1,0 +1,110 @@
+package com.evolutiongaming.kafka.flow.snapshot
+
+import cats.effect.IO
+import com.evolutiongaming.kafka.flow.CassandraSpec
+import com.evolutiongaming.scassandra.CassandraSession
+
+import scala.concurrent.duration._
+
+class SnapshotSchemaSpec extends CassandraSpec {
+  override def munitTimeout: Duration = 2.minutes
+
+  test("table is created using scassandra session API") {
+    val session = cassandra().session.unsafe
+    val sync    = cassandra().sync
+    val schema  = SnapshotSchema.of(session, sync)
+
+    val test = for {
+      _ <- schema.create
+      _ <- validateTableExists(session)
+    } yield ()
+
+    test.unsafeRunSync()
+  }
+
+  test("table is created using kafka-journal session API") {
+    val session = cassandra().session
+    val sync    = cassandra().sync
+    val schema  = SnapshotSchema.apply(session, sync)
+
+    val test = for {
+      _ <- schema.create
+      _ <- validateTableExists(session.unsafe)
+    } yield ()
+
+    test.unsafeRunSync()
+  }
+
+  test("table is truncated using scassandra session API") {
+    val session = cassandra().session.unsafe
+    val sync    = cassandra().sync
+
+    val schema = SnapshotSchema.of(session, sync)
+
+    val test = for {
+      _ <- schema.create
+      _ <- insertSnapshot(session)
+      _ <- schema.truncate
+      _ <- validateTableIsEmpty(session)
+    } yield ()
+
+    test.unsafeRunSync()
+  }
+
+  test("table is truncated using kafka-journal session API") {
+    val session = cassandra().session
+    val sync    = cassandra().sync
+
+    val schema = SnapshotSchema.apply(session, sync)
+
+    val test = for {
+      _ <- schema.create
+      _ <- insertSnapshot(session.unsafe)
+      _ <- schema.truncate
+      _ <- validateTableIsEmpty(session.unsafe)
+    } yield ()
+
+    test.unsafeRunSync()
+  }
+
+  private def insertSnapshot(session: CassandraSession[IO]): IO[Unit] = {
+    session
+      .execute(
+        """
+        INSERT INTO snapshots_v2 (application_id, group_id, topic, partition, key, offset, created, metadata, value) 
+        VALUES ('app_id', 'group_id', 'topic', 1, 'key', 1, toTimestamp(now()), '{}', textAsBlob('value'))
+        """
+      )
+      .void
+  }
+
+  private def validateTableExists(session: CassandraSession[IO]): IO[Unit] = {
+    for {
+      resultSet <- session.execute(
+        "select table_name from system_schema.tables where table_name = 'snapshots_v2' allow filtering"
+      )
+      maybeRow <- IO.delay(Option(resultSet.one()))
+      _ = maybeRow.fold(fail("Table 'snapshots_v2' not found in system_schema.tables")) { row =>
+        val name = row.getString("table_name")
+        assert(
+          name == "snapshots_v2",
+          s"Unexpected table name '$name' in system_schema.tables, expected 'snapshots_v2'"
+        )
+      }
+    } yield ()
+  }
+
+  private def validateTableIsEmpty(session: CassandraSession[IO]): IO[Unit] = {
+    for {
+      resultSet <- session.execute("select count(*) from snapshots_v2 allow filtering")
+      row       <- IO.delay(resultSet.one())
+      count     <- IO.delay(row.getLong(0))
+      _          = assert(count == 0, s"Expected 0 rows in 'snapshots_v2' table, found $count")
+    } yield ()
+  }
+
+  override def afterEach(context: AfterEach): Unit = {
+    super.afterEach(context)
+    cassandra().session.unsafe.execute("DROP TABLE IF EXISTS snapshots_v2").void.unsafeRunSync()
+  }
+}

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotSchema.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotSchema.scala
@@ -4,6 +4,7 @@ import cats.Monad
 import cats.syntax.all._
 import com.evolutiongaming.cassandra.sync.CassandraSync
 import com.evolutiongaming.kafka.journal.eventual.cassandra.CassandraSession
+import com.evolutiongaming.scassandra
 
 private[snapshot] trait SnapshotSchema[F[_]] {
 
@@ -39,6 +40,35 @@ private[snapshot] object SnapshotSchema {
     }
     def truncate = synchronize("SnapshotSchema") {
       session.execute("TRUNCATE snapshots_v2").first.void
+    }
+  }
+
+  def of[F[_]: Monad](
+    session: scassandra.CassandraSession[F],
+    synchronize: CassandraSync[F]
+  ): SnapshotSchema[F] = new SnapshotSchema[F] {
+    def create = synchronize("SnapshotSchema") {
+      session
+        .execute(
+          """CREATE TABLE IF NOT EXISTS snapshots_v2(
+          |application_id TEXT,
+          |group_id TEXT,
+          |topic TEXT,
+          |partition INT,
+          |key TEXT,
+          |offset BIGINT,
+          |created TIMESTAMP,
+          |metadata TEXT,
+          |value BLOB,
+          |PRIMARY KEY((application_id, group_id, topic, partition, key))
+          |)
+          |""".stripMargin
+        )
+        .void
+    }
+
+    def truncate = synchronize("SnapshotSchema") {
+      session.execute("TRUNCATE snapshots_v2").void
     }
   }
 


### PR DESCRIPTION
1. Add `scassandra`-based API to `SnapshotSchema` to further drop `kafka-journal`-based one (https://github.com/evolution-gaming/kafka-flow/issues/592)
2. Add integration tests for `SnapshotSchema` validating both old and new versions work as expected