### PR TITLE
introduce own KeySegments instead of kafka-journal Segments

### DIFF
--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/CassandraPersistence.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/CassandraPersistence.scala
@@ -1,39 +1,42 @@
 package com.evolutiongaming.kafka.flow.cassandra
 
-import cats.Monad
-import cats.MonadThrow
 import cats.arrow.FunctionK
 import cats.effect.Clock
 import cats.syntax.all._
+import cats.{Monad, MonadThrow}
 import com.evolutiongaming.cassandra.sync.CassandraSync
 import com.evolutiongaming.kafka.flow.journal.CassandraJournals
-import com.evolutiongaming.kafka.flow.key.CassandraKeys
+import com.evolutiongaming.kafka.flow.key.{CassandraKeys, KeySegments}
 import com.evolutiongaming.kafka.flow.persistence.PersistenceModule
 import com.evolutiongaming.kafka.flow.snapshot.CassandraSnapshots
-import com.evolutiongaming.kafka.journal.{FromBytes, ToBytes}
 import com.evolutiongaming.kafka.journal.eventual.cassandra.{CassandraSession, Segments}
+import com.evolutiongaming.kafka.journal.{FromBytes, ToBytes}
 
 import scala.util.Try
 
 trait CassandraPersistence[F[_], S] extends PersistenceModule[F, S]
 object CassandraPersistence {
 
-  /** Creates schema in Cassandra if not there yet Uses a default number of Segments (10000) for keys table.
-    */
-  @deprecated("Use the alternative with an explicit passing of segments number", since = "0.6.6")
+  // TODO: deprecate and then remove this method in a major version update
+  // when other components are ready
   def withSchemaF[F[_]: MonadThrow: Clock, S](
     session: CassandraSession[F],
     sync: CassandraSync[F],
-    consistencyOverrides: ConsistencyOverrides = ConsistencyOverrides.none
-  )(implicit fromBytes: FromBytes[F, S], toBytes: ToBytes[F, S]): F[PersistenceModule[F, S]] =
-    withSchemaF(session, sync, consistencyOverrides, CassandraKeys.DefaultSegments)
+    consistencyOverrides: ConsistencyOverrides,
+    keysSegments: Segments
+  )(implicit fromBytes: FromBytes[F, S], toBytes: ToBytes[F, S]): F[PersistenceModule[F, S]] = withSchemaF(
+    session,
+    sync,
+    consistencyOverrides,
+    KeySegments.unsafe(keysSegments.value)
+  )
 
   /** Creates schema in Cassandra if not there yet. */
   def withSchemaF[F[_]: MonadThrow: Clock, S](
     session: CassandraSession[F],
     sync: CassandraSync[F],
     consistencyOverrides: ConsistencyOverrides,
-    keysSegments: Segments
+    keysSegments: KeySegments
   )(implicit fromBytes: FromBytes[F, S], toBytes: ToBytes[F, S]): F[PersistenceModule[F, S]] = for {
     _keys      <- CassandraKeys.withSchema(session, sync, consistencyOverrides, keysSegments)
     _journals  <- CassandraJournals.withSchema(session, sync, consistencyOverrides)
@@ -44,21 +47,19 @@ object CassandraPersistence {
     def snapshots = _snapshots
   }
 
-  /** Creates schema in Cassandra if not there yet
-    *
-    * This method uses the same `JsonCodec[Try]` as `JournalParser` does to simplify defining the basic application. if
-    * \@consistencyConfig is present then applies ConsistencyConfig.Read for all read queries and
-    * ConsistencyConfig.Write for all the mutations
-    *
-    * Uses a default number of Segments (10000) for keys table.
-    */
-  @deprecated("Use the alternative with an explicit passing of segments number", since = "0.6.6")
+  // TODO: deprecate and then remove this method in a major version update
+  // when other components are ready
   def withSchema[F[_]: MonadThrow: Clock, S](
     session: CassandraSession[F],
     sync: CassandraSync[F],
-    consistencyOverrides: ConsistencyOverrides = ConsistencyOverrides.none
-  )(implicit fromBytes: FromBytes[Try, S], toBytes: ToBytes[Try, S]): F[PersistenceModule[F, S]] =
-    withSchema(session, sync, consistencyOverrides, CassandraKeys.DefaultSegments)
+    consistencyOverrides: ConsistencyOverrides,
+    keysSegments: Segments
+  )(implicit fromBytes: FromBytes[Try, S], toBytes: ToBytes[Try, S]): F[PersistenceModule[F, S]] = withSchema(
+    session,
+    sync,
+    consistencyOverrides,
+    KeySegments.unsafe(keysSegments.value)
+  )
 
   /** Creates schema in Cassandra if not there yet
     *
@@ -70,7 +71,7 @@ object CassandraPersistence {
     session: CassandraSession[F],
     sync: CassandraSync[F],
     consistencyOverrides: ConsistencyOverrides,
-    keysSegments: Segments
+    keysSegments: KeySegments
   )(implicit fromBytes: FromBytes[Try, S], toBytes: ToBytes[Try, S]): F[PersistenceModule[F, S]] = {
     val fromTry             = FunctionK.liftFunction[Try, F](MonadThrow[F].fromTry)
     implicit val _fromBytes = fromBytes mapK fromTry

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/key/KeySegments.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/key/KeySegments.scala
@@ -1,0 +1,64 @@
+package com.evolutiongaming.kafka.flow.key
+
+import cats.Show
+import cats.kernel.{Eq, Order}
+import cats.syntax.all._
+
+/** The maximum number of segments in Cassandra table.
+  *
+  * When [[KeySegments]] is used then the segment column value is determined by consistent hashing of the key column.
+  * I.e. there always no more than [[KeySegments#value]] different values.
+  *
+  * The logic itself could be found in [[SegmentNr]] class constructors (apply methods).
+  *
+  * The only place where such approach is used right now is a metajournal specified by
+  * [[SchemaConfig#metaJournalTable]]. This allows the fair distribution of the journal keys between the Cassandra
+  * partitions.
+  *
+  * The value is not end-user configurable and, currently, set in [[EventualCassandra]].
+  *
+  * @see
+  *   [[SegmentSize]] for alternative way used for some other tables.
+  */
+sealed abstract case class KeySegments(value: Int) {
+
+  override def toString: String = value.toString
+}
+
+object KeySegments {
+
+  val min: KeySegments = new KeySegments(1) {}
+
+  val max: KeySegments = new KeySegments(Int.MaxValue) {}
+
+  val old: KeySegments = new KeySegments(100) {}
+
+  val default: KeySegments = new KeySegments(10000) {}
+
+  implicit val eqKeySegments: Eq[KeySegments] = Eq.fromUniversalEquals
+
+  implicit val showKeySegments: Show[KeySegments] = Show.fromToString
+
+  implicit val orderingKeySegments: Ordering[KeySegments] = Ordering.by(_.value)
+
+  implicit val orderKeySegments: Order[KeySegments] = Order.fromOrdering
+
+  def of(value: Int): Either[String, KeySegments] = {
+    if (value < min.value) {
+      Left(s"invalid KeySegments of $value, it must be greater or equal to $min")
+    } else if (value > max.value) {
+      Left(s"invalid KeySegments of $value, it must be less or equal to $max")
+    } else if (value === min.value) {
+      Right(min)
+    } else if (value === max.value) {
+      Right(max)
+    } else {
+      Right(new KeySegments(value) {})
+    }
+  }
+
+  def opt(value: Int): Option[KeySegments] = of(value).toOption
+
+  def unsafe[A](value: A)(implicit numeric: Numeric[A]): KeySegments =
+    of(numeric.toInt(value)).fold(err => throw new RuntimeException(err), identity)
+}

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/key/KeySegments.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/key/KeySegments.scala
@@ -4,21 +4,13 @@ import cats.Show
 import cats.kernel.{Eq, Order}
 import cats.syntax.all._
 
