### PR TITLE
Pass SSL related settings to kafka healthcheck consumer

### DIFF
--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/kafka/KafkaModule.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/kafka/KafkaModule.scala
@@ -47,7 +47,7 @@ object KafkaModule {
 
         val healthCheck = KafkaHealthCheck.of(
           KafkaHealthCheck.Config.default,
-          ConsumerConfig(common = commonConfig),
+          ConsumerConfig(common = commonConfig, saslSupport = config.saslSupport, sslSupport = config.sslSupport),
           ProducerConfig(common = commonConfig, saslSupport = config.saslSupport, sslSupport = config.sslSupport)
         )
         LogResource[F](KafkaModule.getClass, "KafkaHealthCheck") *> healthCheck

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/kafka/KafkaModule.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/kafka/KafkaModule.scala
@@ -26,6 +26,10 @@ trait KafkaModule[F[_]] {
 
 object KafkaModule {
 
+  /** Creates kafka consumer and producer builders, and additionally launches kafka healthcheck mechanism which
+    * repeatedly sends and consumes messages to/from topic named 'healthcheck' (refer to
+    * [[KafkaHealthCheck.Config.default]])
+    */
   def of[F[_]: Async: FromTry: ToTry: ToFuture: LogOf](
     applicationId: String,
     config: ConsumerConfig,


### PR DESCRIPTION
Hi.

Looks like in KafkaModule we need to add SSL related settings to kafka healthcheck consumer config, similar like Producer config is being created.
Reference - https://github.com/evolution-gaming/kafka-flow/blob/master/core/src/main/scala/com/evolutiongaming/kafka/flow/kafka/KafkaModule.scala#L50

Currently without passing SSL related settings to consumer config, one might hit on exception (SSL handshake failed) if 'security-protocol' setting is set to "SSL".