### PR TITLE
introduce new CassandraModule

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -89,6 +89,7 @@ lazy val `persistence-cassandra` = (project in file("persistence-cassandra"))
     name := "kafka-flow-persistence-cassandra",
     libraryDependencies ++= Seq(
       KafkaJournal.cassandra,
+      scassandra,
     ),
   )
 

--- a/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/CassandraSessionStub.scala
+++ b/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/CassandraSessionStub.scala
@@ -4,41 +4,14 @@ import cats.MonadThrow
 import cats.effect.Ref
 import cats.syntax.all._
 import com.datastax.driver.core.{Host, PreparedStatement, RegularStatement, ResultSet, Statement}
-import com.evolutiongaming.kafka.journal.eventual.cassandra.CassandraSession
-import com.evolutiongaming.scassandra
-import com.evolutiongaming.sstream.Stream
+import com.evolutiongaming.scassandra.CassandraSession
 
 object CassandraSessionStub {
-
-  def alwaysFails[F[_]](implicit F: MonadThrow[F]): CassandraSession[F] = new CassandraSession[F] {
-    def fail[T]: F[T] = F.raiseError {
-      new RuntimeException("CassandraSessionStub: always fails")
-    }
-    def prepare(query: String)        = fail
-    def execute(statement: Statement) = Stream.lift(fail)
-    def unsafe = new scassandra.CassandraSession[F] {
-      override def loggedKeyspace: F[Option[String]]                                 = F.pure(None)
-      override def init: F[Unit]                                                     = F.unit
-      override def execute(query: String): F[ResultSet]                              = fail
-      override def execute(query: String, values: Any*): F[ResultSet]                = fail
-      override def execute(query: String, values: Map[String, AnyRef]): F[ResultSet] = fail
-      override def execute(statement: Statement): F[ResultSet]                       = fail
-      override def prepare(query: String): F[PreparedStatement]                      = fail
-      override def prepare(statement: RegularStatement): F[PreparedStatement]        = fail
-      override def state: scassandra.CassandraSession.State[F] = new scassandra.CassandraSession.State[F] {
-        override def connectedHosts: F[Iterable[Host]]      = F.pure(Iterable.empty)
-        override def openConnections(host: Host): F[Int]    = F.pure(0)
-        override def trashedConnections(host: Host): F[Int] = F.pure(0)
-        override def inFlightQueries(host: Host): F[Int]    = F.pure(0)
-      }
-    }
-  }
 
   def injectFailures[F[_]](
     session: CassandraSession[F],
     failAfter: Ref[F, Int]
   )(implicit F: MonadThrow[F]): CassandraSession[F] = new CassandraSession[F] {
-
     def fail[T](query: String): F[T] = F.raiseError {
       new RuntimeException(s"CassandraSessionStub: failing after proper calls exhausted: $query")
     }
@@ -47,39 +20,30 @@ object CassandraSessionStub {
       (failAfter - 1, failAfter <= 0)
     }
 
-    def prepare(query: String) = failed.ifM(fail(query), session.prepare(query))
+    override def loggedKeyspace: F[Option[String]]    = F.pure(None)
+    override def init: F[Unit]                        = F.unit
+    override def execute(query: String): F[ResultSet] = failed.ifM(fail(query), session.execute(query))
 
-    def execute(statement: Statement) = Stream.lift(failed) flatMap { failed =>
-      if (failed) Stream.lift(fail(statement.toString)) else session.execute(statement)
-    }
+    override def execute(query: String, values: Any*): F[ResultSet] =
+      failed.ifM(fail(query), session.execute(query, values: _*))
 
-    def unsafe = new scassandra.CassandraSession[F] {
-      override def loggedKeyspace: F[Option[String]]    = F.pure(None)
-      override def init: F[Unit]                        = F.unit
-      override def execute(query: String): F[ResultSet] = failed.ifM(fail(query), session.unsafe.execute(query))
+    override def execute(query: String, values: Map[String, AnyRef]): F[ResultSet] =
+      failed.ifM(fail(query), session.execute(query, values))
 
-      override def execute(query: String, values: Any*): F[ResultSet] =
-        failed.ifM(fail(query), session.unsafe.execute(query, values: _*))
+    override def execute(statement: Statement): F[ResultSet] =
+      failed.ifM(fail(statement.toString), session.execute(statement))
 
-      override def execute(query: String, values: Map[String, AnyRef]): F[ResultSet] =
-        failed.ifM(fail(query), session.unsafe.execute(query, values))
+    override def prepare(query: String): F[PreparedStatement] =
+      failed.ifM(fail(query), session.prepare(query))
 
-      override def execute(statement: Statement): F[ResultSet] =
-        failed.ifM(fail(statement.toString), session.unsafe.execute(statement))
+    override def prepare(statement: RegularStatement): F[PreparedStatement] =
+      failed.ifM(fail(statement.toString), session.prepare(statement))
 
-      override def prepare(query: String): F[PreparedStatement] =
-        failed.ifM(fail(query), session.unsafe.prepare(query))
-
-      override def prepare(statement: RegularStatement): F[PreparedStatement] =
-        failed.ifM(fail(statement.toString), session.unsafe.prepare(statement))
-
-      override def state: scassandra.CassandraSession.State[F] = new scassandra.CassandraSession.State[F] {
-        override def connectedHosts: F[Iterable[Host]]      = F.pure(Iterable.empty)
-        override def openConnections(host: Host): F[Int]    = F.pure(0)
-        override def trashedConnections(host: Host): F[Int] = F.pure(0)
-        override def inFlightQueries(host: Host): F[Int]    = F.pure(0)
-      }
-
+    override def state: CassandraSession.State[F] = new CassandraSession.State[F] {
+      override def connectedHosts: F[Iterable[Host]]      = F.pure(Iterable.empty)
+      override def openConnections(host: Host): F[Int]    = F.pure(0)
+      override def trashedConnections(host: Host): F[Int] = F.pure(0)
+      override def inFlightQueries(host: Host): F[Int]    = F.pure(0)
     }
 
   }

--- a/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/CassandraSpec.scala
+++ b/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/CassandraSpec.scala
@@ -2,18 +2,21 @@ package com.evolutiongaming.kafka.flow
 
 import cats.effect.IO
 import cats.effect.unsafe.IORuntime
+import com.evolution.kafka.flow.cassandra.CassandraModule
 import com.evolutiongaming.catshelper.LogOf
-import com.evolutiongaming.kafka.flow.cassandra.{CassandraConfig, CassandraModule}
+import com.evolutiongaming.kafka.flow
+import com.evolutiongaming.kafka.flow.cassandra.CassandraConfig
 import com.evolutiongaming.nel.Nel
 import com.evolutiongaming.scassandra
 import munit.FunSuite
 
 import java.util.concurrent.atomic.AtomicReference
+import scala.annotation.nowarn
 
 abstract class CassandraSpec extends FunSuite {
   implicit val ioRuntime: IORuntime = IORuntime.global
 
-  override def munitFixtures: Seq[Fixture[_]] = List(cassandra)
+  override def munitFixtures: Seq[Fixture[_]] = List(cassandra, cassandraJournal)
 
   val cassandra: Fixture[CassandraModule[IO]] = new Fixture[CassandraModule[IO]]("CassandraModule") {
     private val moduleRef = new AtomicReference[(CassandraModule[IO], IO[Unit])]()
@@ -41,4 +44,35 @@ abstract class CassandraSpec extends FunSuite {
       Option(moduleRef.get()).foreach { case (_, finalizer) => finalizer.unsafeRunSync() }
     }
   }
+
+  @nowarn("msg=deprecated")
+  val cassandraJournal: Fixture[flow.cassandra.CassandraModule[IO]] =
+    new Fixture[flow.cassandra.CassandraModule[IO]]("CassandraModule") {
+      private val moduleRef = new AtomicReference[(flow.cassandra.CassandraModule[IO], IO[Unit])]()
+
+      override def apply(): flow.cassandra.CassandraModule[IO] = moduleRef.get()._1
+
+      override def beforeAll(): Unit = {
+        implicit val logOf = LogOf.slf4j[IO].unsafeRunSync()
+
+        val container = CassandraContainerResource.cassandra.cassandraContainer
+        val result: (flow.cassandra.CassandraModule[IO], IO[Unit]) =
+          flow
+            .cassandra
+            .CassandraModule
+            .of[IO](
+              CassandraConfig(client =
+                scassandra.CassandraConfig(contactPoints = Nel(container.getHost), port = container.getFirstMappedPort)
+              )
+            )
+            .allocated
+            .unsafeRunSync()
+
+        moduleRef.set(result)
+      }
+
+      override def afterAll(): Unit = {
+        Option(moduleRef.get()).foreach { case (_, finalizer) => finalizer.unsafeRunSync() }
+      }
+    }
 }

--- a/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/FlowSpec.scala
+++ b/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/FlowSpec.scala
@@ -26,7 +26,7 @@ class FlowSpec extends CassandraSpec {
       storage <- Resource.eval(
         CassandraPersistence
           .withSchema[IO, String](
-            session.unsafe,
+            session,
             cassandra().sync,
             ConsistencyOverrides.none,
             CassandraKeys.DefaultSegments

--- a/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/journal/JournalSchemaSpec.scala
+++ b/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/journal/JournalSchemaSpec.scala
@@ -1,15 +1,17 @@
 package com.evolutiongaming.kafka.flow.journal
 
-import com.evolutiongaming.kafka.flow.CassandraSpec
-import scala.concurrent.duration._
-import com.evolutiongaming.scassandra.CassandraSession
 import cats.effect.IO
+import com.evolutiongaming.kafka.flow.CassandraSpec
+import com.evolutiongaming.scassandra.CassandraSession
+
+import scala.annotation.nowarn
+import scala.concurrent.duration._
 
 class JournalSchemaSpec extends CassandraSpec {
   override def munitTimeout: Duration = 2.minutes
 
   test("table is created using scassandra session API") {
-    val session = cassandra().session.unsafe
+    val session = cassandra().session
     val sync    = cassandra().sync
     val schema  = JournalSchema.of(session, sync)
 
@@ -22,9 +24,10 @@ class JournalSchemaSpec extends CassandraSpec {
   }
 
   test("table is created using kafka-journal session API") {
-    val session = cassandra().session
-    val sync    = cassandra().sync
-    val schema  = JournalSchema.apply(session, sync)
+    val session = cassandraJournal().session
+    val sync    = cassandraJournal().sync
+    @nowarn("msg=deprecated")
+    val schema = JournalSchema.apply(session, sync)
 
     val test = for {
       _ <- schema.create
@@ -35,7 +38,7 @@ class JournalSchemaSpec extends CassandraSpec {
   }
 
   test("table is truncated using scassandra session API") {
-    val session = cassandra().session.unsafe
+    val session = cassandra().session
     val sync    = cassandra().sync
 
     val schema = JournalSchema.of(session, sync)
@@ -51,9 +54,10 @@ class JournalSchemaSpec extends CassandraSpec {
   }
 
   test("table is truncated using kafka-journal session API") {
-    val session = cassandra().session
-    val sync    = cassandra().sync
+    val session = cassandraJournal().session
+    val sync    = cassandraJournal().sync
 
+    @nowarn("msg=deprecated")
     val schema = JournalSchema.apply(session, sync)
 
     val test = for {
@@ -104,6 +108,6 @@ class JournalSchemaSpec extends CassandraSpec {
 
   override def afterEach(context: AfterEach): Unit = {
     super.afterEach(context)
-    cassandra().session.unsafe.execute("DROP TABLE IF EXISTS records").void.unsafeRunSync()
+    cassandra().session.execute("DROP TABLE IF EXISTS records").void.unsafeRunSync()
   }
 }

--- a/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/journal/JournalSpec.scala
+++ b/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/journal/JournalSpec.scala
@@ -11,7 +11,7 @@ class JournalSpec extends CassandraSpec {
   test("queries") {
     val key = KafkaKey("JournalSpec", "integration-tests-1", TopicPartition.empty, "queries")
     val test: IO[Unit] = for {
-      journals <- CassandraJournals.withSchema(cassandra().session.unsafe, cassandra().sync)
+      journals <- CassandraJournals.withSchema(cassandra().session, cassandra().sync)
       contents <- IO.fromEither(ByteVector.encodeUtf8("record-contents"))
       record = ConsumerRecord[String, ByteVector](
         topicPartition   = TopicPartition.empty,
@@ -39,7 +39,7 @@ class JournalSpec extends CassandraSpec {
     val test: IO[Unit] = for {
       failAfter <- Ref.of[IO, Int](100)
       session    = CassandraSessionStub.injectFailures(cassandra().session, failAfter)
-      journals  <- CassandraJournals.withSchema(session.unsafe, cassandra().sync)
+      journals  <- CassandraJournals.withSchema(session, cassandra().sync)
       _         <- failAfter.set(1)
       records   <- journals.get(key).toList.attempt
       _          = assert(clue(records.isLeft))

--- a/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/key/KeySchemaSpec.scala
+++ b/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/key/KeySchemaSpec.scala
@@ -4,13 +4,14 @@ import cats.effect.IO
 import com.evolutiongaming.kafka.flow.CassandraSpec
 import com.evolutiongaming.scassandra.CassandraSession
 
+import scala.annotation.nowarn
 import scala.concurrent.duration._
 
 class KeySchemaSpec extends CassandraSpec {
   override def munitTimeout = 2.minutes
 
   test("table is created using scassandra session API") {
-    val session = cassandra().session.unsafe
+    val session = cassandra().session
     val sync    = cassandra().sync
 
     val keySchema = KeySchema.of(session, sync)
@@ -24,9 +25,10 @@ class KeySchemaSpec extends CassandraSpec {
   }
 
   test("table is created using kafka-journal session API") {
-    val session = cassandra().session
-    val sync    = cassandra().sync
+    val session = cassandraJournal().session
+    val sync    = cassandraJournal().sync
 
+    @nowarn("msg=deprecated")
     val keySchema = KeySchema.apply(session, sync)
 
     val test = for {
@@ -38,7 +40,7 @@ class KeySchemaSpec extends CassandraSpec {
   }
 
   test("table is truncated using scassandra session API") {
-    val session = cassandra().session.unsafe
+    val session = cassandra().session
     val sync    = cassandra().sync
 
     val keySchema = KeySchema.of(session, sync)
@@ -54,9 +56,10 @@ class KeySchemaSpec extends CassandraSpec {
   }
 
   test("table is truncated using kafka-journal session API") {
-    val session = cassandra().session
-    val sync    = cassandra().sync
+    val session = cassandraJournal().session
+    val sync    = cassandraJournal().sync
 
+    @nowarn("msg=deprecated")
     val keySchema = KeySchema.apply(session, sync)
 
     val test = for {
@@ -103,6 +106,6 @@ class KeySchemaSpec extends CassandraSpec {
   }
 
   override def afterEach(context: AfterEach): Unit = {
-    cassandra().session.unsafe.execute("DROP TABLE IF EXISTS keys").void.unsafeRunSync()
+    cassandra().session.execute("DROP TABLE IF EXISTS keys").void.unsafeRunSync()
   }
 }

--- a/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/key/KeySpec.scala
+++ b/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/key/KeySpec.scala
@@ -20,7 +20,7 @@ class KeySpec extends CassandraSpec {
     val key3       = KafkaKey("KeySpec", "integration-tests-1", partition2, "queries.key3")
     val test: IO[Unit] = for {
       keys <- CassandraKeys.withSchema(
-        cassandra().session.unsafe,
+        cassandra().session,
         cassandra().sync,
         ConsistencyOverrides.none,
         CassandraKeys.DefaultSegments
@@ -50,7 +50,7 @@ class KeySpec extends CassandraSpec {
       failAfter <- Ref.of[IO, Int](100)
       session    = CassandraSessionStub.injectFailures(cassandra().session, failAfter)
       keys <- CassandraKeys.withSchema(
-        session.unsafe,
+        session,
         cassandra().sync,
         ConsistencyOverrides.none,
         CassandraKeys.DefaultSegments

--- a/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotSchemaSpec.scala
+++ b/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotSchemaSpec.scala
@@ -5,12 +5,13 @@ import com.evolutiongaming.kafka.flow.CassandraSpec
 import com.evolutiongaming.scassandra.CassandraSession
 
 import scala.concurrent.duration._
+import scala.annotation.nowarn
 
 class SnapshotSchemaSpec extends CassandraSpec {
   override def munitTimeout: Duration = 2.minutes
 
   test("table is created using scassandra session API") {
-    val session = cassandra().session.unsafe
+    val session = cassandra().session
     val sync    = cassandra().sync
     val schema  = SnapshotSchema.of(session, sync)
 
@@ -23,9 +24,10 @@ class SnapshotSchemaSpec extends CassandraSpec {
   }
 
   test("table is created using kafka-journal session API") {
-    val session = cassandra().session
-    val sync    = cassandra().sync
-    val schema  = SnapshotSchema.apply(session, sync)
+    val session = cassandraJournal().session
+    val sync    = cassandraJournal().sync
+    @nowarn("msg=deprecated")
+    val schema = SnapshotSchema.apply(session, sync)
 
     val test = for {
       _ <- schema.create
@@ -36,7 +38,7 @@ class SnapshotSchemaSpec extends CassandraSpec {
   }
 
   test("table is truncated using scassandra session API") {
-    val session = cassandra().session.unsafe
+    val session = cassandra().session
     val sync    = cassandra().sync
 
     val schema = SnapshotSchema.of(session, sync)
@@ -52,9 +54,10 @@ class SnapshotSchemaSpec extends CassandraSpec {
   }
 
   test("table is truncated using kafka-journal session API") {
-    val session = cassandra().session
-    val sync    = cassandra().sync
+    val session = cassandraJournal().session
+    val sync    = cassandraJournal().sync
 
+    @nowarn("msg=deprecated")
     val schema = SnapshotSchema.apply(session, sync)
 
     val test = for {
@@ -105,6 +108,6 @@ class SnapshotSchemaSpec extends CassandraSpec {
 
   override def afterEach(context: AfterEach): Unit = {
     super.afterEach(context)
-    cassandra().session.unsafe.execute("DROP TABLE IF EXISTS snapshots_v2").void.unsafeRunSync()
+    cassandra().session.execute("DROP TABLE IF EXISTS snapshots_v2").void.unsafeRunSync()
   }
 }

--- a/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotSpec.scala
+++ b/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotSpec.scala
@@ -10,7 +10,7 @@ class SnapshotSpec extends CassandraSpec {
     val key      = KafkaKey("SnapshotSpec", "integration-tests-1", TopicPartition.empty, "queries")
     val snapshot = KafkaSnapshot(offset = Offset.min, value = "snapshot-contents")
     val test: IO[Unit] = for {
-      snapshots            <- CassandraSnapshots.withSchema[IO, String](cassandra().session.unsafe, cassandra().sync)
+      snapshots            <- CassandraSnapshots.withSchema[IO, String](cassandra().session, cassandra().sync)
       snapshotBeforeTest   <- snapshots.get(key)
       _                    <- snapshots.persist(key, snapshot)
       snapshotAfterPersist <- snapshots.get(key)
@@ -30,7 +30,7 @@ class SnapshotSpec extends CassandraSpec {
     val test: IO[Unit] = for {
       failAfter <- Ref.of[IO, Int](100)
       session    = CassandraSessionStub.injectFailures(cassandra().session, failAfter)
-      snapshots <- CassandraSnapshots.withSchema[IO, String](session.unsafe, cassandra().sync)
+      snapshots <- CassandraSnapshots.withSchema[IO, String](session, cassandra().sync)
       _         <- failAfter.set(1)
       snapshots <- snapshots.get(key).attempt
     } yield assert(clue(snapshots.isLeft))

--- a/persistence-cassandra/src/main/scala/com/evolution/kafka/flow/cassandra/CassandraHealthCheckOf.scala
+++ b/persistence-cassandra/src/main/scala/com/evolution/kafka/flow/cassandra/CassandraHealthCheckOf.scala
@@ -1,0 +1,27 @@
+package com.evolution.kafka.flow.cassandra
+
+import cats.Parallel
+import cats.effect.{Async, Resource}
+import com.datastax.driver.core.ConsistencyLevel
+import com.evolutiongaming.catshelper.LogOf
+import com.evolutiongaming.kafka.flow.cassandra.CassandraConfig
+import com.evolutiongaming.kafka.flow.cassandra.SessionHelper._
+import com.evolutiongaming.scassandra.{CassandraHealthCheck, CassandraSession}
+
+private[cassandra] object CassandraHealthCheckOf {
+
+  def apply[F[_]: Async: Parallel: LogOf](
+    cassandraSession: CassandraSession[F],
+    config: CassandraConfig
+  ): Resource[F, CassandraHealthCheck[F]] = {
+    for {
+      cassandraSession <- cassandraSession.enhanceError.cachePrepared.map(_.withRetries(config.retries))
+      cassandraHealthCheck <- CassandraHealthCheck.of(
+        Resource.pure[F, CassandraSession[F]](cassandraSession),
+        ConsistencyLevel.LOCAL_QUORUM
+      )
+    } yield {
+      cassandraHealthCheck
+    }
+  }
+}

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/CassandraHealthCheckOf.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/CassandraHealthCheckOf.scala
@@ -9,6 +9,7 @@ import com.evolutiongaming.kafka.journal.cassandra.CassandraConsistencyConfig
 import com.evolutiongaming.scassandra.CassandraSession
 import com.evolutiongaming.scassandra.util.FromGFuture
 
+@deprecated("Use com.evolution.kafka.flow.cassandra.CassandraHealthCheckOf", "4.3.0")
 private[cassandra] object CassandraHealthCheckOf {
 
   def apply[F[_]: Async: FromGFuture: Parallel: LogOf](

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/CassandraPersistence.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/CassandraPersistence.scala
@@ -7,7 +7,7 @@ import cats.{Monad, MonadThrow}
 import com.evolutiongaming.cassandra.sync.CassandraSync
 import com.evolutiongaming.kafka.flow.journal.CassandraJournals
 import com.evolutiongaming.kafka.flow.key.{CassandraKeys, KeySegments}
-import com.evolutiongaming.kafka.flow.migration.migration._
+import com.evolutiongaming.kafka.flow.migration._
 import com.evolutiongaming.kafka.flow.persistence.PersistenceModule
 import com.evolutiongaming.kafka.flow.snapshot.CassandraSnapshots
 import com.evolutiongaming.kafka.journal.eventual.cassandra.{CassandraSession, Segments}

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/journal/JournalSchema.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/journal/JournalSchema.scala
@@ -6,13 +6,14 @@ import com.evolutiongaming.cassandra.sync.CassandraSync
 import com.evolutiongaming.kafka.journal.eventual.cassandra.CassandraSession
 import com.evolutiongaming.scassandra
 
-private[journal] trait JournalSchema[F[_]] {
+trait JournalSchema[F[_]] {
   def create: F[Unit]
 
   def truncate: F[Unit]
 }
 
-private[journal] object JournalSchema {
+object JournalSchema {
+  @deprecated("Use `of` taking `scassandra.CassandraSession`", "4.3.0")
   def apply[F[_]: Monad](
     session: CassandraSession[F],
     synchronize: CassandraSync[F]

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/key/CassandraKeys.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/key/CassandraKeys.scala
@@ -38,7 +38,7 @@ import java.time.{LocalDate, ZoneOffset}
   * @see
   *   See `com.evolutiongaming.kafka.flow.key.KeySchema` for a schema description
   */
-private class CassandraKeys[F[_]: Async](
+class CassandraKeys[F[_]: Async](
   session: scassandra.CassandraSession[F],
   consistencyOverrides: ConsistencyOverrides,
   segments: KeySegments

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/key/KeySchema.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/key/KeySchema.scala
@@ -6,14 +6,15 @@ import com.evolutiongaming.cassandra.sync.CassandraSync
 import com.evolutiongaming.kafka.journal.eventual.cassandra.CassandraSession
 import com.evolutiongaming.scassandra
 
-private[key] trait KeySchema[F[_]] {
+trait KeySchema[F[_]] {
   def create: F[Unit]
 
   def truncate: F[Unit]
 }
 
-private[key] object KeySchema {
+object KeySchema {
 
+  @deprecated("Use `of` taking `scassandra.CassandraSession`", "4.3.0")
   def apply[F[_]: Monad](
     session: CassandraSession[F],
     synchronize: CassandraSync[F]

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/migration.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/migration.scala
@@ -1,4 +1,4 @@
-package com.evolutiongaming.kafka.flow.migration
+package com.evolutiongaming.kafka.flow
 
 import com.evolutiongaming.kafka.journal.FromBytes
 import com.evolutiongaming.skafka
@@ -7,7 +7,8 @@ import cats.Applicative
 import cats.syntax.all._
 
 // This is a temporary object to help with migration from kafka-journal APIs
-private[flow] object migration {
+@deprecated("Switch to directly using skafka's FromBytes and ToBytes", "4.3.0")
+object migration {
   def journalFromBytesToSkafka[F[_], T](fb: FromBytes[F, T]): skafka.FromBytes[F, T] = {
     (a: Array[Byte], _: skafka.Topic) =>
       fb.apply(ByteVector.view(a))

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/CassandraSnapshots.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/CassandraSnapshots.scala
@@ -10,7 +10,7 @@ import com.evolutiongaming.kafka.flow.KafkaKey
 import com.evolutiongaming.kafka.flow.cassandra.CassandraCodecs._
 import com.evolutiongaming.kafka.flow.cassandra.ConsistencyOverrides
 import com.evolutiongaming.kafka.flow.cassandra.StatementHelper.StatementOps
-import com.evolutiongaming.kafka.flow.migration.migration._
+import com.evolutiongaming.kafka.flow.migration._
 import com.evolutiongaming.kafka.journal.eventual.cassandra.CassandraSession
 import com.evolutiongaming.kafka.journal.{FromBytes, ToBytes}
 import com.evolutiongaming.scassandra.StreamingCassandraSession._

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotSchema.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotSchema.scala
@@ -6,14 +6,15 @@ import com.evolutiongaming.cassandra.sync.CassandraSync
 import com.evolutiongaming.kafka.journal.eventual.cassandra.CassandraSession
 import com.evolutiongaming.scassandra
 
-private[snapshot] trait SnapshotSchema[F[_]] {
+trait SnapshotSchema[F[_]] {
   def create: F[Unit]
 
   def truncate: F[Unit]
 }
 
-private[snapshot] object SnapshotSchema {
+object SnapshotSchema {
 
+  @deprecated("Use `of` taking `scassandra.CassandraSession`", "4.3.0")
   def apply[F[_]: Monad](
     session: CassandraSession[F],
     synchronize: CassandraSync[F]

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,6 +8,7 @@ object Dependencies {
   val scache            = "com.evolution"       %% "scache"              % "5.1.2"
   val skafka            = "com.evolutiongaming" %% "skafka"              % "16.0.3"
   val sstream           = "com.evolutiongaming" %% "sstream"             % "1.0.1"
+  val scassandra        = "com.evolutiongaming" %% "scassandra"          % "5.2.1"
 
   object Cats {
     private val version       = "2.10.0"


### PR DESCRIPTION
this is a part of https://github.com/evolution-gaming/kafka-flow/issues/592

- introduce a new `CassandraModule` under a `com.evolution.kafka.flow.cassandra` package using `scassandra` API
- introduce a new `CassandraHealthCheckOf ` under a `com.evolution.kafka.flow.cassandra` package using `scassandra` API
- deprecate the old `CassandraModule` and `CassandraHealthCheckOf`
- deprecate old APIs of `JournalSchema`, `KeySchema`, `SnapshotSchema`
- provide `com.evolutiongaming.kafka.flow.migration` to facilitate migration of ToBytes/FromBytes