### PR TITLE
add ttls to cassandra persist statements

### DIFF
--- a/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/journal/JournalSpec.scala
+++ b/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/journal/JournalSpec.scala
@@ -1,10 +1,15 @@
 package com.evolutiongaming.kafka.flow.journal
 
 import cats.effect.{IO, Ref}
+import cats.syntax.all.*
 import com.evolutiongaming.kafka.flow.{CassandraSessionStub, CassandraSpec, KafkaKey}
+import com.evolutiongaming.scassandra.syntax.*
 import com.evolutiongaming.skafka.consumer.{ConsumerRecord, WithSize}
 import com.evolutiongaming.skafka.{Offset, TopicPartition}
 import scodec.bits.ByteVector
+
+import scala.concurrent.duration.*
+import scala.jdk.CollectionConverters.*
 
 class JournalSpec extends CassandraSpec {
 
@@ -23,13 +28,15 @@ class JournalSpec extends CassandraSpec {
       journalBeforeTest   <- journals.get(key).toList
       _                   <- journals.persist(key, record)
       journalAfterPersist <- journals.get(key).toList
+      ttls                <- getTtls(key)
       _                   <- journals.delete(key)
       journalAfterDelete  <- journals.get(key).toList
-
-      _ = assert(clue(journalBeforeTest.isEmpty))
-      _ = assertEquals(clue(journalAfterPersist), List(record))
-      _ = assert(clue(journalAfterDelete.isEmpty))
-    } yield ()
+    } yield {
+      assert(clue(journalBeforeTest.isEmpty))
+      assertEquals(clue(journalAfterPersist), List(record))
+      assert(clue(journalAfterDelete.isEmpty))
+      assertEquals(clue(ttls), List(none))
+    }
 
     test.unsafeRunSync()
   }
@@ -42,10 +49,56 @@ class JournalSpec extends CassandraSpec {
       journals  <- CassandraJournals.withSchema(session, cassandra().sync)
       _         <- failAfter.set(1)
       records   <- journals.get(key).toList.attempt
-      _          = assert(clue(records.isLeft))
-    } yield ()
+    } yield assert(clue(records.isLeft))
 
     test.unsafeRunSync()
+  }
+
+  test("ttl") {
+    val key     = KafkaKey("JournalSpec", "integration-tests-1", TopicPartition.empty, "ttl")
+    val session = cassandra().session
+    val test: IO[Unit] = for {
+      journals <- CassandraJournals.withSchema(session, cassandra().sync, ttl = 1.hour.some)
+      contents <- IO.fromEither(ByteVector.encodeUtf8("record-contents"))
+      record = ConsumerRecord[String, ByteVector](
+        topicPartition   = TopicPartition.empty,
+        offset           = Offset.min,
+        timestampAndType = None,
+        key              = Some(WithSize("ttl")),
+        value            = Some(WithSize(contents, 15))
+      )
+      _                   <- journals.persist(key, record)
+      journalAfterPersist <- journals.get(key).toList
+      ttls                <- getTtls(key)
+    } yield {
+      assertEquals(clue(journalAfterPersist), List(record))
+      assertEquals(clue(ttls.size), 1)
+      assert(clue(ttls.head.isDefined))
+    }
+
+    test.unsafeRunSync()
+  }
+
+  private def getTtls(key: KafkaKey): IO[List[Option[Int]]] = {
+    val session = cassandra().session
+    for {
+      prepared <- session.prepare(
+        s"""SELECT TTL(value) FROM ${CassandraJournals.DefaultTableName} WHERE
+           |  application_id = :application_id
+           |  AND group_id = :group_id
+           |  AND topic = :topic
+           |  AND partition = :partition
+           |  AND key = :key""".stripMargin
+      )
+      bound = prepared
+        .bind()
+        .encode("application_id", key.applicationId)
+        .encode("group_id", key.groupId)
+        .encode("topic", key.topicPartition.topic)
+        .encode("partition", key.topicPartition.partition.value)
+        .encode("key", key.key)
+      ttls <- session.execute(bound)
+    } yield ttls.all().asScala.map(row => row.decodeAt[Option[Int]](0)).toList
   }
 
 }

--- a/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotSpec.scala
+++ b/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotSpec.scala
@@ -1,8 +1,13 @@
 package com.evolutiongaming.kafka.flow.snapshot
 
 import cats.effect.{IO, Ref}
