### PR TITLE
update CassandraKeys, CassandraSnapshots, CassandraJournals, CassandraPersistence to use scassandra APIs

### DIFF
--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/journal/JournalParser.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/journal/JournalParser.scala
@@ -45,7 +45,7 @@ object JournalParser {
     implicit val parsePayload: KafkaRead[F, Payload] = KafkaRead.payloadKafkaRead[F]
 
     def toAppend(record: ConsumerRecord[String, ByteVector]) = {
-      parseAction(record).value map { record =>
+      parseAction(record).map { record =>
         for {
           record <- record
           append <- record.action match {

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/registry/EntityRegistryTest.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/registry/EntityRegistryTest.scala
@@ -1,7 +1,6 @@
 package com.evolutiongaming.kafka.flow.registry
 
 import cats.effect.IO
-import cats.effect.syntax.resource._
 import cats.effect.unsafe.implicits.global
 import com.evolutiongaming.catshelper.{Log, LogOf}
 import com.evolutiongaming.kafka.flow._

--- a/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/FlowSpec.scala
+++ b/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/FlowSpec.scala
@@ -25,7 +25,12 @@ class FlowSpec extends CassandraSpec {
       session    = CassandraSessionStub.injectFailures(cassandra().session, failAfter)
       storage <- Resource.eval(
         CassandraPersistence
-          .withSchema[IO, String](session, cassandra().sync, ConsistencyOverrides.none, CassandraKeys.DefaultSegments)
+          .withSchema[IO, String](
+            session.unsafe,
+            cassandra().sync,
+            ConsistencyOverrides.none,
+            CassandraKeys.DefaultSegments
+          )
       )
       timersOf      <- Resource.eval(TimersOf.memory[IO, KafkaKey])
       keysOf        <- Resource.eval(storage.keys.keysOf)

--- a/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/journal/JournalSpec.scala
+++ b/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/journal/JournalSpec.scala
@@ -11,7 +11,7 @@ class JournalSpec extends CassandraSpec {
   test("queries") {
     val key = KafkaKey("JournalSpec", "integration-tests-1", TopicPartition.empty, "queries")
     val test: IO[Unit] = for {
-      journals <- CassandraJournals.withSchema(cassandra().session, cassandra().sync)
+      journals <- CassandraJournals.withSchema(cassandra().session.unsafe, cassandra().sync)
       contents <- IO.fromEither(ByteVector.encodeUtf8("record-contents"))
       record = ConsumerRecord[String, ByteVector](
         topicPartition   = TopicPartition.empty,
@@ -39,7 +39,7 @@ class JournalSpec extends CassandraSpec {
     val test: IO[Unit] = for {
       failAfter <- Ref.of[IO, Int](100)
       session    = CassandraSessionStub.injectFailures(cassandra().session, failAfter)
-      journals  <- CassandraJournals.withSchema(session, cassandra().sync)
+      journals  <- CassandraJournals.withSchema(session.unsafe, cassandra().sync)
       _         <- failAfter.set(1)
       records   <- journals.get(key).toList.attempt
       _          = assert(clue(records.isLeft))

--- a/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/key/KeySpec.scala
+++ b/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/key/KeySpec.scala
@@ -20,7 +20,7 @@ class KeySpec extends CassandraSpec {
     val key3       = KafkaKey("KeySpec", "integration-tests-1", partition2, "queries.key3")
     val test: IO[Unit] = for {
       keys <- CassandraKeys.withSchema(
-        cassandra().session,
+        cassandra().session.unsafe,
         cassandra().sync,
         ConsistencyOverrides.none,
         CassandraKeys.DefaultSegments
@@ -50,7 +50,7 @@ class KeySpec extends CassandraSpec {
       failAfter <- Ref.of[IO, Int](100)
       session    = CassandraSessionStub.injectFailures(cassandra().session, failAfter)
       keys <- CassandraKeys.withSchema(
-        session,
+        session.unsafe,
         cassandra().sync,
         ConsistencyOverrides.none,
         CassandraKeys.DefaultSegments

--- a/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotSpec.scala
+++ b/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotSpec.scala
@@ -10,7 +10,7 @@ class SnapshotSpec extends CassandraSpec {
     val key      = KafkaKey("SnapshotSpec", "integration-tests-1", TopicPartition.empty, "queries")
     val snapshot = KafkaSnapshot(offset = Offset.min, value = "snapshot-contents")
     val test: IO[Unit] = for {
-      snapshots            <- CassandraSnapshots.withSchema[IO, String](cassandra().session, cassandra().sync)
+      snapshots            <- CassandraSnapshots.withSchema[IO, String](cassandra().session.unsafe, cassandra().sync)
       snapshotBeforeTest   <- snapshots.get(key)
       _                    <- snapshots.persist(key, snapshot)
       snapshotAfterPersist <- snapshots.get(key)
@@ -30,7 +30,7 @@ class SnapshotSpec extends CassandraSpec {
     val test: IO[Unit] = for {
       failAfter <- Ref.of[IO, Int](100)
       session    = CassandraSessionStub.injectFailures(cassandra().session, failAfter)
-      snapshots <- CassandraSnapshots.withSchema[IO, String](session, cassandra().sync)
+      snapshots <- CassandraSnapshots.withSchema[IO, String](session.unsafe, cassandra().sync)
       _         <- failAfter.set(1)
       snapshots <- snapshots.get(key).attempt
     } yield assert(clue(snapshots.isLeft))

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/CassandraCodecs.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/CassandraCodecs.scala
@@ -1,6 +1,6 @@
 package com.evolutiongaming.kafka.flow.cassandra
 
-import com.datastax.driver.core.SettableData
+import com.datastax.driver.core.{GettableByNameData, SettableData}
 import com.evolutiongaming.scassandra.{DecodeByName, EncodeByName}
 import com.evolutiongaming.skafka.{Offset, Partition, TimestampType}
 import scodec.bits.ByteVector
@@ -39,6 +39,22 @@ private[flow] object CassandraCodecs {
       def apply[B <: SettableData[B]](data: B, name: String, values: List[String]) = {
         data.setList(name, values.asJava, classOf[String])
       }
+    }
+  }
+
+  implicit val mapTextEncodeByName: EncodeByName[Map[String, String]] = {
+    val text = classOf[String]
+    new EncodeByName[Map[String, String]] {
+      def apply[B <: SettableData[B]](data: B, name: String, value: Map[String, String]) = {
+        data.setMap(name, value.asJava, text, text)
+      }
+    }
+  }
+
+  implicit val mapTextDecodeByName: DecodeByName[Map[String, String]] = {
+    val text = classOf[String]
+    (data: GettableByNameData, name: String) => {
+      data.getMap(name, text, text).asScala.toMap
     }
   }
 

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/CassandraHealthCheckOf.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/CassandraHealthCheckOf.scala
@@ -3,11 +3,9 @@ package com.evolutiongaming.kafka.flow.cassandra
 import cats.Parallel
 import cats.effect.{Async, Resource}
 import com.evolutiongaming.catshelper.LogOf
-import com.evolutiongaming.kafka.journal.eventual.cassandra.EventualCassandraConfig.ConsistencyConfig
-import com.evolutiongaming.kafka.journal.eventual.cassandra.{
-  CassandraHealthCheck,
-  CassandraSession => CassandraSession2
-}
+import com.evolutiongaming.kafka.journal.eventual.cassandra.{CassandraSession => CassandraSession2}
+import com.evolutiongaming.kafka.journal.cassandra.CassandraHealthCheck
+import com.evolutiongaming.kafka.journal.cassandra.CassandraConsistencyConfig
 import com.evolutiongaming.scassandra.CassandraSession
 import com.evolutiongaming.scassandra.util.FromGFuture
 
@@ -22,7 +20,7 @@ private[cassandra] object CassandraHealthCheckOf {
       cassandraSession2 = CassandraSession2[F](cassandraSession, config.retries)
       cassandraHealthCheck <- CassandraHealthCheck.of(
         Resource.pure[F, CassandraSession2[F]](cassandraSession2),
-        ConsistencyConfig.default.read
+        CassandraConsistencyConfig.default.read
       )
     } yield {
       cassandraHealthCheck

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/CassandraModule.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/CassandraModule.scala
@@ -6,7 +6,8 @@ import cats.syntax.all._
 import com.evolutiongaming.cassandra.sync.{AutoCreate, CassandraSync}
 import com.evolutiongaming.catshelper.{Log, LogOf}
 import com.evolutiongaming.kafka.flow.LogResource
-import com.evolutiongaming.kafka.journal.eventual.cassandra.{CassandraHealthCheck, CassandraSession => SafeSession}
+import com.evolutiongaming.kafka.journal.eventual.cassandra.{CassandraSession => SafeSession}
+import com.evolutiongaming.kafka.journal.cassandra.CassandraHealthCheck
 import com.evolutiongaming.scassandra.CassandraClusterOf
 import com.evolutiongaming.scassandra.util.FromGFuture
 import com.google.common.util.concurrent.ListenableFuture

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/CassandraPersistence.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/CassandraPersistence.scala
@@ -1,43 +1,44 @@
 package com.evolutiongaming.kafka.flow.cassandra
 
 import cats.arrow.FunctionK
-import cats.effect.Clock
+import cats.effect.Async
 import cats.syntax.all._
 import cats.{Monad, MonadThrow}
 import com.evolutiongaming.cassandra.sync.CassandraSync
 import com.evolutiongaming.kafka.flow.journal.CassandraJournals
 import com.evolutiongaming.kafka.flow.key.{CassandraKeys, KeySegments}
+import com.evolutiongaming.kafka.flow.migration.migration._
 import com.evolutiongaming.kafka.flow.persistence.PersistenceModule
 import com.evolutiongaming.kafka.flow.snapshot.CassandraSnapshots
 import com.evolutiongaming.kafka.journal.eventual.cassandra.{CassandraSession, Segments}
 import com.evolutiongaming.kafka.journal.{FromBytes, ToBytes}
+import com.evolutiongaming.{scassandra, skafka}
 
 import scala.util.Try
 
 trait CassandraPersistence[F[_], S] extends PersistenceModule[F, S]
 object CassandraPersistence {
 
-  // TODO: deprecate and then remove this method in a major version update
-  // when other components are ready
-  def withSchemaF[F[_]: MonadThrow: Clock, S](
+  @deprecated("Use the alternative taking `scassandra.CassandraSession`", "4.3.0")
+  def withSchemaF[F[_]: Async, S](
     session: CassandraSession[F],
     sync: CassandraSync[F],
     consistencyOverrides: ConsistencyOverrides,
     keysSegments: Segments
   )(implicit fromBytes: FromBytes[F, S], toBytes: ToBytes[F, S]): F[PersistenceModule[F, S]] = withSchemaF(
-    session,
+    session.unsafe,
     sync,
     consistencyOverrides,
     KeySegments.unsafe(keysSegments.value)
-  )
+  )(Async[F], journalFromBytesToSkafka(fromBytes), journalToBytesToSkafka(toBytes))
 
   /** Creates schema in Cassandra if not there yet. */
-  def withSchemaF[F[_]: MonadThrow: Clock, S](
-    session: CassandraSession[F],
+  def withSchemaF[F[_]: Async, S](
+    session: scassandra.CassandraSession[F],
     sync: CassandraSync[F],
     consistencyOverrides: ConsistencyOverrides,
     keysSegments: KeySegments
-  )(implicit fromBytes: FromBytes[F, S], toBytes: ToBytes[F, S]): F[PersistenceModule[F, S]] = for {
+  )(implicit fromBytes: skafka.FromBytes[F, S], toBytes: skafka.ToBytes[F, S]): F[PersistenceModule[F, S]] = for {
     _keys      <- CassandraKeys.withSchema(session, sync, consistencyOverrides, keysSegments)
     _journals  <- CassandraJournals.withSchema(session, sync, consistencyOverrides)
     _snapshots <- CassandraSnapshots.withSchema[F, S](session, sync, consistencyOverrides)
@@ -47,19 +48,18 @@ object CassandraPersistence {
     def snapshots = _snapshots
   }
 
-  // TODO: deprecate and then remove this method in a major version update
-  // when other components are ready
-  def withSchema[F[_]: MonadThrow: Clock, S](
+  @deprecated("Use the alternative taking `scassandra.CassandraSession`", "4.3.0")
+  def withSchema[F[_]: Async, S](
     session: CassandraSession[F],
     sync: CassandraSync[F],
     consistencyOverrides: ConsistencyOverrides,
     keysSegments: Segments
   )(implicit fromBytes: FromBytes[Try, S], toBytes: ToBytes[Try, S]): F[PersistenceModule[F, S]] = withSchema(
-    session,
+    session.unsafe,
     sync,
     consistencyOverrides,
     KeySegments.unsafe(keysSegments.value)
-  )
+  )(Async[F], journalFromBytesToSkafka(fromBytes), journalToBytesToSkafka(toBytes))
 
   /** Creates schema in Cassandra if not there yet
     *
@@ -67,12 +67,12 @@ object CassandraPersistence {
     * \@consistencyConfig is present then applies ConsistencyConfig.Read for all read queries and
     * ConsistencyConfig.Write for all the mutations
     */
-  def withSchema[F[_]: MonadThrow: Clock, S](
-    session: CassandraSession[F],
+  def withSchema[F[_]: Async, S](
+    session: scassandra.CassandraSession[F],
     sync: CassandraSync[F],
     consistencyOverrides: ConsistencyOverrides,
     keysSegments: KeySegments
-  )(implicit fromBytes: FromBytes[Try, S], toBytes: ToBytes[Try, S]): F[PersistenceModule[F, S]] = {
+  )(implicit fromBytes: skafka.FromBytes[Try, S], toBytes: skafka.ToBytes[Try, S]): F[PersistenceModule[F, S]] = {
     val fromTry             = FunctionK.liftFunction[Try, F](MonadThrow[F].fromTry)
     implicit val _fromBytes = fromBytes mapK fromTry
     implicit val _toBytes   = toBytes mapK fromTry
@@ -80,12 +80,19 @@ object CassandraPersistence {
   }
 
   /** Deletes all data in Cassandra */
+  @deprecated("Use the alternative taking `scassandra.CassandraSession`", "4.3.0")
   def truncate[F[_]: Monad](
     session: CassandraSession[F],
+    sync: CassandraSync[F]
+  ): F[Unit] =
+    truncate(session.unsafe, sync)
+
+  /** Deletes all data in Cassandra */
+  def truncate[F[_]: Monad](
+    session: scassandra.CassandraSession[F],
     sync: CassandraSync[F]
   ): F[Unit] =
     CassandraKeys.truncate(session, sync) *>
       CassandraJournals.truncate(session, sync) *>
       CassandraSnapshots.truncate(session, sync)
-
 }

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/SessionHelper.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/SessionHelper.scala
@@ -1,0 +1,83 @@
+package com.evolutiongaming.kafka.flow.cassandra
+
+import cats.MonadThrow
+import cats.effect.{Concurrent, Resource}
+import cats.Parallel
+import cats.syntax.all._
+import com.datastax.driver.core.{PreparedStatement, RegularStatement, ResultSet, Statement}
+import com.evolutiongaming.scassandra.CassandraSession
+import com.evolutiongaming.catshelper.Runtime
+import com.evolution.scache.Cache
+import com.datastax.driver.core.policies.LoggingRetryPolicy
+import com.evolutiongaming.scassandra.NextHostRetryPolicy
+
+object SessionHelper {
+  implicit final class SessionOps[F[_]](val self: CassandraSession[F]) extends AnyVal {
+    def enhanceError(implicit F: MonadThrow[F]): CassandraSession[F] = {
+
+      def error[A](msg: String, cause: Throwable) = {
+        new RuntimeException(s"CassandraSession.$msg failed with $cause", cause).raiseError[F, A]
+      }
+
+      new Delegate(self) {
+        override def execute(query: String): F[ResultSet] =
+          self.execute(query).handleErrorWith(error(s"execute query: $query", _))
+        override def execute(query: String, values: Any*): F[ResultSet] =
+          self.execute(query, values: _*).handleErrorWith(error(s"execute query: $query", _))
+        override def execute(query: String, values: Map[String, AnyRef]): F[ResultSet] =
+          self.execute(query, values).handleErrorWith(error(s"execute query: $query", _))
+        override def execute(statement: Statement): F[ResultSet] =
+          self.execute(statement).handleErrorWith(error(s"execute statement: $statement", _))
+        override def prepare(query: String): F[PreparedStatement] =
+          self.prepare(query).handleErrorWith(error(s"prepare query: $query", _))
+        override def prepare(statement: RegularStatement): F[PreparedStatement] =
+          self.prepare(statement).handleErrorWith(error(s"prepare statement: $statement", _))
+      }
+    }
+
+    def cachePrepared(
+      implicit F: Concurrent[F],
+      parallel: Parallel[F],
+      runtime: Runtime[F]
+    ): Resource[F, CassandraSession[F]] = {
+      for {
+        cache <- Cache.loading[F, String, PreparedStatement]
+      } yield new Delegate(self) {
+        override def prepare(query: String): F[PreparedStatement] =
+          cache.getOrUpdate(query)(self.prepare(query))
+      }
+
+    }
+
+    def withRetries(retries: Int, trace: Boolean = false): CassandraSession[F] = {
+      import com.evolutiongaming.scassandra.syntax._
+      val retryPolicy = new LoggingRetryPolicy(NextHostRetryPolicy(retries))
+
+      new Delegate[F](self) {
+        override def execute(statement: Statement): F[ResultSet] = {
+          val configured = statement
+            .setRetryPolicy(retryPolicy)
+            .setIdempotent(true)
+            .trace(trace)
+          self.execute(configured)
+        }
+      }
+    }
+  }
+
+  // A delegate class allowing to override only specific methods of the original session
+  private class Delegate[F[_]](self: CassandraSession[F]) extends CassandraSession[F] {
+    override def loggedKeyspace: F[Option[String]] = self.loggedKeyspace
+    override def init: F[Unit]                     = self.init
+    override def execute(query: String): F[ResultSet] =
+      self.execute(query)
+    override def execute(query: String, values: Any*): F[ResultSet] =
+      self.execute(query, values: _*)
+    override def execute(query: String, values: Map[String, AnyRef]): F[ResultSet] =
+      self.execute(query, values)
+    override def execute(statement: Statement): F[ResultSet]                = self.execute(statement)
+    override def prepare(query: String): F[PreparedStatement]               = self.prepare(query)
+    override def prepare(statement: RegularStatement): F[PreparedStatement] = self.prepare(statement)
+    override def state: CassandraSession.State[F]                           = self.state
+  }
+}

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/migration/migration.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/migration/migration.scala
@@ -1,0 +1,21 @@
+package com.evolutiongaming.kafka.flow.migration
+
+import com.evolutiongaming.kafka.journal.FromBytes
+import com.evolutiongaming.skafka
+import scodec.bits.ByteVector
+import cats.Applicative
+import cats.syntax.all._
+
+// This is a temporary object to help with migration from kafka-journal APIs
+private[flow] object migration {
+  def journalFromBytesToSkafka[F[_], T](fb: FromBytes[F, T]): skafka.FromBytes[F, T] = {
+    (a: Array[Byte], _: skafka.Topic) =>
+      fb.apply(ByteVector.view(a))
+  }
+
+  def journalToBytesToSkafka[F[_]: Applicative, T](
+    tb: com.evolutiongaming.kafka.journal.ToBytes[F, T]
+  ): skafka.ToBytes[F, T] = { (a: T, _: skafka.Topic) =>
+    tb.apply(a).map(_.toArray)
+  }
+}

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/CassandraSnapshots.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/CassandraSnapshots.scala
@@ -1,50 +1,58 @@
 package com.evolutiongaming.kafka.flow.snapshot
 
-import cats.{Monad, MonadThrow}
-import cats.effect.Clock
+import cats.Monad
+import cats.effect.{Async, Clock}
 import cats.syntax.all._
 import com.datastax.driver.core.{BoundStatement, Row}
 import com.evolutiongaming.cassandra.sync.CassandraSync
 import com.evolutiongaming.catshelper.ClockHelper._
 import com.evolutiongaming.kafka.flow.KafkaKey
 import com.evolutiongaming.kafka.flow.cassandra.CassandraCodecs._
-import com.evolutiongaming.kafka.journal.FromBytes
-import com.evolutiongaming.kafka.journal.FromBytes.implicits._
-import com.evolutiongaming.kafka.journal.ToBytes
-import com.evolutiongaming.kafka.journal.ToBytes.implicits._
-import com.evolutiongaming.kafka.journal.eventual.cassandra.CassandraSession
-import com.evolutiongaming.scassandra.syntax._
-import com.evolutiongaming.skafka.Offset
-import CassandraSnapshots._
 import com.evolutiongaming.kafka.flow.cassandra.ConsistencyOverrides
 import com.evolutiongaming.kafka.flow.cassandra.StatementHelper.StatementOps
+import com.evolutiongaming.kafka.flow.migration.migration._
+import com.evolutiongaming.kafka.journal.eventual.cassandra.CassandraSession
+import com.evolutiongaming.kafka.journal.{FromBytes, ToBytes}
+import com.evolutiongaming.scassandra.StreamingCassandraSession._
+import com.evolutiongaming.scassandra.syntax._
+import com.evolutiongaming.skafka.Offset
+import com.evolutiongaming.{scassandra, skafka}
 import scodec.bits.ByteVector
 
-class CassandraSnapshots[F[_]: MonadThrow: Clock, T](
-  session: CassandraSession[F],
+import CassandraSnapshots._
+
+class CassandraSnapshots[F[_]: Async, T](
+  session: scassandra.CassandraSession[F],
   consistencyOverrides: ConsistencyOverrides = ConsistencyOverrides.none
-)(implicit fromBytes: FromBytes[F, T], toBytes: ToBytes[F, T])
+)(implicit fromBytes: skafka.FromBytes[F, T], toBytes: skafka.ToBytes[F, T])
     extends SnapshotDatabase[F, KafkaKey, KafkaSnapshot[T]] {
+
+  @deprecated("Use the primary constructor instead", "4.3.0")
+  def this(session: CassandraSession[F], consistencyOverrides: ConsistencyOverrides)(
+    implicit fb: FromBytes[F, T],
+    tb: ToBytes[F, T]
+  ) =
+    this(session.unsafe, consistencyOverrides)(Async[F], journalFromBytesToSkafka(fb), journalToBytesToSkafka(tb))
 
   def persist(key: KafkaKey, snapshot: KafkaSnapshot[T]): F[Unit] =
     for {
       boundStatement <- Statements.persist(session, key, snapshot)
       statement       = boundStatement.withConsistencyLevel(consistencyOverrides.write)
-      _              <- session.execute(statement).first.void
+      _              <- session.execute(statement).void
     } yield ()
 
   def get(key: KafkaKey): F[Option[KafkaSnapshot[T]]] =
     for {
       boundStatement <- Statements.get(session, key)
       statement       = boundStatement.withConsistencyLevel(consistencyOverrides.read)
-      row            <- session.execute(statement).first
+      row            <- session.executeStream(statement).first
       snapshot       <- row.map(row => decode(row)).sequence
     } yield snapshot
 
   def delete(key: KafkaKey): F[Unit] = for {
     boundStatement <- Statements.delete(session, key)
     statement       = boundStatement.withConsistencyLevel(consistencyOverrides.write)
-    _              <- session.execute(statement).first.void
+    _              <- session.execute(statement).void
   } yield ()
 
 }
@@ -52,22 +60,50 @@ class CassandraSnapshots[F[_]: MonadThrow: Clock, T](
 object CassandraSnapshots {
 
   /** Creates schema in Cassandra if not there yet */
-  def withSchema[F[_]: MonadThrow: Clock, T](
+  @deprecated("Use an alternative taking `scassandra.CassandraSession`", "4.3.0")
+  def withSchema[F[_]: Async, T](
     session: CassandraSession[F],
     sync: CassandraSync[F],
     consistencyOverrides: ConsistencyOverrides = ConsistencyOverrides.none
   )(implicit fromBytes: FromBytes[F, T], toBytes: ToBytes[F, T]): F[SnapshotDatabase[F, KafkaKey, KafkaSnapshot[T]]] =
     SnapshotSchema(session, sync).create as new CassandraSnapshots(session, consistencyOverrides)
 
+  /** Creates schema in Cassandra if not there yet */
+  def withSchema[F[_]: Async, T](
+    session: scassandra.CassandraSession[F],
+    sync: CassandraSync[F],
+    consistencyOverrides: ConsistencyOverrides
+  )(
+    implicit fromBytes: skafka.FromBytes[F, T],
+    toBytes: skafka.ToBytes[F, T]
+  ): F[SnapshotDatabase[F, KafkaKey, KafkaSnapshot[T]]] =
+    SnapshotSchema.of(session, sync).create as new CassandraSnapshots(session, consistencyOverrides)
+
+  /** Creates schema in Cassandra if not there yet */
+  def withSchema[F[_]: Async, T](
+    session: scassandra.CassandraSession[F],
+    sync: CassandraSync[F],
+  )(
+    implicit fromBytes: skafka.FromBytes[F, T],
+    toBytes: skafka.ToBytes[F, T]
+  ): F[SnapshotDatabase[F, KafkaKey, KafkaSnapshot[T]]] =
+    withSchema(session, sync, ConsistencyOverrides.none)
+
+  @deprecated("Use an alternative taking `scassandra.CassandraSession`", "4.3.0")
   def truncate[F[_]: Monad](
     session: CassandraSession[F],
     sync: CassandraSync[F]
-  ): F[Unit] = SnapshotSchema(session, sync).truncate
+  ): F[Unit] = truncate(session.unsafe, sync)
+
+  def truncate[F[_]: Monad](
+    session: scassandra.CassandraSession[F],
+    sync: CassandraSync[F]
+  ): F[Unit] = SnapshotSchema.of(session, sync).truncate
 
   // we cannot use DecodeRow here because Code[T].decode is effectful
-  protected def decode[F[_]: Monad, T](row: Row)(implicit fromBytes: FromBytes[F, T]): F[KafkaSnapshot[T]] = {
+  protected def decode[F[_]: Monad, T](row: Row)(implicit fromBytes: skafka.FromBytes[F, T]): F[KafkaSnapshot[T]] = {
     val value = row.decode[ByteVector]("value")
-    value.fromBytes.map { value =>
+    fromBytes.apply(value.toArray, "").map { value =>
       KafkaSnapshot[T](
         offset   = row.decode[Offset]("offset"),
         metadata = row.decode[String]("metadata"),
@@ -78,10 +114,10 @@ object CassandraSnapshots {
 
   protected object Statements {
     def persist[F[_]: Clock: Monad, T](
-      session: CassandraSession[F],
+      session: scassandra.CassandraSession[F],
       key: KafkaKey,
       snapshot: KafkaSnapshot[T]
-    )(implicit toBytes: ToBytes[F, T]): F[BoundStatement] =
+    )(implicit toBytes: skafka.ToBytes[F, T]): F[BoundStatement] =
       for {
         preparedStatement <- session.prepare(
           """ UPDATE
@@ -100,7 +136,7 @@ object CassandraSnapshots {
         """.stripMargin
         )
         created <- Clock[F].instant
-        value   <- snapshot.value.toBytes
+        value   <- toBytes.apply(snapshot.value, key.topicPartition.topic)
       } yield {
         preparedStatement
           .bind()
@@ -115,7 +151,7 @@ object CassandraSnapshots {
           .encode("value", value)
       }
 
-    def get[F[_]: Monad](session: CassandraSession[F], key: KafkaKey): F[BoundStatement] =
+    def get[F[_]: Monad](session: scassandra.CassandraSession[F], key: KafkaKey): F[BoundStatement] =
       session
         .prepare(
           """ SELECT
@@ -141,7 +177,7 @@ object CassandraSnapshots {
             .encode("key", key.key)
         )
 
-    def delete[F[_]: Monad](session: CassandraSession[F], key: KafkaKey): F[BoundStatement] =
+    def delete[F[_]: Monad](session: scassandra.CassandraSession[F], key: KafkaKey): F[BoundStatement] =
       session
         .prepare(
           """ DELETE FROM

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,7 +19,7 @@ object Dependencies {
   }
 
   object KafkaJournal {
-    private val version = "3.2.4"
+    private val version = "3.3.9"
     val journal         = "com.evolutiongaming" %% "kafka-journal"                    % version
     val cassandra       = "com.evolutiongaming" %% "kafka-journal-eventual-cassandra" % version
     val persistence     = "com.evolutiongaming" %% "kafka-journal-persistence"        % version


### PR DESCRIPTION
Changes:
1. `kafka-journal` updated to the latest
2. update `CassandraKeys`, `CassandraSnapshots`, `CassandraJournals` and `CassandraPersistence` to use `scassandra` APIs, mark old methods as deprecated
3. introduce some extension methods for `CassandraSession` (copied from `kafka-journal`) that will facilitate further migration of healthcheck-related pieces of code

**note**: this breaks binary compatibility of the aforementioned classes unfortunately as they now have to require `Async` instead of a bunch of other traits (tagless final is cool innit). hopefully no one will notice as it's unlikely to be embedded somewhere