### PR TITLE
Introduce a custom GH action to publish a new release only on git tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,18 +10,18 @@ jobs:
     strategy:
       matrix:
         scala:
-          - 2.13.12
+          - 2.13.14
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: coursier/cache-action@v6
 
     - name: Setup Java
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: "17"
-        distribution: "temurin"
+        distribution: "oracle"
         cache: "sbt"
 
     - name: Check formatting
@@ -29,11 +29,7 @@ jobs:
 
     - name: Run tests ${{ matrix.scala }}
       if: success() 
-      run: sbt ++${{ matrix.scala }} clean coverage test docs/mdoc
-
-    - name: Run tests ${{ matrix.scala }}
-      if: success() 
-      run: sbt ++${{ matrix.scala }} clean coverage test versionPolicyCheck
+      run: sbt ++${{ matrix.scala }} clean coverage test docs/mdoc versionPolicyCheck
 
     - name: Report test coverage
       if: success() && github.repository == 'evolution-gaming/kafka-flow'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
           echo "password=${{secrets.JFROG_ACCESS_TOKEN}}" >> ${{ env.SBT_CREDENTIALS }}
 
       - name: check, test and package
-        run: sbt "clean; +show version; +all test package"
+        run: sbt "clean; versionPolicyCheck; +all test package"
 
       - name: publish on JFrog Artifactory
         run: sbt "+publish"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,53 @@
-name: Publish Release
+name: Test and publish a new release
   
 on:
-  release:
-    types: [published]
-    branches: [master]
+  push:
+    tags:
+      - 'v*'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  SBT_CREDENTIALS: '.credentials'
   
 jobs:
-  release:
-    uses: evolution-gaming/scala-github-actions/.github/workflows/release.yml@v1
-    secrets: inherit
+  publish-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: coursier/cache-action@v6
+      
+      - name: setup Java and SBT
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'oracle'
+          cache: 'sbt'
+
+      - name: setup credentials
+        run: |
+          echo "realm=Artifactory Realm" >> ${{ env.SBT_CREDENTIALS }}
+          echo "host=evolution.jfrog.io" >> ${{ env.SBT_CREDENTIALS }}
+          echo "user=github-publish" >> ${{ env.SBT_CREDENTIALS }}
+          echo "password=${{secrets.JFROG_ACCESS_TOKEN}}" >> ${{ env.SBT_CREDENTIALS }}
+
+      - name: check, test and package
+        run: sbt "clean; +show version; +all test package"
+
+      - name: publish on JFrog Artifactory
+        run: sbt "+publish"
+
+      - name: cleanup credentials
+        if: always()
+        run: rm -rf ${{ env.SBT_CREDENTIALS }}
+
+      - name: delete tag
+        if: failure()
+        run: git push --delete origin ${{ github.ref_name }}

--- a/README.md
+++ b/README.md
@@ -34,14 +34,9 @@ libraryDependencies ++= Seq(
 ```
 
 ## Release process
-The release process makes use of https://github.com/evolution-gaming/scala-github-actions that runs 
-tests and ensures proper publishing with the required credentials via GitHub Actions. 
-The flow is defined in `.github/workflows/release.yml`.  
+The release process is based on Git tags and makes use of [sbt-dynver](https://github.com/sbt/sbt-dynver) to automatically obtain the version from the latest Git tag. The flow is defined in `.github/workflows/release.yml`.  
 A typical release process is as follows:
-1. Update version in `version.sbt` to the target one. Example: current version is `4.0.0` and you 
-want to publish `4.1.0`. Update `version.sbt` to `4.1.0`.
-2. Push changes to the repository. Do not make a new tag manually.
-3. Create a new release in GitHub. Go to the `Releases` page, click `Draft a new release`, select 
-"Choose a tag", enter the target version in a format `vX.Y.Z` (example: `v4.1.0`).
-4. Press `Generate release notes`. Release title will be automatically filled with the tag name. Change the description if needed.
-5. Press `Publish release`. The build will be triggered automatically, it will run the tests and publish the target release.
+1. Create and push a new Git tag. The version should be in the format `vX.Y.Z` (example: `v4.1.0`). Example: `git tag v4.1.0 && git push origin v4.1.0`
+2. Create a new release in GitHub. Go to the `Releases` page, click `Draft a new release`, select `Choose a tag`, pick the tag you just created
+3. Press `Generate release notes`. Release title will be automatically filled with the tag name. Change the description if needed
+4. Press `Publish release`

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ lazy val commonSettings = Seq(
   organizationName := "Evolution Gaming",
   organizationHomepage := Some(url("https://evolution.com/")),
   publishTo := Some(Resolver.evolutionReleases),
-  scalaVersion := "2.13.12",
+  scalaVersion := "2.13.14",
   licenses := Seq(("MIT", url("https://opensource.org/licenses/MIT"))),
   testFrameworks += new TestFramework("munit.Framework"),
   testOptions += Tests.Argument(new TestFramework("munit.Framework"), "+l"),
@@ -20,8 +20,8 @@ lazy val commonSettings = Seq(
   libraryDependencySchemes ++= Seq(
     "org.scala-lang.modules" %% "scala-java8-compat" % "always"
   ),
-  addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.13.2" cross CrossVersion.full),
-  coverageScalacPluginVersion := "2.0.11",
+  addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.13.3" cross CrossVersion.full),
+  coverageScalacPluginVersion := "2.2.0",
 )
 
 lazy val root = (project in file("."))

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.10.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,7 +7,8 @@ addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.9")
 
 addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.3.11")
 
-addSbtPlugin("com.github.sbt" % "sbt-release" % "1.0.15")
+// This sets the 'version' property based on the git tag during release process to publish the right version
+addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.0.1")
 
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.3.8")
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,0 @@
-ThisBuild / version := "4.5.1-SNAPSHOT"


### PR DESCRIPTION
## Motivation
The current release process is cumbersome, requiring multiple manual steps in a strict sequence: first, updating the version in `version.sbt`, then manually creating a GitHub release with the same version, after which the release is triggered. This process can be simplified to improve efficiency and reduce potential errors.

## Changes in this PR
This PR introduces a new model for publishing, triggered by pushing git tags in the `v*` format. When such a tag is pushed, the release process automatically starts.

The `version.sbt` file has been removed and replaced with [sbt-dynver](https://github.com/sbt/sbt-dynver), which dynamically sets the version property based on the latest git tag. This ensures that when a new `vX.Y.Z` tag is pushed, the version used during publishing step is correctly set, streamlining the release process.