+import cats.syntax.all.*
 import com.evolutiongaming.kafka.flow.{CassandraSessionStub, CassandraSpec, KafkaKey}
+import com.evolutiongaming.scassandra.syntax.*
 import com.evolutiongaming.skafka.{Offset, TopicPartition}
+
+import scala.concurrent.duration.*
+import scala.jdk.CollectionConverters.*
 
 class SnapshotSpec extends CassandraSpec {
 
@@ -14,12 +19,14 @@ class SnapshotSpec extends CassandraSpec {
       snapshotBeforeTest   <- snapshots.get(key)
       _                    <- snapshots.persist(key, snapshot)
       snapshotAfterPersist <- snapshots.get(key)
+      ttls                 <- getTtls(key)
       _                    <- snapshots.delete(key)
       snapshotAfterDelete  <- snapshots.get(key)
     } yield {
       assert(clue(snapshotBeforeTest.isEmpty))
       assertEquals(clue(snapshotAfterPersist), Some(snapshot))
       assert(clue(snapshotAfterDelete.isEmpty))
+      assertEquals(clue(ttls), List(none))
     }
 
     test.unsafeRunSync()
@@ -36,6 +43,45 @@ class SnapshotSpec extends CassandraSpec {
     } yield assert(clue(snapshots.isLeft))
 
     test.unsafeRunSync()
+  }
+
+  test("ttl") {
+    val key      = KafkaKey("SnapshotSpec", "integration-tests-1", TopicPartition.empty, "queries")
+    val snapshot = KafkaSnapshot(offset = Offset.min, value = "snapshot-contents")
+    val test: IO[Unit] = for {
+      snapshots <- CassandraSnapshots.withSchema[IO, String](cassandra().session, cassandra().sync, ttl = 1.hour.some)
+      _         <- snapshots.persist(key, snapshot)
+      snapshotAfterPersist <- snapshots.get(key)
+      ttls                 <- getTtls(key)
+    } yield {
+      assertEquals(clue(snapshotAfterPersist), snapshot.some)
+      assertEquals(clue(ttls.size), 1)
+      assert(clue(ttls.head.isDefined))
+    }
+
+    test.unsafeRunSync()
+  }
+
+  private def getTtls(key: KafkaKey): IO[List[Option[Int]]] = {
+    val session = cassandra().session
+    for {
+      prepared <- session.prepare(
+        s"""SELECT TTL(value) FROM ${CassandraSnapshots.DefaultTableName} WHERE
+           |  application_id = :application_id
+           |  AND group_id = :group_id
+           |  AND topic = :topic
+           |  AND partition = :partition
+           |  AND key = :key""".stripMargin
+      )
+      bound = prepared
+        .bind()
+        .encode("application_id", key.applicationId)
+        .encode("group_id", key.groupId)
+        .encode("topic", key.topicPartition.topic)
+        .encode("partition", key.topicPartition.partition.value)
+        .encode("key", key.key)
+      ttls <- session.execute(bound)
+    } yield ttls.all().asScala.map(row => row.decodeAt[Option[Int]](0)).toList
   }
 
 }

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/RecordExpiration.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/RecordExpiration.scala
@@ -1,0 +1,13 @@
+package com.evolutiongaming.kafka.flow.cassandra
+
+import scala.concurrent.duration.FiniteDuration
+
+final case class RecordExpiration(
+  journals: Option[FiniteDuration]  = None,
+  keys: Option[FiniteDuration]      = None,
+  snapshots: Option[FiniteDuration] = None,
+)
+
+object RecordExpiration {
+  val default: RecordExpiration = RecordExpiration()
+}

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/StatementHelper.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/StatementHelper.scala
@@ -2,9 +2,14 @@ package com.evolutiongaming.kafka.flow.cassandra
 
 import com.datastax.driver.core.{ConsistencyLevel, Statement}
 
+import scala.concurrent.duration.FiniteDuration
+
 object StatementHelper {
   implicit final class StatementOps(val self: Statement) extends AnyVal {
     def withConsistencyLevel(level: Option[ConsistencyLevel]): Statement =
       level.map(self.setConsistencyLevel).getOrElse(self)
   }
+
+  def ttlFragment(ttl: Option[FiniteDuration]): String =
+    ttl.map(ttl => s"USING TTL ${ttl.toSeconds}").getOrElse("")
 }

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/journal/CassandraJournals.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/journal/CassandraJournals.scala
@@ -8,7 +8,7 @@ import com.evolutiongaming.cassandra.sync.CassandraSync
 import com.evolutiongaming.catshelper.ClockHelper.*
 import com.evolutiongaming.kafka.flow.KafkaKey
 import com.evolutiongaming.kafka.flow.cassandra.CassandraCodecs.*