-/** The maximum number of segments in Cassandra table.
+/** A maximum number of segments in Cassandra table.
   *
-  * When [[KeySegments]] is used then the segment column value is determined by consistent hashing of the key column.
+  * When [[KeySegments]] is used, the value of 'segment' column is determined by consistent hashing of the key column.
   * I.e. there always no more than [[KeySegments#value]] different values.
   *
-  * The logic itself could be found in [[SegmentNr]] class constructors (apply methods).
-  *
-  * The only place where such approach is used right now is a metajournal specified by
-  * [[SchemaConfig#metaJournalTable]]. This allows the fair distribution of the journal keys between the Cassandra
-  * partitions.
-  *
-  * The value is not end-user configurable and, currently, set in [[EventualCassandra]].
-  *
-  * @see
-  *   [[SegmentSize]] for alternative way used for some other tables.
+  * The only place where such approach is used right now is [[com.evolutiongaming.kafka.flow.key.CassandraKeys]]. This
+  * allows fair distribution of 'key' records between the Cassandra partitions.
   */
 sealed abstract case class KeySegments(value: Int) {
 
@@ -30,8 +22,6 @@ object KeySegments {
   val min: KeySegments = new KeySegments(1) {}
 
   val max: KeySegments = new KeySegments(Int.MaxValue) {}
-
-  val old: KeySegments = new KeySegments(100) {}
 
   val default: KeySegments = new KeySegments(10000) {}
 


### PR DESCRIPTION
This is a step towards https://github.com/evolution-gaming/kafka-flow/issues/592. 

- remove methods that were marked for removal since long ago
- introduce our own version of `KeySegment` instead of `Segment` from `kafka-journal` and a corresponding set of methods
- make current methods delegate to the new ones

Current methods aren't deprecated yet because there's no alternative of `CassandraKeys`, `CassandraSnapshots`, `CassandraJournals`, `CassandraPersistence` that would use `CassandraSession` from `scassandra` instead of `kafka-journal` one. I plan to gradually introduce these and mark the old implementations as deprecated once all new ones are done. Until then, I will only introduce new APIs and change the old ones to delegate to them.

Next step is introducing our own `SegmentNr`