### PR TITLE
Make keys DDL use LeveledCompactionStrategy by default

### DIFF
--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/key/KeySchema.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/key/KeySchema.scala
@@ -39,6 +39,7 @@ object KeySchema {
           |metadata TEXT,
           |PRIMARY KEY((application_id, group_id, segment), topic, partition, key)
           |)
+          |WITH compaction = {'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'}
           |""".stripMargin
         ) >>
         session


### PR DESCRIPTION
This fits the use case as `keys` table is read intensively during the bootstrap phase when eager recovery is used, and then it does a lot of updates/deletes which plays well with this strategy and allows avoiding putting more pressure on the compaction process. We've observed significant performance gains when using this strategy compared to the default one in a keyspace with hundreds of thousands of keys -- compaction manages to keep up and allows for a fast keys recovery