-import com.evolutiongaming.kafka.flow.cassandra.ConsistencyOverrides
+import com.evolutiongaming.kafka.flow.cassandra.{ConsistencyOverrides, StatementHelper}
 import com.evolutiongaming.kafka.flow.cassandra.StatementHelper.StatementOps
 import com.evolutiongaming.kafka.flow.journal.conversions.{HeaderToTuple, TupleToHeader}
 import com.evolutiongaming.scassandra.CassandraSession
@@ -20,21 +20,26 @@ import com.evolutiongaming.sstream.Stream
 import scodec.bits.ByteVector
 
 import java.time.Instant
-
 import CassandraJournals.*
+
+import scala.concurrent.duration.FiniteDuration
 
 class CassandraJournals[F[_]: Async](
   session: CassandraSession[F],
   consistencyOverrides: ConsistencyOverrides = ConsistencyOverrides.none,
   tableName: String,
+  ttl: Option[FiniteDuration],
 ) extends JournalDatabase[F, KafkaKey, ConsumerRecord[String, ByteVector]] {
+
+  def this(session: CassandraSession[F], consistencyOverrides: ConsistencyOverrides, tableName: String) =
+    this(session, consistencyOverrides, tableName, ttl = None)
 
   def this(session: CassandraSession[F], consistencyOverrides: ConsistencyOverrides) =
     this(session, consistencyOverrides, DefaultTableName)
 
   def persist(key: KafkaKey, event: ConsumerRecord[String, ByteVector]): F[Unit] =
     for {
-      boundStatement <- Statements.persist(session, key, event, tableName)
+      boundStatement <- Statements.persist(session, key, event, tableName, ttl)
       statement       = boundStatement.withConsistencyLevel(consistencyOverrides.write)
       _              <- session.execute(statement).void
     } yield ()
@@ -66,11 +71,20 @@ object CassandraJournals {
     sync: CassandraSync[F],
     consistencyOverrides: ConsistencyOverrides,
     tableName: String,
+    ttl: Option[FiniteDuration],
   ): F[JournalDatabase[F, KafkaKey, ConsumerRecord[String, ByteVector]]] =
     JournalSchema
       .of(session, sync, tableName)
       .create
-      .as(new CassandraJournals(session, consistencyOverrides, tableName))
+      .as(new CassandraJournals(session, consistencyOverrides, tableName, ttl))
+
+  def withSchema[F[_]: Async](
+    session: CassandraSession[F],
+    sync: CassandraSync[F],
+    consistencyOverrides: ConsistencyOverrides,
+    tableName: String,
+  ): F[JournalDatabase[F, KafkaKey, ConsumerRecord[String, ByteVector]]] =
+    withSchema(session, sync, consistencyOverrides, tableName, ttl = None)
 
   def withSchema[F[_]: Async](
     session: CassandraSession[F],
@@ -172,16 +186,30 @@ object CassandraJournals {
       event: ConsumerRecord[String, ByteVector],
     ): F[BoundStatement] = persist(session, key, event, DefaultTableName)
 
+    @deprecated(
+      "Use the version with an explicit ttl. This exists to preserve binary compatibility until the next major release",
+      since = "6.1.3"
+    )
     def persist[F[_]: MonadThrow: Clock](
       session: CassandraSession[F],
       key: KafkaKey,
       event: ConsumerRecord[String, ByteVector],
       tableName: String,
+    ): F[BoundStatement] =
+      persist(session, key, event, tableName, ttl = None)
+
+    def persist[F[_]: MonadThrow: Clock](
+      session: CassandraSession[F],
+      key: KafkaKey,
+      event: ConsumerRecord[String, ByteVector],
+      tableName: String,
+      ttl: Option[FiniteDuration],
     ): F[BoundStatement] = for {
       preparedStatement <- session.prepare(
         s"""
         |UPDATE
         |  $tableName
+        |  ${StatementHelper.ttlFragment(ttl)}
         |SET
         |  created = :created,
         |  timestamp = :timestamp,

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/key/CassandraKeys.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/key/CassandraKeys.scala
@@ -42,23 +42,17 @@ import scala.concurrent.duration.FiniteDuration
   */
 class CassandraKeys[F[_]: Async](
   session: CassandraSession[F],
-  consistencyOverrides: ConsistencyOverrides,
+  consistencyOverrides: ConsistencyOverrides = ConsistencyOverrides.none,
   segments: KeySegments,
-  tableName: String,
-  ttl: Option[FiniteDuration],
+  tableName: String           = CassandraKeys.DefaultTableName,
+  ttl: Option[FiniteDuration] = None,
 ) extends KeyDatabase[F, KafkaKey] {
 
-  def this(
-    session: CassandraSession[F],
-    consistencyOverrides: ConsistencyOverrides,
-    segments: KeySegments,
-    tableName: String,
-  ) =
-    this(session, consistencyOverrides, segments, tableName, ttl = None)
-
+  // This exists for the sake of binary compatibility, to be removed in next major version
   def this(session: CassandraSession[F], consistencyOverrides: ConsistencyOverrides, segments: KeySegments) =
     this(session, consistencyOverrides, segments, CassandraKeys.DefaultTableName)
 
+  // This exists for the sake of binary compatibility, to be removed in next major version
   def this(session: CassandraSession[F], segments: KeySegments) =
     this(session, ConsistencyOverrides.none, segments, CassandraKeys.DefaultTableName)
 
@@ -128,10 +122,10 @@ object CassandraKeys {
   def withSchema[F[_]: Async](
     session: CassandraSession[F],
     sync: CassandraSync[F],
-    consistencyOverrides: ConsistencyOverrides,
+    consistencyOverrides: ConsistencyOverrides = ConsistencyOverrides.none,
     keySegments: KeySegments,
-    tableName: String,
-    ttl: Option[FiniteDuration],
+    tableName: String           = DefaultTableName,
+    ttl: Option[FiniteDuration] = None,
   ): F[KeyDatabase[F, KafkaKey]] = {
     KeySchema
       .of(session, sync, tableName)
@@ -139,14 +133,7 @@ object CassandraKeys {
       .as(new CassandraKeys(session, consistencyOverrides, keySegments, tableName, ttl))
   }
 
-  def withSchema[F[_]: Async](
-    session: CassandraSession[F],
-    sync: CassandraSync[F],
-    consistencyOverrides: ConsistencyOverrides,
-    keySegments: KeySegments,
-    tableName: String,
-  ): F[KeyDatabase[F, KafkaKey]] = withSchema(session, sync, consistencyOverrides, keySegments, tableName, ttl = None)
-
+  // This exists for the sake of binary compatibility, to be removed in next major version
   def withSchema[F[_]: Async](
     session: CassandraSession[F],
     sync: CassandraSync[F],
@@ -268,7 +255,7 @@ object CassandraKeys {
         )
 
     @deprecated(
-      "Use the version with an explicit table name. This exists to preserve binary compatibility until the next major release",
+      "Use the version with an explicit table name and TTL. This exists to preserve binary compatibility until the next major release",
       since = "6.1.3"
     )
     def persist[F[_]: Monad: Clock](
@@ -276,19 +263,7 @@ object CassandraKeys {
       key: KafkaKey,
       segments: KeySegments,
     ): F[BoundStatement] =
-      persist(session, key, segments, DefaultTableName)
-
-    @deprecated(
-      "Use the version with an explicit ttl. This exists to preserve binary compatibility until the next major release",
-      since = "6.1.3"
-    )
-    def persist[F[_]: Monad: Clock](
-      session: CassandraSession[F],
-      key: KafkaKey,
-      segments: KeySegments,
-      tableName: String,
-    ): F[BoundStatement] =
-      persist(session, key, segments, tableName, ttl = None)
+      persist(session, key, segments, DefaultTableName, ttl = None)
 
     def persist[F[_]: Monad: Clock](
       session: CassandraSession[F],


### PR DESCRIPTION
Adds TTL option to Cassandra tables, to let the data expire automatically.

Some work was done to clean up the constructors and factory methods and old methods were marked for removal. 

In certain places the deprecated annotation could not be used, because the old method is used instead of the one with default parameters.