### PR TITLE
Prepare `CassandraJournals` statements only once at the startup

### DIFF
--- a/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/CassandraSessionStub.scala
+++ b/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/CassandraSessionStub.scala
@@ -7,51 +7,8 @@ import com.datastax.driver.core.{Host, PreparedStatement, RegularStatement, Resu
 import com.evolutiongaming.scassandra.CassandraSession
 
 object CassandraSessionStub {
-
+  // Doesn't inject failures on statements preparation since we don't prepare them on each call.
   def injectFailures[F[_]](
-    session: CassandraSession[F],
-    failAfter: Ref[F, Int]
-  )(implicit F: MonadThrow[F]): CassandraSession[F] = new CassandraSession[F] {
-    def fail[T](query: String): F[T] = F.raiseError {
-      new RuntimeException(s"CassandraSessionStub: failing after proper calls exhausted: $query")
-    }
-
-    val failed = failAfter modify { failAfter =>
-      (failAfter - 1, failAfter <= 0)
-    }
-
-    override def loggedKeyspace: F[Option[String]]    = F.pure(None)
-    override def init: F[Unit]                        = F.unit
-    override def execute(query: String): F[ResultSet] = failed.ifM(fail(query), session.execute(query))
-
-    override def execute(query: String, values: Any*): F[ResultSet] =
-      failed.ifM(fail(query), session.execute(query, values: _*))
-
-    override def execute(query: String, values: Map[String, AnyRef]): F[ResultSet] =
-      failed.ifM(fail(query), session.execute(query, values))
-
-    override def execute(statement: Statement): F[ResultSet] =
-      failed.ifM(fail(statement.toString), session.execute(statement))
-
-    override def prepare(query: String): F[PreparedStatement] =
-      failed.ifM(fail(query), session.prepare(query))
-
-    override def prepare(statement: RegularStatement): F[PreparedStatement] =
-      failed.ifM(fail(statement.toString), session.prepare(statement))
-
-    override def state: CassandraSession.State[F] = new CassandraSession.State[F] {
-      override def connectedHosts: F[Iterable[Host]]      = F.pure(Iterable.empty)
-      override def openConnections(host: Host): F[Int]    = F.pure(0)
-      override def trashedConnections(host: Host): F[Int] = F.pure(0)
-      override def inFlightQueries(host: Host): F[Int]    = F.pure(0)
-    }
-
-  }
-
-  // Doesn't inject failures on statements preparation since we want to avoid preparing them on each call.
-  // This is a temporary method to be used in specs that test the classes that have already been migrated to
-  // preparing statements in advance
-  def injectFailuresOnExecute[F[_]](
     session: CassandraSession[F],
     failAfter: Ref[F, Int]
   )(implicit F: MonadThrow[F]): CassandraSession[F] = new CassandraSession[F] {

--- a/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/journal/JournalSpec.scala
+++ b/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/journal/JournalSpec.scala
@@ -47,7 +47,7 @@ class JournalSpec extends CassandraSpec {
       failAfter <- Ref.of[IO, Int](100)
       session    = CassandraSessionStub.injectFailures(cassandra().session, failAfter)
       journals  <- CassandraJournals.withSchema(session, cassandra().sync)
-      _         <- failAfter.set(1)
+      _         <- failAfter.set(0) // fail immediately on the first read attempt
       records   <- journals.get(key).toList.attempt
     } yield assert(clue(records.isLeft))
 

--- a/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/key/KeySpec.scala
+++ b/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/key/KeySpec.scala
@@ -52,7 +52,7 @@ class KeySpec extends CassandraSpec {
   test("failures") {
     val test: IO[Unit] = for {
       failAfter <- Ref.of[IO, Int](100)
-      session    = CassandraSessionStub.injectFailuresOnExecute(cassandra().session, failAfter)
+      session    = CassandraSessionStub.injectFailures(cassandra().session, failAfter)
       keys <- CassandraKeys.withSchema(
         session,
         cassandra().sync,

--- a/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotSpec.scala
+++ b/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotSpec.scala
@@ -36,7 +36,7 @@ class SnapshotSpec extends CassandraSpec {
     val key = KafkaKey("SnapshotSpec", "integration-tests-1", TopicPartition.empty, "queries")
     val test: IO[Unit] = for {
       failAfter <- Ref.of[IO, Int](100)
-      session    = CassandraSessionStub.injectFailuresOnExecute(cassandra().session, failAfter)
+      session    = CassandraSessionStub.injectFailures(cassandra().session, failAfter)
       snapshots <- CassandraSnapshots.withSchema[IO, String](session, cassandra().sync)
       _         <- failAfter.set(0) // fail immediately on the first read attempt
       snapshots <- snapshots.get(key).attempt

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/journal/CassandraJournals.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/journal/CassandraJournals.scala
@@ -68,7 +68,13 @@ object CassandraJournals {
       getStatement     <- Statements.prepareGet(session, tableName)
       persistStatement <- Statements.preparePersist(session, tableName, ttl)
       deleteStatement  <- Statements.prepareDelete(session, tableName)
-    } yield new CassandraJournals(session, getStatement, persistStatement, deleteStatement, consistencyOverrides)
+    } yield new CassandraJournals(
+      session              = session,
+      getStatement         = getStatement,
+      persistStatement     = persistStatement,
+      deleteStatement      = deleteStatement,
+      consistencyOverrides = consistencyOverrides
+    )
   }
 
   def truncate[F[_]: Monad](

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/journal/CassandraJournals.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/journal/CassandraJournals.scala
@@ -3,13 +3,14 @@ package com.evolutiongaming.kafka.flow.journal
 import cats.effect.{Async, Clock}
 import cats.syntax.all.*
 import cats.{Monad, MonadThrow}
-import com.datastax.driver.core.{BoundStatement, Row}
+import com.datastax.driver.core.{BoundStatement, PreparedStatement, Row}
 import com.evolutiongaming.cassandra.sync.CassandraSync
 import com.evolutiongaming.catshelper.ClockHelper.*
 import com.evolutiongaming.kafka.flow.KafkaKey
 import com.evolutiongaming.kafka.flow.cassandra.CassandraCodecs.*
-import com.evolutiongaming.kafka.flow.cassandra.{ConsistencyOverrides, StatementHelper}
 import com.evolutiongaming.kafka.flow.cassandra.StatementHelper.StatementOps
+import com.evolutiongaming.kafka.flow.cassandra.{ConsistencyOverrides, StatementHelper}
+import com.evolutiongaming.kafka.flow.journal.CassandraJournals.*
 import com.evolutiongaming.kafka.flow.journal.conversions.{HeaderToTuple, TupleToHeader}
 import com.evolutiongaming.scassandra.CassandraSession
 import com.evolutiongaming.scassandra.StreamingCassandraSession.*
@@ -20,44 +21,35 @@ import com.evolutiongaming.sstream.Stream
 import scodec.bits.ByteVector
 
 import java.time.Instant
-import CassandraJournals.*
-
 import scala.concurrent.duration.FiniteDuration
 
 class CassandraJournals[F[_]: Async](
   session: CassandraSession[F],
+  getStatement: PreparedStatement,
+  persistStatement: PreparedStatement,
+  deleteStatement: PreparedStatement,
   consistencyOverrides: ConsistencyOverrides = ConsistencyOverrides.none,
-  tableName: String                          = CassandraJournals.DefaultTableName,
-  ttl: Option[FiniteDuration]                = None,
 ) extends JournalDatabase[F, KafkaKey, ConsumerRecord[String, ByteVector]] {
 
-  // This exists for the sake of binary compatibility, to be removed in next major version
-  def this(session: CassandraSession[F], consistencyOverrides: ConsistencyOverrides) =
-    this(session, consistencyOverrides, CassandraJournals.DefaultTableName, None)
-
-  def persist(key: KafkaKey, event: ConsumerRecord[String, ByteVector]): F[Unit] =
+  def persist(key: KafkaKey, event: ConsumerRecord[String, ByteVector]): F[Unit] = {
     for {
-      boundStatement <- Statements.persist(session, key, event, tableName, ttl)
-      statement       = boundStatement.withConsistencyLevel(consistencyOverrides.write)
-      _              <- session.execute(statement).void
+      boundStatement <- Statements
+        .bindPersist(persistStatement, key, event)
+        .map(_.withConsistencyLevel(consistencyOverrides.write))
+      _ <- session.execute(boundStatement).void
     } yield ()
-
-  def get(key: KafkaKey): Stream[F, ConsumerRecord[String, ByteVector]] = {
-    val boundStatement = Statements
-      .get(session, key, tableName)
-      .map(_.withConsistencyLevel(consistencyOverrides.read))
-
-    Stream.lift(boundStatement).flatMap(session.executeStream(_)).mapM { row =>
-      decode(key, row)
-    }
   }
 
-  def delete(key: KafkaKey): F[Unit] =
-    for {
-      boundStatement <- Statements.delete(session, key, tableName)
-      statement       = boundStatement.withConsistencyLevel(consistencyOverrides.write)
-      _              <- session.execute(statement).void
-    } yield ()
+  def get(key: KafkaKey): Stream[F, ConsumerRecord[String, ByteVector]] = {
+    val boundStatement = Statements.bindGet(getStatement, key).withConsistencyLevel(consistencyOverrides.read)
+
+    session.executeStream(boundStatement).mapM(row => decode(key, row))
+  }
+
+  def delete(key: KafkaKey): F[Unit] = {
+    val boundStatement = Statements.bindDelete(deleteStatement, key).withConsistencyLevel(consistencyOverrides.write)
+    session.execute(boundStatement).void
+  }
 
 }
 object CassandraJournals {
@@ -70,35 +62,14 @@ object CassandraJournals {
     consistencyOverrides: ConsistencyOverrides = ConsistencyOverrides.none,
     tableName: String                          = DefaultTableName,
     ttl: Option[FiniteDuration]                = None,
-  ): F[JournalDatabase[F, KafkaKey, ConsumerRecord[String, ByteVector]]] =
-    JournalSchema
-      .of(session, sync, tableName)
-      .create
-      .as(new CassandraJournals(session, consistencyOverrides, tableName, ttl))
-
-  // This exists for the sake of binary compatibility, to be removed in next major version
-  def withSchema[F[_]: Async](
-    session: CassandraSession[F],
-    sync: CassandraSync[F],
-    consistencyOverrides: ConsistencyOverrides,
-  ): F[JournalDatabase[F, KafkaKey, ConsumerRecord[String, ByteVector]]] =
-    withSchema(session, sync, consistencyOverrides, DefaultTableName)
-
-  // This exists for the sake of binary compatibility, to be removed in next major version
-  def withSchema[F[_]: Async](
-    session: CassandraSession[F],
-    sync: CassandraSync[F],
-  ): F[JournalDatabase[F, KafkaKey, ConsumerRecord[String, ByteVector]]] =
-    withSchema(session, sync, ConsistencyOverrides.none, DefaultTableName)
-
-  @deprecated(
-    "Use the version with an explicit table name. This exists to preserve binary compatibility until the next major release",
-    since = "6.1.3"
-  )
-  def truncate[F[_]: Monad](
-    session: CassandraSession[F],
-    sync: CassandraSync[F],
-  ): F[Unit] = truncate(session, sync, DefaultTableName)
+  ): F[JournalDatabase[F, KafkaKey, ConsumerRecord[String, ByteVector]]] = {
+    for {
+      _                <- JournalSchema.of(session, sync, tableName).create
+      getStatement     <- Statements.prepareGet(session, tableName)
+      persistStatement <- Statements.preparePersist(session, tableName, ttl)
+      deleteStatement  <- Statements.prepareDelete(session, tableName)
+    } yield new CassandraJournals(session, getStatement, persistStatement, deleteStatement, consistencyOverrides)
+  }
 
   def truncate[F[_]: Monad](
     session: CassandraSession[F],
@@ -129,88 +100,73 @@ object CassandraJournals {
   }
 
   protected object Statements {
-    @deprecated(
-      "Use the version with an explicit table name. This exists to preserve binary compatibility until the next major release",
-      since = "6.1.3"
-    )
-    def get[F[_]: Monad](session: CassandraSession[F], key: KafkaKey): F[BoundStatement] =
-      get(session, key, DefaultTableName)
-
-    def get[F[_]: Monad](session: CassandraSession[F], key: KafkaKey, tableName: String): F[BoundStatement] =
+    def prepareGet[F[_]](session: CassandraSession[F], tableName: String): F[PreparedStatement] =
       session
-        .prepare(
-          s"""
-          |SELECT
-          |  offset,
-          |  created,
-          |  timestamp,
-          |  timestamp_type,
-          |  headers,
-          |  metadata,
-          |  value
-          |FROM
-          |  $tableName
-          |WHERE
-          |  application_id = :application_id
-          |  AND group_id = :group_id
-          |  AND topic = :topic
-          |  AND partition = :partition
-          |  AND key = :key
-          |ORDER BY offset
-      """.stripMargin
-        )
-        .map(
-          _.bind()
-            .encode("application_id", key.applicationId)
-            .encode("group_id", key.groupId)
-            .encode("topic", key.topicPartition.topic)
-            .encode("partition", key.topicPartition.partition)
-            .encode("key", key.key)
-        )
+        .prepare(s"""
+             |SELECT
+             |  offset,
+             |  created,
+             |  timestamp,
+             |  timestamp_type,
+             |  headers,
+             |  metadata,
+             |  value
+             |FROM
+             |  $tableName
+             |WHERE
+             |  application_id = :application_id
+             |  AND group_id = :group_id
+             |  AND topic = :topic
+             |  AND partition = :partition
+             |  AND key = :key
+             |ORDER BY offset
+      """.stripMargin)
 
-    @deprecated(
-      "Use the version with an explicit table name and TTL. This exists to preserve binary compatibility until the next major release",
-      since = "6.1.3"
-    )
-    def persist[F[_]: MonadThrow: Clock](
-      session: CassandraSession[F],
-      key: KafkaKey,
-      event: ConsumerRecord[String, ByteVector],
-    ): F[BoundStatement] = persist(session, key, event, DefaultTableName, None)
+    def bindGet(statement: PreparedStatement, key: KafkaKey): BoundStatement =
+      statement
+        .bind()
+        .encode("application_id", key.applicationId)
+        .encode("group_id", key.groupId)
+        .encode("topic", key.topicPartition.topic)
+        .encode("partition", key.topicPartition.partition)
+        .encode("key", key.key)
 
-    def persist[F[_]: MonadThrow: Clock](
+    def preparePersist[F[_]](
       session: CassandraSession[F],
-      key: KafkaKey,
-      event: ConsumerRecord[String, ByteVector],
       tableName: String,
       ttl: Option[FiniteDuration],
-    ): F[BoundStatement] = for {
-      preparedStatement <- session.prepare(
+    ): F[PreparedStatement] =
+      session.prepare(
         s"""
-        |UPDATE
-        |  $tableName
-        |  ${StatementHelper.ttlFragment(ttl)}
-        |SET
-        |  created = :created,
-        |  timestamp = :timestamp,
-        |  timestamp_type = :timestamp_type,
-        |  headers = :headers,
-        |  metadata = :metadata,
-        |  value = :value
-        |WHERE
-        |  application_id = :application_id
-        |  AND group_id = :group_id
-        |  AND topic = :topic
-        |  AND partition = :partition
-        |  AND key = :key
-        |  AND offset = :offset
+           |UPDATE
+           |  $tableName
+           |  ${StatementHelper.ttlFragment(ttl)}
+           |SET
+           |  created = :created,
+           |  timestamp = :timestamp,
+           |  timestamp_type = :timestamp_type,
+           |  headers = :headers,
+           |  metadata = :metadata,
+           |  value = :value
+           |WHERE
+           |  application_id = :application_id
+           |  AND group_id = :group_id
+           |  AND topic = :topic
+           |  AND partition = :partition
+           |  AND key = :key
+           |  AND offset = :offset
         """.stripMargin
       )
 
+    def bindPersist[F[_]: MonadThrow: Clock](
+      statement: PreparedStatement,
+      key: KafkaKey,
+      event: ConsumerRecord[String, ByteVector],
+    ): F[BoundStatement] = for {
       headers <- event.headers traverse HeaderToTuple.convert[F]
       created <- Clock[F].instant
     } yield {
-      preparedStatement
+      statement
         .bind()
         .encode("application_id", key.applicationId)
         .encode("group_id", key.groupId)
@@ -226,34 +182,28 @@ object CassandraJournals {
         .encodeSome("value", event.value map (_.value))
     }
 
-    @deprecated(
-      "Use the version with an explicit table name. This exists to preserve binary compatibility until the next major release",
-      since = "6.1.3"
-    )
-    def delete[F[_]: Monad](session: CassandraSession[F], key: KafkaKey): F[BoundStatement] =
-      delete(session, key, DefaultTableName)
-
-    def delete[F[_]: Monad](session: CassandraSession[F], key: KafkaKey, tableName: String): F[BoundStatement] =
+    def prepareDelete[F[_]](session: CassandraSession[F], tableName: String): F[PreparedStatement] =
       session
         .prepare(
           s"""
-          |DELETE FROM
-          |  $tableName
-          |WHERE
-          |  application_id = :application_id
-          |  AND group_id = :group_id
-          |  AND topic = :topic
-          |  AND partition = :partition
-          |  AND key = :key
+             |DELETE FROM
+             |  $tableName
+             |WHERE
+             |  application_id = :application_id
+             |  AND group_id = :group_id
+             |  AND topic = :topic
+             |  AND partition = :partition
+             |  AND key = :key
         """.stripMargin
         )
-        .map(
-          _.bind()
-            .encode("application_id", key.applicationId)
-            .encode("group_id", key.groupId)
-            .encode("topic", key.topicPartition.topic)
-            .encode("partition", key.topicPartition.partition)
-            .encode("key", key.key)
-        )
+
+    def bindDelete(statement: PreparedStatement, key: KafkaKey): BoundStatement =
+      statement
+        .bind()
+        .encode("application_id", key.applicationId)
+        .encode("group_id", key.groupId)
+        .encode("topic", key.topicPartition.topic)
+        .encode("partition", key.topicPartition.partition)
+        .encode("key", key.key)
   }
 }


### PR DESCRIPTION
Same as https://github.com/evolution-gaming/kafka-flow/pull/736 but for `CassandraJournals`