### PR TITLE
Initialize buffers with state after it was read from persistence

### DIFF
--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/persistence/Persistence.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/persistence/Persistence.scala
@@ -38,6 +38,13 @@ trait Buffers[F[_], S, E] extends WriteToBuffers[F, S, E] {
     */
   def delete(persist: Boolean): F[Unit]
 
+  /** Initialize an already persisted state, used to store a state in buffers that was fetched from the database.
+    *
+    * It won't be saved to the database when `flush` is called unless replaced by `replaceState` with the next state
+    * before `flush`.
+    */
+  def initPersistedState(state: S): F[Unit]
+
 }
 trait WriteToBuffers[F[_], S, E] {
 
@@ -122,8 +129,8 @@ object Persistence {
     }
 
     def read = readState.read flatTap { state =>
-      state traverse_ { _ =>
-        Timestamps[F].onPersisted
+      state traverse_ { state =>
+        Timestamps[F].onPersisted *> buffers.initPersistedState(state)
       }
     }
 
@@ -133,11 +140,12 @@ object Persistence {
 object Buffers {
 
   def empty[F[_]: Applicative, S, E]: Buffers[F, S, E] = new Buffers[F, S, E] {
-    def appendEvent(event: E)    = ().pure[F]
-    def replaceState(state: S)   = ().pure[F]
-    def flushKeys                = ().pure[F]
-    def flushState               = ().pure[F]
-    def delete(persist: Boolean) = ().pure[F]
+    def appendEvent(event: E)        = ().pure[F]
+    def replaceState(state: S)       = ().pure[F]
+    def initPersistedState(state: S) = ().pure[F]
+    def flushKeys                    = ().pure[F]
+    def flushState                   = ().pure[F]
+    def delete(persist: Boolean)     = ().pure[F]
   }
 
   def apply[F[_]: Monad, S, E](
@@ -149,6 +157,8 @@ object Buffers {
     def appendEvent(event: E) = journals.append(event)
 
     def replaceState(state: S) = snapshots.append(state)
+
+    def initPersistedState(state: S) = snapshots.initPersisted(state)
 
     def delete(persist: Boolean) =
       snapshots.delete(persist) *> journals.delete(persist) *> keys.delete(persist)

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/Snapshots.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/Snapshots.scala
@@ -28,6 +28,13 @@ trait SnapshotWriter[F[_], S] {
     */
   def append(snapshot: S): F[Unit]
 
+  /** Saves the initial snapshot to a buffer.
+    *
+    * The snapshot is stored in the buffer as already persisted. This means that on the next flush, it will not be
+    * persisted again, but only when it is replaced using `append`.
+    */
+  def initPersisted(snapshot: S): F[Unit]
+
   /** Flushes buffer to a database */
   def flush: F[Unit]
 
@@ -64,6 +71,10 @@ object Snapshots {
       }
     }
 
+    def initPersisted(snapshot: S) = {
+      buffer.set(Snapshot.initPersisted(snapshot).some)
+    }
+
     def flush = {
       for {
         snapshot <- buffer.get
@@ -92,6 +103,7 @@ object Snapshots {
   def empty[F[_]: Applicative, S]: Snapshots[F, S] = new Snapshots[F, S] {
     def read                     = none[S].pure[F]
     def append(event: S)         = ().pure[F]
+    def initPersisted(event: S)  = ().pure[F]
     def flush                    = ().pure[F]
     def delete(persist: Boolean) = ().pure[F]
   }
@@ -103,7 +115,8 @@ object Snapshots {
   }
 
   object Snapshot {
-    def init[S](value: S): Snapshot[S] = Snapshot(value, persisted = false)
+    def init[S](value: S): Snapshot[S]          = Snapshot(value, persisted = false)
+    def initPersisted[S](value: S): Snapshot[S] = Snapshot(value, persisted = true)
   }
 
 }

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/persistence/PersistenceSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/persistence/PersistenceSpec.scala
@@ -84,6 +84,18 @@ class PersistenceSpec extends FunSuite {
     assert(!context.deleteCalled)
   }
 
+  test("state is initialized in buffers when it is read from the database") {
+    val f = new ConstFixture(state = Some(1))
+
+    // Given("a state is read from persistence")
+    val program = f.persistence.read
+
+    // When("program is run")
+    val context = program.runS(Context()).value
+
+    // Then("state is initialized in the buffers")
+    assert(context.initializedState.contains(1))
+  }
 }
 object PersistenceSpec {
 
@@ -96,7 +108,8 @@ object PersistenceSpec {
         offset    = Offset.min
       )
     ),
-    deleteCalled: Boolean = false
+    deleteCalled: Boolean         = false,
+    initializedState: Option[Int] = None
   )
 
   class ConstFixture(state: Option[Int] = None) {
@@ -104,6 +117,9 @@ object PersistenceSpec {
     val buffers: Buffers[F, Int, String] = new Buffers[F, Int, String] {
       def appendEvent(event: String) = ().pure[F]
       def replaceState(state: Int)   = ().pure[F]
+      def initPersistedState(state: Int) = State.modify { context =>
+        context.copy(initializedState = state.some)
+      }
       def delete(persist: Boolean) = State.modify { context =>
         context.copy(deleteCalled = persist)
       }

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotsSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotsSpec.scala
@@ -126,6 +126,26 @@ class SnapshotsSpec extends FunSuite {
     assert(database.persistsCounted == 1)
   }
 
+  test("Snapshots does not persist snapshots when it was initialized from persistence") {
+
+    val f = new ConstFixture
+
+    // Given("database without contents")
+    val database  = countingSnapshotDb(f.database)
+    val snapshots = Snapshots("key1", database, f.buffer)
+    val context = Context(
+      database = Map.empty,
+      buffer   = None
+    )
+
+    // When("snapshot is initialized and flush is requested")
+    val program = snapshots.initPersisted(100) *> snapshots.flush
+    program.runS(context).value
+
+    // Then("state is not persisted")
+    assert(database.persistsCounted == 0)
+  }
+
 }
 
 object SnapshotsSpec {


### PR DESCRIPTION
This change ensures that persistence buffers are populated with the initial state read from the database.

Before this change, upon calling `flush`, the state would always be written to the database after it was read, even when there were no changes. This resulted in many write operations immediately after recovering, when an application has a lot of state.