### PR TITLE
Cassandra JournalSchema improvements

### DIFF
--- a/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/CassandraSessionStub.scala
+++ b/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/CassandraSessionStub.scala
@@ -3,27 +3,43 @@ package com.evolutiongaming.kafka.flow
 import cats.MonadThrow
 import cats.effect.Ref
 import cats.syntax.all._
-import com.datastax.driver.core.Statement
+import com.datastax.driver.core.{Host, PreparedStatement, RegularStatement, ResultSet, Statement}
 import com.evolutiongaming.kafka.journal.eventual.cassandra.CassandraSession
+import com.evolutiongaming.scassandra
 import com.evolutiongaming.sstream.Stream
 
 object CassandraSessionStub {
 
-  def alwaysFails[F[_]: MonadThrow]: CassandraSession[F] = new CassandraSession[F] {
-    def fail[T]: F[T] = MonadThrow[F].raiseError {
+  def alwaysFails[F[_]](implicit F: MonadThrow[F]): CassandraSession[F] = new CassandraSession[F] {
+    def fail[T]: F[T] = F.raiseError {
       new RuntimeException("CassandraSessionStub: always fails")
     }
     def prepare(query: String)        = fail
     def execute(statement: Statement) = Stream.lift(fail)
-    def unsafe                        = sys.error("CassandraSessionStub: no unsafe session")
+    def unsafe = new scassandra.CassandraSession[F] {
+      override def loggedKeyspace: F[Option[String]]                                 = F.pure(None)
+      override def init: F[Unit]                                                     = F.unit
+      override def execute(query: String): F[ResultSet]                              = fail
+      override def execute(query: String, values: Any*): F[ResultSet]                = fail
+      override def execute(query: String, values: Map[String, AnyRef]): F[ResultSet] = fail
+      override def execute(statement: Statement): F[ResultSet]                       = fail
+      override def prepare(query: String): F[PreparedStatement]                      = fail
+      override def prepare(statement: RegularStatement): F[PreparedStatement]        = fail
+      override def state: scassandra.CassandraSession.State[F] = new scassandra.CassandraSession.State[F] {
+        override def connectedHosts: F[Iterable[Host]]      = F.pure(Iterable.empty)
+        override def openConnections(host: Host): F[Int]    = F.pure(0)
+        override def trashedConnections(host: Host): F[Int] = F.pure(0)
+        override def inFlightQueries(host: Host): F[Int]    = F.pure(0)
+      }
+    }
   }
 
-  def injectFailures[F[_]: MonadThrow](
+  def injectFailures[F[_]](
     session: CassandraSession[F],
     failAfter: Ref[F, Int]
-  ): CassandraSession[F] = new CassandraSession[F] {
+  )(implicit F: MonadThrow[F]): CassandraSession[F] = new CassandraSession[F] {
 
-    def fail[T](query: String): F[T] = MonadThrow[F].raiseError {
+    def fail[T](query: String): F[T] = F.raiseError {
       new RuntimeException(s"CassandraSessionStub: failing after proper calls exhausted: $query")
     }
 
@@ -37,7 +53,34 @@ object CassandraSessionStub {
       if (failed) Stream.lift(fail(statement.toString)) else session.execute(statement)
     }
 
-    def unsafe = sys.error("CassandraSessionStub: no unsafe session")
+    def unsafe = new scassandra.CassandraSession[F] {
+      override def loggedKeyspace: F[Option[String]]    = F.pure(None)
+      override def init: F[Unit]                        = F.unit
+      override def execute(query: String): F[ResultSet] = failed.ifM(fail(query), session.unsafe.execute(query))
+
+      override def execute(query: String, values: Any*): F[ResultSet] =
+        failed.ifM(fail(query), session.unsafe.execute(query, values: _*))
+
+      override def execute(query: String, values: Map[String, AnyRef]): F[ResultSet] =
+        failed.ifM(fail(query), session.unsafe.execute(query, values))
+
+      override def execute(statement: Statement): F[ResultSet] =
+        failed.ifM(fail(statement.toString), session.unsafe.execute(statement))
+
+      override def prepare(query: String): F[PreparedStatement] =
+        failed.ifM(fail(query), session.unsafe.prepare(query))
+
+      override def prepare(statement: RegularStatement): F[PreparedStatement] =
+        failed.ifM(fail(statement.toString), session.unsafe.prepare(statement))
+
+      override def state: scassandra.CassandraSession.State[F] = new scassandra.CassandraSession.State[F] {
+        override def connectedHosts: F[Iterable[Host]]      = F.pure(Iterable.empty)
+        override def openConnections(host: Host): F[Int]    = F.pure(0)
+        override def trashedConnections(host: Host): F[Int] = F.pure(0)
+        override def inFlightQueries(host: Host): F[Int]    = F.pure(0)
+      }
+
+    }
 
   }
 

--- a/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/journal/JournalSchemaSpec.scala
+++ b/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/journal/JournalSchemaSpec.scala
@@ -1,0 +1,109 @@
+package com.evolutiongaming.kafka.flow.journal
+
+import com.evolutiongaming.kafka.flow.CassandraSpec
+import scala.concurrent.duration._
+import com.evolutiongaming.scassandra.CassandraSession
+import cats.effect.IO
+
+class JournalSchemaSpec extends CassandraSpec {
+  override def munitTimeout: Duration = 2.minutes
+
+  test("table is created using scassandra session API") {
+    val session = cassandra().session.unsafe
+    val sync    = cassandra().sync
+    val schema  = JournalSchema.of(session, sync)
+
+    val test = for {
+      _ <- schema.create
+      _ <- validateTableExists(session)
+    } yield ()
+
+    test.unsafeRunSync()
+  }
+
+  test("table is created using kafka-journal session API") {
+    val session = cassandra().session
+    val sync    = cassandra().sync
+    val schema  = JournalSchema.apply(session, sync)
+
+    val test = for {
+      _ <- schema.create
+      _ <- validateTableExists(session.unsafe)
+    } yield ()
+
+    test.unsafeRunSync()
+  }
+
+  test("table is truncated using scassandra session API") {
+    val session = cassandra().session.unsafe
+    val sync    = cassandra().sync
+
+    val schema = JournalSchema.of(session, sync)
+
+    val test = for {
+      _ <- schema.create
+      _ <- insertRecord(session)
+      _ <- schema.truncate
+      _ <- validateTableIsEmpty(session)
+    } yield ()
+
+    test.unsafeRunSync()
+  }
+
+  test("table is truncated using kafka-journal session API") {
+    val session = cassandra().session
+    val sync    = cassandra().sync
+
+    val schema = JournalSchema.apply(session, sync)
+
+    val test = for {
+      _ <- schema.create
+      _ <- insertRecord(session.unsafe)
+      _ <- schema.truncate
+      _ <- validateTableIsEmpty(session.unsafe)
+    } yield ()
+
+    test.unsafeRunSync()
+  }
+
+  private def insertRecord(session: CassandraSession[IO]): IO[Unit] = {
+    session
+      .execute(
+        """
+        INSERT INTO records (application_id, group_id, topic, partition, key, offset, created, timestamp, timestamp_type, headers, metadata, value)
+        VALUES ('app', 'group', 'topic', 1, 'key', 1, toTimestamp(now()), toTimestamp(now()), 'create', {'header': 'value'}, 'metadata', textAsBlob('value'))
+        """
+      )
+      .void
+  }
+
+  private def validateTableExists(session: CassandraSession[IO]): IO[Unit] = {
+    for {
+      resultSet <- session.execute(
+        "select table_name from system_schema.tables where table_name = 'records' allow filtering"
+      )
+      maybeRow <- IO.delay(Option(resultSet.one()))
+      _ = maybeRow.fold(fail("Table 'records' not found in system_schema.tables")) { row =>
+        val name = row.getString("table_name")
+        assert(
+          name == "records",
+          s"Unexpected table name '$name' in system_schema.tables, expected 'records'"
+        )
+      }
+    } yield ()
+  }
+
+  private def validateTableIsEmpty(session: CassandraSession[IO]): IO[Unit] = {
+    for {
+      resultSet <- session.execute("select count(*) from records allow filtering")
+      row       <- IO.delay(resultSet.one())
+      count     <- IO.delay(row.getLong(0))
+      _          = assert(count == 0, s"Expected 0 rows in 'records' table, found $count")
+    } yield ()
+  }
+
+  override def afterEach(context: AfterEach): Unit = {
+    super.afterEach(context)
+    cassandra().session.unsafe.execute("DROP TABLE IF EXISTS records").void.unsafeRunSync()
+  }
+}

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/journal/JournalSchema.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/journal/JournalSchema.scala
@@ -4,20 +4,25 @@ import cats.Monad
 import cats.syntax.all._
 import com.evolutiongaming.cassandra.sync.CassandraSync
 import com.evolutiongaming.kafka.journal.eventual.cassandra.CassandraSession
+import com.evolutiongaming.scassandra
 
 private[journal] trait JournalSchema[F[_]] {
-
   def create: F[Unit]
+
   def truncate: F[Unit]
-
 }
-private[journal] object JournalSchema {
 
+private[journal] object JournalSchema {
   def apply[F[_]: Monad](
     session: CassandraSession[F],
     synchronize: CassandraSync[F]
+  ): JournalSchema[F] = of(session.unsafe, synchronize)
+
+  def of[F[_]: Monad](
+    session: scassandra.CassandraSession[F],
+    synchronize: CassandraSync[F]
   ): JournalSchema[F] = new JournalSchema[F] {
-    def create = synchronize("JournalSchema") {
+    def create: F[Unit] = synchronize("JournalSchema") {
       session
         .execute(
           """CREATE TABLE IF NOT EXISTS records(
@@ -37,11 +42,11 @@ private[journal] object JournalSchema {
           |)
           |""".stripMargin
         )
-        .first
         .void
     }
-    def truncate = synchronize("JournalSchema") {
-      session.execute("TRUNCATE records").first.void
+
+    def truncate: F[Unit] = synchronize("JournalSchema") {
+      session.execute("TRUNCATE records").void
     }
   }
 

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/key/KeySchema.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/key/KeySchema.scala
@@ -7,52 +7,23 @@ import com.evolutiongaming.kafka.journal.eventual.cassandra.CassandraSession
 import com.evolutiongaming.scassandra
 
 private[key] trait KeySchema[F[_]] {
-
   def create: F[Unit]
-  def truncate: F[Unit]
 
+  def truncate: F[Unit]
 }
+
 private[key] object KeySchema {
 
   def apply[F[_]: Monad](
     session: CassandraSession[F],
     synchronize: CassandraSync[F]
-  ): KeySchema[F] = new KeySchema[F] {
-    def create = synchronize("KeySchema") {
-      session
-        .execute(
-          """CREATE TABLE IF NOT EXISTS keys(
-          |application_id TEXT,
-          |group_id TEXT,
-          |segment BIGINT,
-          |topic TEXT,
-          |partition INT,
-          |key TEXT,
-          |created TIMESTAMP,
-          |created_date DATE,
-          |metadata TEXT,
-          |PRIMARY KEY((application_id, group_id, segment), topic, partition, key)
-          |)
-          |""".stripMargin
-        )
-        .first *>
-        session
-          .execute(
-            "CREATE INDEX IF NOT EXISTS keys_created_date_idx ON keys(created_date)"
-          )
-          .first
-          .void
-    }
-    def truncate = synchronize("KeySchema") {
-      session.execute("TRUNCATE keys").first.void
-    }
-  }
+  ): KeySchema[F] = of(session.unsafe, synchronize)
 
   def of[F[_]: Monad](
     session: scassandra.CassandraSession[F],
     synchronize: CassandraSync[F]
   ): KeySchema[F] = new KeySchema[F] {
-    def create = synchronize("KeySchema") {
+    def create: F[Unit] = synchronize("KeySchema") {
       session
         .execute(
           """CREATE TABLE IF NOT EXISTS keys(
@@ -76,7 +47,7 @@ private[key] object KeySchema {
           .void
     }
 
-    def truncate = synchronize("KeySchema") {
+    def truncate: F[Unit] = synchronize("KeySchema") {
       session.execute("TRUNCATE keys").void
     }
   }


### PR DESCRIPTION
1. Add `scassandra`-based API to `JournalSchema` to further drop `kafka-journal`-based one (https://github.com/evolution-gaming/kafka-flow/issues/592)
2. Add integration tests for `JournalSchema` validating both old and new versions work as expected
3. Improve `KeySchema` and `SnapshotSchema`: delegate to a `scassandra`-based implementation instead of having two identical ones