### PR TITLE
log topic-partition and key in KeyDatabase/Keys logging when deleting a key

### DIFF
--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/key/KeyDatabase.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/key/KeyDatabase.scala
@@ -5,6 +5,7 @@ import cats.mtl.Stateful
 import cats.syntax.all._
 import cats.{Applicative, Monad}
 import com.evolutiongaming.catshelper.LogOf
+import com.evolutiongaming.kafka.flow.LogPrefix
 import com.evolutiongaming.kafka.flow.effect.CatsEffectMtlInstances._
 import com.evolutiongaming.skafka.TopicPartition
 import com.evolutiongaming.sstream.Stream
@@ -19,7 +20,7 @@ trait KeyDatabase[F[_], K] {
 
   def all(applicationId: String, groupId: String, topicPartition: TopicPartition): Stream[F, K]
 
-  def keysOf(implicit F: Monad[F], logOf: LogOf[F]): F[KeysOf[F, K]] =
+  def keysOf(implicit F: Monad[F], logOf: LogOf[F], logPrefix: LogPrefix[K]): F[KeysOf[F, K]] =
     logOf(KeyDatabase.getClass) map { implicit log => KeysOf(this) }
 
 }

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/key/KeysOf.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/key/KeysOf.scala
@@ -1,9 +1,10 @@
 package com.evolutiongaming.kafka.flow.key
 
+import cats.Monad
 import cats.effect.Sync
 import cats.syntax.all._
-import cats.Monad
 import com.evolutiongaming.catshelper.Log
+import com.evolutiongaming.kafka.flow.LogPrefix
 import com.evolutiongaming.skafka.TopicPartition
 import com.evolutiongaming.sstream.Stream
 
@@ -16,13 +17,13 @@ trait KeysOf[F[_], K] {
 }
 object KeysOf {
 
-  def memory[F[_]: Sync: Log, K]: F[KeysOf[F, K]] =
+  def memory[F[_]: Sync: Log, K: LogPrefix]: F[KeysOf[F, K]] =
     KeyDatabase.memory[F, K] map { database =>
       KeysOf(database)
     }
 
   /** Creates `KeysOf` with a passed logger */
-  def apply[F[_]: Monad: Log, K](
+  def apply[F[_]: Monad: Log, K: LogPrefix](
     database: KeyDatabase[F, K]
   ): KeysOf[F, K] = new KeysOf[F, K] {
     def apply(key: K) = Keys(key, database)


### PR DESCRIPTION
Currently, when deleting a key, the log message doesn't give much information, looking like this:
```
2025-01-21 11:45:14,543 INFO io-compute-0 c.e.k.f.k.KeyDatabase deleted key
```

This PR adds more info to the log message, prefixing it with topic-partition and key info, so it'll look like this:
```
2025-01-21 11:45:14,543 INFO io-compute-0 c.e.k.f.k.KeyDatabase [topic-1 key1] deleted key
```