### PR TITLE
Protect Kafka snapshot writes from stale writers (transactional offset binding)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -148,7 +148,8 @@ lazy val `persistence-kafka` = (project in file("persistence-kafka"))
   .settings(
     name := "kafka-flow-persistence-kafka",
     libraryDependencies ++= Seq(
-      Testing.munit % Test,
+      Cats.effectTestkit % Test,
+      Testing.munit      % Test,
     ),
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -147,6 +147,9 @@ lazy val `persistence-kafka` = (project in file("persistence-kafka"))
   .settings(commonSettings)
   .settings(
     name := "kafka-flow-persistence-kafka",
+    libraryDependencies ++= Seq(
+      Testing.munit % Test,
+    ),
   )
 
 lazy val `persistence-kafka-it-tests` = (project in file("persistence-kafka-it-tests"))

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/PartitionFlow.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/PartitionFlow.scala
@@ -280,6 +280,8 @@ object PartitionFlow {
 
         _ <- log.debug(s"offset to commit: ${offsetToCommit.show}")
 
+        // not error-handled like the revoke path below: in transactional mode a fenced periodic commit
+        // (CommitFailedException) must crash the stale instance - that is the fencing
         _ <- offsetToCommit.traverse_(offset => scheduleCommit.schedule(offset))
 
         _ <- log.debug("done with commits")
@@ -326,7 +328,12 @@ object PartitionFlow {
       offsetsHeldByCurrentKeys.flatMap { getMinOffsets =>
         cache.clear.flatten *> offsetToCommit(getMinOffsets).flatMap { offset =>
           offset.traverse_ { offset =>
-            log.info(s"committing on revoke: $offset") *> scheduleCommit.schedule(offset)
+            log.info(s"committing on revoke: $offset") *>
+              // best-effort: a transactional ScheduleCommit can fail here (e.g. fenced), but the partition is being
+              // given away anyway (the new owner replays) and the error must not escape into the rebalance callback
+              scheduleCommit
+                .schedule(offset)
+                .handleErrorWith(e => log.warn(s"committing on revoke failed for offset $offset, ignoring: $e"))
           }
         }
       }

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/PartitionFlowConfig.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/PartitionFlowConfig.scala
@@ -46,7 +46,8 @@ import scala.concurrent.duration.*
   *     fibers to prevent CPU starvation and overwhelming the underlying storage with too many parallel executions.
   *
   * @param commitOnRevoke
-  *   Try committing everything when partition is revoked.
+  *   On revoke, try committing the partition's offset (the minimum held offset) so the next owner reprocesses fewer
+  *   events on handoff.
   */
 case class PartitionFlowConfig(
   triggerTimersInterval: FiniteDuration         = 1.second,

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/TopicFlow.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/TopicFlow.scala
@@ -111,6 +111,8 @@ object TopicFlow {
         // and after it was fixed a next issue was discovered
         // pendingCommits map is not updated on release of key/timer flows, it only persists the state
         // see https://github.com/evolution-gaming/kafka-flow/issues/256 for more details
+        // note: this is the default (consumer-commit) path only; the transactional snapshot mode commits on revoke
+        // through the producer (its own ScheduleCommit), not through this path
         val topicPartitions = partitions map (TopicPartition(topic, _))
         val removeOffsets   = pendingCommits.remove(topicPartitions)
 

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/kafka/Consumer.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/kafka/Consumer.scala
@@ -2,7 +2,7 @@ package com.evolutiongaming.kafka.flow.kafka
 
 import cats.MonadThrow
 import cats.data.{NonEmptyList, NonEmptyMap, NonEmptySet}
-import cats.effect.Ref
+import cats.effect.{Ref, Sync}
 import cats.syntax.all.*
 import com.evolutiongaming.skafka.*
 import com.evolutiongaming.skafka.consumer.{Consumer => KafkaConsumer, _}
@@ -24,24 +24,51 @@ trait Consumer[F[_]] {
 
   def commit(offsets: NonEmptyMap[TopicPartition, OffsetAndMetadata]): F[Unit]
 
+  /** Last consumer group metadata observed on a rebalance, used to fence a stale owner by generation when binding
+    * offset commits into a producer transaction (KIP-447). `None` until the consumer has joined a group.
+    */
+  def groupMetadata: F[Option[ConsumerGroupMetadata]]
+
 }
 object Consumer {
 
   def apply[F[_]](implicit F: Consumer[F]): Consumer[F] = F
 
-  def apply[F[_]](
+  def of[F[_]: Sync](
     consumer: KafkaConsumer[F, String, ByteVector]
-  ): Consumer[F] = new Consumer[F] {
-    def subscribe(topics: NonEmptySet[Topic], listener: RebalanceListener1[F]): F[Unit] =
-      consumer.subscribe(topics, listener)
+  ): F[Consumer[F]] =
+    // capture the group metadata on assignment (on the poll thread, where it is safe to read) into a Ref so the
+    // transactional snapshot writer can read the current generation off-thread; None until the first assignment
+    Ref[F].of(none[ConsumerGroupMetadata]).map { groupMetadataRef =>
+      new Consumer[F] {
+        def subscribe(topics: NonEmptySet[Topic], listener: RebalanceListener1[F]): F[Unit] = {
+          val capturing = new RebalanceListener1WithConsumer[F] {
+            import com.evolutiongaming.skafka.consumer.RebalanceCallback.syntax.*
+            // capture before the listener: assignment establishes the generation the listener (recovery, then every
+            // later flush) is gated by, and on a freshly assigned consumer groupMetadata cannot fail
+            private def capture: RebalanceCallback[F, Unit] =
+              this.consumer.groupMetadata.flatMap(meta => groupMetadataRef.set(meta.some).lift)
+            def onPartitionsAssigned(partitions: NonEmptySet[TopicPartition]): RebalanceCallback[F, Unit] =
+              capture *> listener.onPartitionsAssigned(partitions)
+            // revoke/lost just delegate: the generation is unchanged until the next assignment (which re-captures), and
+            // a capture failure here could suppress the wrapped listener's flush/commit-on-revoke
+            def onPartitionsRevoked(partitions: NonEmptySet[TopicPartition]): RebalanceCallback[F, Unit] =
+              listener.onPartitionsRevoked(partitions)
+            def onPartitionsLost(partitions: NonEmptySet[TopicPartition]): RebalanceCallback[F, Unit] =
+              listener.onPartitionsLost(partitions)
+          }
+          consumer.subscribe(topics, capturing)
+        }
 
-    def poll(timeout: FiniteDuration): F[ConsumerRecords[String, ByteVector]] =
-      consumer.poll(timeout)
+        def poll(timeout: FiniteDuration): F[ConsumerRecords[String, ByteVector]] =
+          consumer.poll(timeout)
 
-    def commit(offsets: NonEmptyMap[TopicPartition, OffsetAndMetadata]): F[Unit] =
-      consumer.commit(offsets)
+        def commit(offsets: NonEmptyMap[TopicPartition, OffsetAndMetadata]): F[Unit] =
+          consumer.commit(offsets)
 
-  }
+        def groupMetadata: F[Option[ConsumerGroupMetadata]] = groupMetadataRef.get
+      }
+    }
 
   /** Does not call Kafka, returns specified records on every poll */
   def repeat[F[_]: MonadThrow: Ref.Make](
@@ -66,6 +93,8 @@ object Consumer {
 
       def commit(offsets: NonEmptyMap[TopicPartition, OffsetAndMetadata]): F[Unit] =
         ().pure[F]
+
+      def groupMetadata: F[Option[ConsumerGroupMetadata]] = none[ConsumerGroupMetadata].pure[F]
     }
   }
 

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/kafka/KafkaModule.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/kafka/KafkaModule.scala
@@ -69,8 +69,8 @@ object KafkaModule {
               autoOffsetReset = AutoOffsetReset.Earliest
             )
           ) evalMap { consumer =>
-            LogOf[F].apply(Consumer.getClass) map { log =>
-              Consumer(consumer.withLogging(log))
+            LogOf[F].apply(Consumer.getClass) flatMap { log =>
+              Consumer.of[F](consumer.withLogging(log))
             }
           }
       }

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/kafka/KafkaModule.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/kafka/KafkaModule.scala
@@ -69,7 +69,7 @@ object KafkaModule {
               autoOffsetReset = AutoOffsetReset.Earliest
             )
           ) evalMap { consumer =>
-            LogOf[F].apply(Consumer.getClass) flatMap { log =>
+            LogOf[F].apply(Consumer.getClass).flatMap { log =>
               Consumer.of[F](consumer.withLogging(log))
             }
           }

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/kafka/ScheduleCommit.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/kafka/ScheduleCommit.scala
@@ -4,6 +4,11 @@ import cats.Applicative
 import cats.effect.Ref
 import com.evolutiongaming.skafka.{Offset, OffsetAndMetadata, Partition, TopicPartition}
 
+/** Schedules an input offset to be committed for a partition. `schedule` is not necessarily a cheap in-memory record:
+  * the default implementations only update a `Ref` and never fail, but the transactional snapshot mode runs it as a
+  * Kafka transaction that performs I/O and can fail (e.g. fenced by a stale generation), so treat it as best-effort on
+  * the revoke path.
+  */
 trait ScheduleCommit[F[_]] {
 
   /** Request ("schedule") an offset to be committed for a partition during the next commit attempt */

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/kafka/ScheduleCommit.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/kafka/ScheduleCommit.scala
@@ -6,8 +6,9 @@ import com.evolutiongaming.skafka.{Offset, OffsetAndMetadata, Partition, TopicPa
 
 /** Schedules an input offset to be committed for a partition. `schedule` is not necessarily a cheap in-memory record:
   * the default implementations only update a `Ref` and never fail, but the transactional snapshot mode runs it as a
-  * Kafka transaction that performs I/O and can fail (e.g. fenced by a stale generation), so treat it as best-effort on
-  * the revoke path.
+  * Kafka transaction that performs I/O and can fail (e.g. fenced by a stale generation). On revoke such a failure is
+  * best-effort (swallowed, since the partition is being handed off anyway); on the periodic path it instead surfaces,
+  * failing the stale instance.
   */
 trait ScheduleCommit[F[_]] {
 

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/ConsumerFlowSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/ConsumerFlowSpec.scala
@@ -157,6 +157,9 @@ object ConsumerFlowSpec {
       }
 
       def commit(offsets: NonEmptyMap[TopicPartition, OffsetAndMetadata]): F[Unit] = ().pure[F]
+
+      def groupMetadata: F[Option[com.evolutiongaming.skafka.consumer.ConsumerGroupMetadata]] =
+        Option.empty[com.evolutiongaming.skafka.consumer.ConsumerGroupMetadata].pure[F]
     }
 
     def flow(topic: String) = new TopicFlow[F] {

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/KafkaFlowSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/KafkaFlowSpec.scala
@@ -201,6 +201,9 @@ object KafkaFlowSpec {
         def commit(offsets: NonEmptyMap[TopicPartition, OffsetAndMetadata]) =
           state update (_ + Action.Commit(offsets))
 
+        def groupMetadata: F[Option[com.evolutiongaming.skafka.consumer.ConsumerGroupMetadata]] =
+          Option.empty[com.evolutiongaming.skafka.consumer.ConsumerGroupMetadata].pure[F]
+
         def revoke(partitions: NonEmptySet[Partition]) =
           state.get flatMap { state =>
             val revoke = state.actions collectFirst {

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/PartitionFlowSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/PartitionFlowSpec.scala
@@ -392,6 +392,34 @@ class PartitionFlowSpec extends FunSuite {
 
   }
 
+  test(
+    "PartitionFlow swallows a failing scheduleCommit on release (commitOnRevoke=true), " +
+      "so a fenced offset commit cannot escape the revoke finalizer"
+  ) {
+    // the transactional ScheduleCommit runs a Kafka transaction that can be fenced on revoke; that failure must be
+    // logged and swallowed (the partition is being given away anyway), never escape into the rebalance callback
+    class LocalFixture extends ConstFixture(waitForN = 100) {
+      val scheduleAttempted: Ref[IO, Boolean] = Ref.unsafe(false)
+      override val scheduleCommit: ScheduleCommit[IO] = new ScheduleCommit[IO] {
+        def schedule(offset: Offset): IO[Unit] =
+          scheduleAttempted.set(true) *> IO.raiseError(new RuntimeException("fenced offset commit on revoke"))
+      }
+    }
+
+    val f = new LocalFixture
+
+    // all keys flush successfully on revoke, so an offset commit is scheduled on release - and it fails
+    val test = for {
+      released  <- f.flow.use(flow => flow(f.records("key1", 100, List("event1", "event2"))).void).attempt
+      attempted <- f.scheduleAttempted.get
+    } yield {
+      assert(clue(attempted), "expected scheduleCommit to be attempted on release")
+      assertEquals(clue(released), Right(()), "a failing scheduleCommit on release must be swallowed")
+    }
+
+    test.unsafeRunSync()
+  }
+
   def setupRemapKeyTest(remapKey: RemapKey[IO], initialData: Map[KafkaKey, String]) = {
     import com.evolutiongaming.kafka.flow.effect.CatsEffectMtlInstances.*
     implicit val logOf: LogOf[IO] = LogOf.empty[IO]

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/PartitionFlowSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/PartitionFlowSpec.scala
@@ -323,7 +323,7 @@ class PartitionFlowSpec extends FunSuite {
   }
 
   test(
-    "PartitionFlow commits latest consumed offset on release when commitOnRevoke=true, " +
+    "PartitionFlow schedules a commit of the latest consumed offset on release when commitOnRevoke=true, " +
       "a TimerFlow with flushOnRevoke=true is used, and all keys successfully persisted their state on release"
   ) {
 
@@ -347,7 +347,7 @@ class PartitionFlowSpec extends FunSuite {
   }
 
   test(
-    "PartitionFlow commits an offset corresponding to the oldest successfully persisted key on release" +
+    "PartitionFlow schedules a commit of the offset corresponding to the oldest successfully persisted key on release" +
       "when commitOnRevoke=true, a TimerFlow with flushOnRevoke=true is used," +
       "and some keys failed to persist their state on release"
   ) {

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/RebalanceListenerSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/RebalanceListenerSpec.scala
@@ -110,6 +110,8 @@ object RebalanceListenerSpec {
       def subscribe(topics: NonEmptySet[Topic], listener: SRebalanceListener[F]): F[Unit] = ().pure[F]
       def poll(timeout: FiniteDuration): F[ConsumerRecords[String, ByteVector]]    = ConsumerRecords.empty.pure[F]
       def commit(offsets: NonEmptyMap[TopicPartition, OffsetAndMetadata]): F[Unit] = ().pure[F]
+      def groupMetadata: F[Option[com.evolutiongaming.skafka.consumer.ConsumerGroupMetadata]] =
+        Option.empty[com.evolutiongaming.skafka.consumer.ConsumerGroupMetadata].pure[F]
     }
 
     def flow(topic: String) = new TopicFlow[F] {

--- a/docs/kafka-single-writer-design.md
+++ b/docs/kafka-single-writer-design.md
@@ -1,0 +1,184 @@
+---
+id: kafka-single-writer-design
+title: Kafka single-writer design
+sidebar_label: Kafka single-writer design
+---
+
+Design notes for the transactional snapshot mode of `kafka-flow-persistence-kafka`
+(`KafkaPersistenceModuleOf.cachingTransactional`). User-facing guarantees, costs and rollout
+guidance are in [Persistence](persistence.md#protecting-against-stale-snapshot-writes); this page
+records the mechanism and the measurements behind it.
+
+## Problem
+
+[kafka-flow#732](https://github.com/evolution-gaming/kafka-flow/issues/732): consumer-group
+ownership of the input topic does not extend to the snapshot topic. During a rebalance a previous
+owner that has not yet observed the revocation (network issue, GC pause, slow poll loop) keeps
+writing snapshots alongside the new owner. The snapshot topic is compacted (last-write-wins), so a
+stale snapshot can overwrite a newer one; the next recovery then loads stale state and loses the
+events between the two snapshots, even though their input offsets were committed. Overlaps of tens
+of seconds have been observed in production.
+
+```mermaid
+sequenceDiagram
+    participant A as Owner A<br/>(previous)
+    participant ST as Snapshot topic<br/>(compacted: last-write-wins)
+    participant B as Owner B<br/>(new)
+
+    Note over A: folds input up to offset 100,<br/>state buffered, not yet flushed
+    Note over A,B: rebalance — partition revoked from A and assigned to B,<br/>but A has not observed it yet
+    B->>ST: recover: read to end (no newer snapshot)
+    B->>B: fold input up to offset 150
+    B->>ST: write snapshot @150 ✓
+    A-->>ST: flush buffered snapshot @100<br/>(stale: A no longer owns the partition)
+    Note over ST: last write wins — @100 overwrites @150
+    Note over ST,B: next recovery loads @100<br/>(events 101 to 150 lost)
+```
+
+## Mechanism: generation fencing
+
+The input-offset commit moves out of the consumer and **into the snapshot producer's transaction**
+via `sendOffsetsToTransaction(offsets, consumerGroupMetadata)` (KIP-447): the group coordinator
+validates the consumer **generation** and rejects a commit from a stale one (`ILLEGAL_GENERATION`).
+Since that commit and the snapshot writes share a transaction, the rejection aborts the writes too.
+The generation — authoritative for partition ownership — gates both, so a stale owner can neither
+advance offsets nor overwrite a newer snapshot.
+
+```mermaid
+sequenceDiagram
+    participant B as Stale owner<br/>(old generation)
+    participant TC as Broker<br/>(txn + group coordinator)
+    participant ST as Snapshot topic
+
+    B->>TC: beginTransaction
+    B->>ST: send stale snapshot (buffered in txn)
+    B->>TC: sendOffsetsToTransaction(offset, gen=old)
+    TC-->>B: ILLEGAL_GENERATION (partition reassigned)
+    B->>TC: abort — stale snapshot never committed
+    Note over ST: newer snapshot survives
+```
+
+This is corruption prevention, not exactly-once: output produces stay outside the transaction, so
+output is at-least-once (see [Persistence](persistence.md#protecting-against-stale-snapshot-writes) non-goals). The
+committed offset is the minimum held offset, always behind durable state, so it can never outrun the
+snapshots on disk even though offset and writes may land in different transactions.
+
+Key points:
+
+- **Every** transaction carries the partition's committable offset, so every write is gated. A
+  `ScheduleCommit` forces an offset-only transaction so progress and the on-revoke offset commit
+  even with no writes pending.
+- The offset-to-commit is **seeded with the assigned offset**, so even the first flush (before the
+  first commit tick) is gated. Committing `assignedAt` is a no-op.
+- Recovery is forced to `read_committed` so a fenced writer's aborted records are invisible.
+- The partition is never `consumer.commit`-ed in this mode; offsets only commit through the producer.
+
+Wiring needs the input topic and a reader of the driving consumer's group metadata
+(`Consumer.groupMetadata`, captured on each rebalance on the poll thread). A fence surfaces as
+`CommitFailedException` on the failing `persist` / `scheduleCommit`.
+
+### No epoch fencing
+
+Generation fencing is the sole mechanism; there is deliberately no producer-epoch fencing. Each
+producer gets a unique `transactional.id` (`"{prefix}-{partition}-{uuid8}"`), so old and new owners
+never share one. A *stable* per-partition id would add cross-owner epoch fencing, which is both
+redundant and harmful: the epoch is assigned in `initTransactions` arrival order, not assignment
+order, so a slow stale owner that inits late wins the epoch and would false-positive-fence the true
+owner. The cost of unique ids — transaction-coordinator state expiring via
+`transactional.id.expiration.ms` — is accepted. A hard-crashed owner's in-flight transaction is, for
+the same reason, not fenced on the spot (a stable id would abort it through the new owner's
+`initTransactions`); the coordinator reclaims it only after `transaction.timeout.ms`, which bounds how
+long a `read_committed` reader (recovery, or a downstream consumer) can stall behind its
+last-stable-offset.
+
+## Write path: group-committed transactions
+
+A producer allows one transaction at a time, while kafka-flow flushes a partition's keys in
+parallel — and after a restart most of the active key population flushes in one wave per
+`persistEvery`. Writes are therefore **group committed**: a write is queued, and the first writer to
+take the per-partition transaction lock drains what is queued at that moment — up to the cap below —
+into a single transaction and delivers the outcome to each waiter. No batching delay — a lone write commits
+immediately; a batch is whatever accumulated during the previous transaction's flight.
+
+`maxWritesPerTransaction` (default 256) bounds a transaction's duration below
+`transaction.timeout.ms` (default 1 min), past which the coordinator aborts it. It is not a
+throughput knob: uncapped is ~7% faster (below), so never raise it for speed. Transaction bytes ≈
+cap × snapshot size; lower it for large snapshots.
+
+`persist` does not complete until its transaction commits, and the flush awaits each `persist`, so
+the source is back-pressured: the `pending` queue holds at most the keys flushing in one wave. If a
+partition produces writes faster than `cap / transaction-time` drains, the symptom is rising flush
+latency and lag, not unbounded memory — the remedy is more partitions.
+
+## Measurements
+
+From `TransactionalWriteThroughputSpec`: single-node testcontainers broker on localhost, replication
+factor 1, no network latency — a *floor*; expect a few ms per transaction against real brokers. Each
+number is the min of 3 interleaved runs on a fresh state topic. Read them as orders of magnitude.
+
+**Experiment A** — 500 keys, small snapshots, one partition:
+
+| Mode | Arrival | Result |
+|---|---|---|
+| Shared batched producer (default, no transactions) | sequential | 197 ms |
+| Group-committed transactions | sequential | 879 ms (500 txns, ~1.8 ms/txn) |
+| Group-committed transactions | concurrent burst | 13 ms (a few batches) |
+
+The lower two rows are the same group commit — only arrival differs. Sequentially every write is a
+batch of one; concurrently (the real flush pattern) writes collapse into a few large batches, below
+even the non-transactional producer.
+
+**Experiment B** — 2000 keys, 10 KiB snapshots, all flushed concurrently (the post-restart wave).
+The cap bounds writes per transaction, so for `N` keys it is ≈ the transaction count (`N / cap`):
+
+| Configuration | ≈ transactions | Result |
+|---|---|---|
+| Shared batched producer (baseline) | — | 282 ms |
+| `maxWritesPerTransaction = 1` | 2000 | 4 002 ms |
+| `maxWritesPerTransaction = 16` | 125 | 513 ms |
+| `maxWritesPerTransaction = 256` (default) | ≈ 8 | 300 ms |
+| `maxWritesPerTransaction = 2000` (uncapped) | 1 | 279 ms |
+
+Cost tracks the transaction count until Kafka's network batching floors it (~280–300 ms). At the
+default cap the transactional burst is within ~6% of the baseline; without the group commit
+(cap = 1) it is an order of magnitude slower, with multi-second poll-path stalls at realistic key
+counts.
+
+Reproduce: `KAFKA_FLOW_PERF=1 sbt "persistence-kafka-it-tests/testOnly *TransactionalWriteThroughputSpec"`
+(the suite is excluded from the default run).
+
+## Testing
+
+Integration tests (persistence-kafka-it-tests) run through the real PartitionFlow / eager-recovery /
+flush-on-revoke machinery: the reproduction asserts corruption with the plain shared producer; the
+prevention drives a stale owner with an *older consumer generation* and asserts the newer snapshot
+survives. The paired non-transactional reproduction (the plain shared producer, no offset binding)
+shows the corruption, isolating the binding as the cause rather than incidental fencing. Other pins:
+first-flush gating (the seed), fenced writer fails its next flush, an open transaction neither blocks
+nor leaks into recovery, concurrent-write safety. The group-commit machinery is also exercised in
+isolation by a unit test with a recording in-memory producer (no broker).
+
+## Rejected alternatives
+
+- **Cassandra-style compare-and-set**: no conditional produce on a Kafka topic.
+- **Transaction per write**: correct but O(keys) round-trips on the poll path (cap = 1 above).
+- **Unbounded batches**: ~7% faster, but transaction duration then scales unbounded against the
+  coordinator timeout.
+- **Producer-epoch fencing (stable `transactional.id`)**: epoch order can diverge from ownership
+  order, so it does not fully close #732 and can false-positive-fence the true owner (above).
+- **Transactional output produces (full exactly-once)**: out of scope; output stays at-least-once.
+- **Static partition assignment** (`assign()` instead of `subscribe()`): no consumer group, no
+  rebalance, so no overlap window and no fence needed — the workaround [#732](https://github.com/evolution-gaming/kafka-flow/issues/732)
+  itself names. Rejected because it gives up automatic failover and elastic reassignment; letting
+  users keep dynamic assignment *safely* is the point of this design. (Static *membership* (KIP-345)
+  is not an alternative here: it suppresses rebalances only for graceful restarts within
+  `session.timeout.ms`, and does not fence a stuck owner whose session expired.)
+
+## Forward-looking
+
+[KIP-939 (participation in 2PC)](https://cwiki.apache.org/confluence/display/KAFKA/KIP-939:+Support+Participation+in+2PC)
+is the route to extend this fence to non-Kafka snapshot stores: a transactional producer in an
+externally-coordinated two-phase commit could bind a Cassandra/RDBMS snapshot write to the same
+generation-fenced Kafka offset commit, giving those backends the per-partition ownership guarantee
+this mode has — without the per-key compare-and-set the Cassandra backend uses today. Not actionable
+now; tracked as the convergence point for the two persistence backends.

--- a/docs/kafka-single-writer-design.md
+++ b/docs/kafka-single-writer-design.md
@@ -105,19 +105,21 @@ last-stable-offset.
 A producer allows one transaction at a time, while kafka-flow flushes a partition's keys in
 parallel — and after a restart most of the active key population flushes in one wave per
 `persistEvery`. Writes are therefore **group committed**: a write is queued, and the first writer to
-take the per-partition transaction lock drains what is queued at that moment — up to the cap below —
-into a single transaction and delivers the outcome to each waiter. No batching delay — a lone write commits
-immediately; a batch is whatever accumulated during the previous transaction's flight.
+take the per-partition transaction lock drains the queued writes at that moment — up to the cap below —
+into a single transaction (offset commits ride along without consuming the cap) and delivers the outcome
+to each waiter. No batching delay — a lone write commits immediately; a batch is whatever accumulated
+during the previous transaction's flight.
 
-`maxWritesPerTransaction` (default 256) bounds a transaction's duration below
-`transaction.timeout.ms` (default 1 min), past which the coordinator aborts it. It is not a throughput
-knob: uncapped measured ~7% faster (below), so estimated no need to raise it for speed. Transaction bytes
-≈ cap × snapshot size.
+`maxWritesPerTransaction` (default 256) caps the batch. Transactions are serial — the next cannot
+begin until the current commits — so a partition's sustained write rate ≈ cap / transaction time.
+Raising the cap past the default gains little (uncapped measured ~7% faster, below): transaction time
+grows with the batch. The cap's job is to bound transaction duration (commit within
+`transaction.timeout.ms`, default 1 min) and bytes (≈ cap × snapshot size).
 
 A snapshot write does not complete until its transaction commits, and the flush awaits each write, so
 the source is back-pressured: the in-flight queue holds at most the keys flushing in one wave, bounding
-memory rather than letting it grow without limit. A partition that sustains writes faster than
-`cap / transaction-time` drains shows up as rising flush latency and lag.
+memory rather than letting it grow without limit. Sustaining writes above that rate surfaces as rising
+flush latency and lag.
 
 ## Implementation
 

--- a/docs/kafka-single-writer-design.md
+++ b/docs/kafka-single-writer-design.md
@@ -30,16 +30,22 @@ sequenceDiagram
     B->>ST: recover: read to end (no newer snapshot)
     B->>B: fold input up to offset 150
     B->>ST: write snapshot @150 ✓
+    Note over B: commit input offset 150
     A-->>ST: flush buffered snapshot @100<br/>(stale: A no longer owns the partition)
     Note over ST: last write wins — @100 overwrites @150
-    Note over ST,B: next recovery loads @100<br/>(events 101 to 150 lost)
+    Note over ST,B: next recovery resumes from committed offset 150<br/>but loads snapshot @100 — events 101 to 150 never replayed (lost)
 ```
 
 ## Mechanism: generation fencing
 
-The input-offset commit moves out of the consumer and **into the snapshot producer's transaction**
-via `sendOffsetsToTransaction(offsets, consumerGroupMetadata)` (KIP-447): the group coordinator
-validates the consumer **generation** and rejects a commit from a stale one (`ILLEGAL_GENERATION`).
+Normally kafka-flow commits input offsets through the **consumer**: `TopicFlow` collects the
+per-partition offsets the flow scheduled and issues a `consumer.commit`. In this mode that commit is
+performed by the snapshot producer instead: the consumer commit path is left a no-op, and the offset
+moves **into the producer's transaction** via
+`sendOffsetsToTransaction(offsets, consumerGroupMetadata)`
+([KIP-447](https://cwiki.apache.org/confluence/display/KAFKA/KIP-447%3A+Producer+scalability+for+exactly+once+semantics)):
+the group coordinator validates the consumer **generation** and rejects a commit from a stale one
+(`ILLEGAL_GENERATION`).
 Since that commit and the snapshot writes share a transaction, the rejection aborts the writes too.
 The generation — authoritative for partition ownership — gates both, so a stale owner can neither
 advance offsets nor overwrite a newer snapshot.
@@ -58,16 +64,19 @@ sequenceDiagram
     Note over ST: newer snapshot survives
 ```
 
-This is corruption prevention, not exactly-once: output produces stay outside the transaction, so
-output is at-least-once (see [Persistence](persistence.md#protecting-against-stale-snapshot-writes) non-goals). The
+This is corruption prevention, not exactly-once. Output produces go through the application's own
+producer, and the transaction wraps only the snapshot write and the offset commit, so they stay outside
+it — enrolling them would be full transactional output, an explicit non-goal (see Rejected alternatives).
+Output is therefore at-least-once: a replayed batch re-emits it, so the consuming side must tolerate
+duplicates (see [Persistence](persistence.md#protecting-against-stale-snapshot-writes) non-goals). The
 committed offset is the minimum held offset, always behind durable state, so it can never outrun the
 snapshots on disk even though offset and writes may land in different transactions.
 
 Key points:
 
-- **Every** transaction carries the partition's committable offset, so every write is gated. A
-  `ScheduleCommit` forces an offset-only transaction so progress and the on-revoke offset commit
-  even with no writes pending.
+- **Every** transaction carries the partition's committable offset, so every write is gated. When the
+  committed offset needs to advance but no snapshot writes are pending — a periodic commit tick, or a
+  revoke — `ScheduleCommit` forces an *offset-only* transaction so the offset still moves.
 - The offset-to-commit is **seeded with the assigned offset**, so even the first flush (before the
   first commit tick) is gated. Committing `assignedAt` is a no-op.
 - Recovery is forced to `read_committed` so a fenced writer's aborted records are invisible.

--- a/docs/kafka-single-writer-design.md
+++ b/docs/kafka-single-writer-design.md
@@ -5,9 +5,7 @@ sidebar_label: Kafka single-writer design
 ---
 
 Design notes for the transactional snapshot mode of `kafka-flow-persistence-kafka`
-(`KafkaPersistenceModuleOf.cachingTransactional`). User-facing guarantees, costs and rollout
-guidance are in [Persistence](persistence.md#protecting-against-stale-snapshot-writes); this page
-records the mechanism and the measurements behind it.
+(`KafkaPersistenceModuleOf.cachingTransactional`) — the mechanism and the measurements behind it.
 
 ## Problem
 
@@ -22,26 +20,25 @@ of seconds have been observed in production.
 ```mermaid
 sequenceDiagram
     participant A as Owner A<br/>(previous)
-    participant ST as Snapshot topic<br/>(compacted: last-write-wins)
+    participant ST as Snapshot topic<br/>(compacted)
     participant B as Owner B<br/>(new)
 
-    Note over A: folds input up to offset 100,<br/>state buffered, not yet flushed
-    Note over A,B: rebalance — partition revoked from A and assigned to B,<br/>but A has not observed it yet
-    B->>ST: recover: read to end (no newer snapshot)
-    B->>B: fold input up to offset 150
+    Note over A: folds input to offset 100,<br/>state buffered, not flushed
+    Note over A,B: rebalance: partition revoked from A<br/>and assigned to B — but A<br/>has not observed it yet
+    B->>ST: recover: read to end<br/>(no newer snapshot)
+    B->>B: fold input to offset 150
     B->>ST: write snapshot @150 ✓
     Note over B: commit input offset 150
-    A-->>ST: flush buffered snapshot @100<br/>(stale: A no longer owns the partition)
-    Note over ST: last write wins — @100 overwrites @150
-    Note over ST,B: next recovery resumes from committed offset 150<br/>but loads snapshot @100 — events 101 to 150 never replayed (lost)
+    A-->>ST: flush buffered snapshot @100<br/>(stale: A no longer owns it)
+    Note over ST: last write wins:<br/>@100 overwrites @150
+    Note over ST,B: next recovery resumes at offset 150<br/>but loads snapshot @100 —<br/>events 101 to 150 never replayed (lost)
 ```
 
 ## Mechanism: generation fencing
 
-Normally kafka-flow commits input offsets through the **consumer**: `TopicFlow` collects the
-per-partition offsets the flow scheduled and issues a `consumer.commit`. In this mode that commit is
-performed by the snapshot producer instead: the consumer commit path is left a no-op, and the offset
-moves **into the producer's transaction** via
+Normally the input offsets are committed through the **Kafka consumer** (the ordinary consumer-group
+offset commit). In this mode they are committed through the snapshot **producer** instead, with the
+consumer-side commit disabled — the offset moves **into the producer's transaction** via
 `sendOffsetsToTransaction(offsets, consumerGroupMetadata)`
 ([KIP-447](https://cwiki.apache.org/confluence/display/KAFKA/KIP-447%3A+Producer+scalability+for+exactly+once+semantics)):
 the group coordinator validates the consumer **generation** and rejects a commit from a stale one
@@ -68,23 +65,26 @@ This is corruption prevention, not exactly-once. Output produces go through the 
 producer, and the transaction wraps only the snapshot write and the offset commit, so they stay outside
 it — enrolling them would be full transactional output, an explicit non-goal (see Rejected alternatives).
 Output is therefore at-least-once: a replayed batch re-emits it, so the consuming side must tolerate
-duplicates (see [Persistence](persistence.md#protecting-against-stale-snapshot-writes) non-goals). The
-committed offset is the minimum held offset, always behind durable state, so it can never outrun the
-snapshots on disk even though offset and writes may land in different transactions.
+duplicates. The committed offset is the minimum held offset, always behind durable state, so it can
+never outrun the snapshots on disk even though offset and writes may land in different transactions.
 
 Key points:
 
 - **Every** transaction carries the partition's committable offset, so every write is gated. When the
   committed offset needs to advance but no snapshot writes are pending — a periodic commit tick, or a
-  revoke — `ScheduleCommit` forces an *offset-only* transaction so the offset still moves.
+  revoke — an *offset-only* transaction is forced so the offset still moves.
 - The offset-to-commit is **seeded with the assigned offset**, so even the first flush (before the
-  first commit tick) is gated. Committing `assignedAt` is a no-op.
+  first commit tick) is gated. Committing the assigned offset is a no-op.
 - Recovery is forced to `read_committed` so a fenced writer's aborted records are invisible.
 - The partition is never `consumer.commit`-ed in this mode; offsets only commit through the producer.
+- Both the write and the offset-only commit are **synchronous** — there is no background committer, so
+  the call itself drives the transaction and blocks on its outcome. That blocking is what lets a fence
+  (`CommitFailedException`) propagate into the flow and crash a stale owner, rather than being lost on a
+  fire-and-forget commit thread.
 
 Wiring needs the input topic and a reader of the driving consumer's group metadata
 (`Consumer.groupMetadata`, captured on each rebalance on the poll thread). A fence surfaces as
-`CommitFailedException` on the failing `persist` / `scheduleCommit`.
+`CommitFailedException` on the failing snapshot write (or offset-only commit).
 
 ### No epoch fencing
 
@@ -110,14 +110,24 @@ into a single transaction and delivers the outcome to each waiter. No batching d
 immediately; a batch is whatever accumulated during the previous transaction's flight.
 
 `maxWritesPerTransaction` (default 256) bounds a transaction's duration below
-`transaction.timeout.ms` (default 1 min), past which the coordinator aborts it. It is not a
-throughput knob: uncapped is ~7% faster (below), so never raise it for speed. Transaction bytes ≈
-cap × snapshot size; lower it for large snapshots.
+`transaction.timeout.ms` (default 1 min), past which the coordinator aborts it. It is not a throughput
+knob: uncapped measured ~7% faster (below), so estimated no need to raise it for speed. Transaction bytes
+≈ cap × snapshot size.
 
-`persist` does not complete until its transaction commits, and the flush awaits each `persist`, so
-the source is back-pressured: the `pending` queue holds at most the keys flushing in one wave. If a
-partition produces writes faster than `cap / transaction-time` drains, the symptom is rising flush
-latency and lag, not unbounded memory — the remedy is more partitions.
+A snapshot write does not complete until its transaction commits, and the flush awaits each write, so
+the source is back-pressured: the in-flight queue holds at most the keys flushing in one wave, bounding
+memory rather than letting it grow without limit. A partition that sustains writes faster than
+`cap / transaction-time` drains shows up as rising flush latency and lag.
+
+## Implementation
+
+Entry point: `KafkaPersistenceModuleOf.cachingTransactional`. In the current code:
+
+- **Group-committed transactional writes** — `KafkaSnapshotWriteDatabase.transactional` (the
+  `GroupCommit` machinery); the per-partition transactional producer is built in `KafkaPersistenceModule`.
+- **Offset-only commit** (the forced offset advance when no writes are pending) — `ScheduleCommit`.
+- **Generation capture** on each rebalance — the `Consumer` wrapper, holding `groupMetadata` in a `Ref`
+  read off the poll thread.
 
 ## Measurements
 
@@ -158,14 +168,13 @@ Reproduce: `KAFKA_FLOW_PERF=1 sbt "persistence-kafka-it-tests/testOnly *Transact
 
 ## Testing
 
-Integration tests (persistence-kafka-it-tests) run through the real PartitionFlow / eager-recovery /
-flush-on-revoke machinery: the reproduction asserts corruption with the plain shared producer; the
+Integration tests (`TransactionalKafkaPersistenceSpec`, in persistence-kafka-it-tests) run through the
+real eager-recovery / flush-on-revoke machinery. The reproduction shows corruption with the plain shared producer (no offset binding); the
 prevention drives a stale owner with an *older consumer generation* and asserts the newer snapshot
-survives. The paired non-transactional reproduction (the plain shared producer, no offset binding)
-shows the corruption, isolating the binding as the cause rather than incidental fencing. Other pins:
-first-flush gating (the seed), fenced writer fails its next flush, an open transaction neither blocks
-nor leaks into recovery, concurrent-write safety. The group-commit machinery is also exercised in
-isolation by a unit test with a recording in-memory producer (no broker).
+survives — isolating the offset binding as the cause, not incidental fencing. Other pins: first-flush
+gating (the seed), a fenced writer fails its next flush, an open transaction neither blocks nor leaks
+into recovery, concurrent-write safety. The group commit is exercised in isolation by `GroupCommitSpec`, a unit test with a
+recording in-memory producer (no broker).
 
 ## Rejected alternatives
 

--- a/docs/kafka-single-writer-design.md
+++ b/docs/kafka-single-writer-design.md
@@ -12,10 +12,10 @@ Design notes for the transactional snapshot mode of `kafka-flow-persistence-kafk
 [kafka-flow#732](https://github.com/evolution-gaming/kafka-flow/issues/732): consumer-group
 ownership of the input topic does not extend to the snapshot topic. During a rebalance a previous
 owner that has not yet observed the revocation (network issue, GC pause, slow poll loop) keeps
-writing snapshots alongside the new owner. The snapshot topic is compacted (last-write-wins), so a
-stale snapshot can overwrite a newer one; the next recovery then loads stale state and loses the
-events between the two snapshots, even though their input offsets were committed. Overlaps of tens
-of seconds have been observed in production.
+writing snapshots alongside the new owner — overlaps of tens of seconds have been observed in
+production. The snapshot topic is compacted (last-write-wins), so a stale snapshot can overwrite a
+newer one; the next recovery then loads stale state but resumes from the committed offset, so the
+events between the two snapshots are never re-folded — corrupting the state.
 
 ```mermaid
 sequenceDiagram
@@ -24,28 +24,36 @@ sequenceDiagram
     participant B as Owner B<br/>(new)
 
     Note over A: folds input to offset 100,<br/>state buffered, not flushed
-    Note over A,B: rebalance: partition revoked from A<br/>and assigned to B — but A<br/>has not observed it yet
+    Note over A,B: rebalance: partition reassigned from A to B<br/>— but A has not observed the revocation yet
     B->>ST: recover: read to end<br/>(no newer snapshot)
     B->>B: fold input to offset 150
     B->>ST: write snapshot @150 ✓
-    Note over B: commit input offset 150
+    Note over B: commit through offset 150
     A-->>ST: flush buffered snapshot @100<br/>(stale: A no longer owns it)
     Note over ST: last write wins:<br/>@100 overwrites @150
-    Note over ST,B: next recovery resumes at offset 150<br/>but loads snapshot @100 —<br/>events 101 to 150 never replayed (lost)
+    Note over ST,B: next recovery folds from 151<br/>onto stale @100 — corruption
 ```
 
 ## Mechanism: generation fencing
 
-Normally the input offsets are committed through the **Kafka consumer** (the ordinary consumer-group
-offset commit). In this mode they are committed through the snapshot **producer** instead, with the
-consumer-side commit disabled — the offset moves **into the producer's transaction** via
+In the default (non-transactional) mode the input offsets are committed through the **Kafka consumer**
+(the ordinary consumer-group offset commit). In this mode they are committed through the snapshot
+**producer** instead, with the consumer-side commit disabled — the offset moves **into the producer's
+transaction** via
 `sendOffsetsToTransaction(offsets, consumerGroupMetadata)`
 ([KIP-447](https://cwiki.apache.org/confluence/display/KAFKA/KIP-447%3A+Producer+scalability+for+exactly+once+semantics)):
 the group coordinator validates the consumer **generation** and rejects a commit from a stale one
-(`ILLEGAL_GENERATION`).
+(`ILLEGAL_GENERATION`, surfaced to the client as `CommitFailedException`).
 Since that commit and the snapshot writes share a transaction, the rejection aborts the writes too.
 The generation — authoritative for partition ownership — gates both, so a stale owner can neither
 advance offsets nor overwrite a newer snapshot.
+
+Seen as a whole, the mechanism combines two ideas — a distributed lock, and a transactional snapshot
+write + offset commit. Kafka's consumer group is the lock, and it already provides both an ownership
+*lease* and a [fencing token](https://martin.kleppmann.com/2016/02/08/how-to-do-distributed-locking.html):
+the partition assignment is the lease, and the **generation** (bumped on each rebalance) is the token.
+What is missing by default is only the link: the snapshot write is not bound to the fenced offset
+commit. Binding them in one transaction is the link.
 
 ```mermaid
 sequenceDiagram
@@ -58,32 +66,40 @@ sequenceDiagram
     B->>TC: sendOffsetsToTransaction(offset, gen=old)
     TC-->>B: ILLEGAL_GENERATION (partition reassigned)
     B->>TC: abort — stale snapshot never committed
-    Note over ST: newer snapshot survives
+    Note over ST: newer snapshot (new owner's) survives
 ```
 
 This is corruption prevention, not exactly-once. Output produces go through the application's own
 producer, and the transaction wraps only the snapshot write and the offset commit, so they stay outside
 it — enrolling them would be full transactional output, an explicit non-goal (see Rejected alternatives).
 Output is therefore at-least-once: a replayed batch re-emits it, so the consuming side must tolerate
-duplicates. The committed offset is the minimum held offset, always behind durable state, so it can
-never outrun the snapshots on disk even though offset and writes may land in different transactions.
+duplicates. The **committable offset** — the minimum offset still held across the partition's keys — is
+never ahead of the persisted snapshots: an offset becomes committable only after its snapshot is
+persisted, so recovery never skips events.
 
 Key points:
 
-- **Every** transaction carries the partition's committable offset, so every write is gated. When the
-  committed offset needs to advance but no snapshot writes are pending — a periodic commit tick, or a
-  revoke — an *offset-only* transaction is forced so the offset still moves.
-- The offset-to-commit is **seeded with the assigned offset**, so even the first flush (before the
-  first commit tick) is gated. Committing the assigned offset is a no-op.
+- **Every** transaction commits the partition's current committable offset, so every write is gated. The
+  offset itself advances only on the periodic offset-commit interval (`commitOffsetsInterval`, separate
+  from the snapshot-flush interval `persistEvery`) or on revoke; a snapshot write never advances it, it
+  just re-commits the current value to stay gated. That advance is committed in a transaction — batching
+  in any snapshot writes queued at that moment, or committing the offset alone (an *offset-only*
+  transaction) when there are none.
+- The offset-to-commit is **seeded with the assigned offset**, so even the first snapshot flush (before
+  the first commit tick) carries an offset and is gated.
 - Recovery is forced to `read_committed` so a fenced writer's aborted records are invisible.
-- The partition is never `consumer.commit`-ed in this mode; offsets only commit through the producer.
+- The ordinary consumer-group offset commit is **replaced**, not run alongside. In the default mode the
+  committable offset is staged and the **consumer** commits it; in this mode that same offset-scheduling
+  step is rerouted to the **producer**, so the offset is committed only inside the transaction (above).
+  The consumer-commit path still runs each poll cycle but now finds nothing staged — a no-op — so the
+  partition is never committed through the consumer.
 - Both the write and the offset-only commit are **synchronous** — there is no background committer, so
   the call itself drives the transaction and blocks on its outcome. That blocking is what lets a fence
   (`CommitFailedException`) propagate into the flow and crash a stale owner, rather than being lost on a
   fire-and-forget commit thread.
 
 Wiring needs the input topic and a reader of the driving consumer's group metadata
-(`Consumer.groupMetadata`, captured on each rebalance on the poll thread). A fence surfaces as
+(`Consumer.groupMetadata`, captured on each partition assignment on the poll thread). A fence surfaces as
 `CommitFailedException` on the failing snapshot write (or offset-only commit).
 
 ### No epoch fencing
@@ -91,19 +107,21 @@ Wiring needs the input topic and a reader of the driving consumer's group metada
 Generation fencing is the sole mechanism; there is deliberately no producer-epoch fencing. Each
 producer gets a unique `transactional.id` (`"{prefix}-{partition}-{uuid8}"`), so old and new owners
 never share one. A *stable* per-partition id would add cross-owner epoch fencing, which is both
-redundant and harmful: the epoch is assigned in `initTransactions` arrival order, not assignment
-order, so a slow stale owner that inits late wins the epoch and would false-positive-fence the true
-owner. The cost of unique ids — transaction-coordinator state expiring via
-`transactional.id.expiration.ms` — is accepted. A hard-crashed owner's in-flight transaction is, for
-the same reason, not fenced on the spot (a stable id would abort it through the new owner's
-`initTransactions`); the coordinator reclaims it only after `transaction.timeout.ms`, which bounds how
-long a `read_committed` reader (recovery, or a downstream consumer) can stall behind its
-last-stable-offset.
+redundant and harmful: with a shared id each `initTransactions` bumps the epoch and fences the
+previous holder, so whichever owner inits *latest* wins — a race unrelated to who actually owns the
+partition. A slow stale owner that inits late therefore wins the epoch, its stale write lands (the
+fence fails), and the true owner is fenced instead.
+
+The cost of unique ids — transaction-coordinator state expiring via `transactional.id.expiration.ms` —
+is accepted. A hard-crashed owner's in-flight transaction is, for the same reason, not fenced on the
+spot (a stable id would abort it through the new owner's `initTransactions`); the coordinator reclaims
+it only after `transaction.timeout.ms`, which bounds how long a `read_committed` reader (recovery, or a
+downstream consumer) can stall behind its last-stable-offset.
 
 ## Write path: group-committed transactions
 
 A producer allows one transaction at a time, while kafka-flow flushes a partition's keys in
-parallel — and after a restart most of the active key population flushes in one wave per
+parallel — and after a fresh assignment most of the active key population flushes in one wave per
 `persistEvery`. Writes are therefore **group committed**: a write is queued, and the first writer to
 take the per-partition transaction lock drains the queued writes at that moment — up to the cap below —
 into a single transaction (offset commits ride along without consuming the cap) and delivers the outcome
@@ -117,9 +135,8 @@ grows with the batch. The cap's job is to bound transaction duration (commit wit
 `transaction.timeout.ms`, default 1 min) and bytes (≈ cap × snapshot size).
 
 A snapshot write does not complete until its transaction commits, and the flush awaits each write, so
-the source is back-pressured: the in-flight queue holds at most the keys flushing in one wave, bounding
-memory rather than letting it grow without limit. Sustaining writes above that rate surfaces as rising
-flush latency and lag.
+the source is back-pressured: outstanding writes are bounded by the flush concurrency (one per live key
+in the wave), not by internal buffering.
 
 ## Implementation
 
@@ -127,30 +144,42 @@ Entry point: `KafkaPersistenceModuleOf.cachingTransactional`. In the current cod
 
 - **Group-committed transactional writes** — `KafkaSnapshotWriteDatabase.transactional` (the
   `GroupCommit` machinery); the per-partition transactional producer is built in `KafkaPersistenceModule`.
-- **Offset-only commit** (the forced offset advance when no writes are pending) — `ScheduleCommit`.
-- **Generation capture** on each rebalance — the `Consumer` wrapper, holding `groupMetadata` in a `Ref`
-  read off the poll thread.
+- **Offset commit** (on the periodic tick / on revoke; an offset-only transaction when no snapshot
+  writes are pending) — `ScheduleCommit`.
+- **Consumer-commit reroute** — at wiring the module's `scheduleCommit` (the transactional `ScheduleCommit`)
+  overrides the default consumer-backed one (`kafkaPersistenceModule.scheduleCommit.getOrElse(...)` in the
+  persistence-kafka `package` object). That bypasses the default path, where offsets are normally staged
+  through `PendingCommits` and committed by `TopicFlow.commitPending` via `consumer.commit`; with nothing
+  staged, it commits nothing (a no-op).
+- **Generation capture** on each partition assignment — the `Consumer` wrapper, holding `groupMetadata`
+  in a `Ref` read off the poll thread.
 
 ## Measurements
 
 From `TransactionalWriteThroughputSpec`: single-node testcontainers broker on localhost, replication
 factor 1, no network latency — a *floor*; expect a few ms per transaction against real brokers. Each
-number is the min of 3 interleaved runs on a fresh state topic. Read them as orders of magnitude.
+number is the min of 3 runs on a fresh state topic. Read them as orders of magnitude.
 
-**Experiment A** — 500 keys, small snapshots, one partition:
+**Experiment A** — 500 keys, small snapshots, one partition, cap held at the default (256); the only
+thing that varies is whether the writes are issued one at a time (sequentially) or all at once
+(concurrently):
 
-| Mode | Arrival | Result |
+| Mode | Issued | Result |
 |---|---|---|
-| Shared batched producer (default, no transactions) | sequential | 197 ms |
-| Group-committed transactions | sequential | 879 ms (500 txns, ~1.8 ms/txn) |
-| Group-committed transactions | concurrent burst | 13 ms (a few batches) |
+| Shared batched producer (default, no transactions) | one at a time | 197 ms |
+| Group-committed transactions | one at a time | 879 ms (500 txns, ~1.8 ms/txn) |
+| Group-committed transactions | all at once | 13 ms (a few batches) |
 
-The lower two rows are the same group commit — only arrival differs. Sequentially every write is a
-batch of one; concurrently (the real flush pattern) writes collapse into a few large batches, below
-even the non-transactional producer.
+This isolates one variable: group commit only pays off when writes are issued together. Issued one at a
+time, nothing batches, so transactions run one per write — several times slower than the plain producer;
+issued all at once, they collapse into a few transactions and that cost is gone. The plain producer is
+measured one-at-a-time only as a reference point — not a fair head-to-head, since nothing makes it batch
+here. The fair comparison, both issued concurrently against realistic payloads, is Experiment B.
 
-**Experiment B** — 2000 keys, 10 KiB snapshots, all flushed concurrently (the post-restart wave).
-The cap bounds writes per transaction, so for `N` keys it is ≈ the transaction count (`N / cap`):
+**Experiment B** — 2000 keys, 10 KiB snapshots, flushed **concurrently** (the *post-assignment wave*: a
+new owner recovers all its keys, so they fall due together, and the timer tick fans the per-key flushes
+out concurrently — `parTraverse` across keys in `PartitionFlow`, which the test mirrors). The cap bounds
+writes per transaction, so the transaction count is ≈ `N / cap`:
 
 | Configuration | ≈ transactions | Result |
 |---|---|---|
@@ -161,9 +190,8 @@ The cap bounds writes per transaction, so for `N` keys it is ≈ the transaction
 | `maxWritesPerTransaction = 2000` (uncapped) | 1 | 279 ms |
 
 Cost tracks the transaction count until Kafka's network batching floors it (~280–300 ms). At the
-default cap the transactional burst is within ~6% of the baseline; without the group commit
-(cap = 1) it is an order of magnitude slower, with multi-second poll-path stalls at realistic key
-counts.
+default cap the burst is within ~6% of the plain baseline; at cap = 1 (a transaction per write) it is
+an order of magnitude slower — multi-second poll-path stalls at realistic key counts.
 
 Reproduce: `KAFKA_FLOW_PERF=1 sbt "persistence-kafka-it-tests/testOnly *TransactionalWriteThroughputSpec"`
 (the suite is excluded from the default run).
@@ -171,30 +199,31 @@ Reproduce: `KAFKA_FLOW_PERF=1 sbt "persistence-kafka-it-tests/testOnly *Transact
 ## Testing
 
 Integration tests (`TransactionalKafkaPersistenceSpec`, in persistence-kafka-it-tests) run through the
-real eager-recovery / flush-on-revoke machinery. The reproduction shows corruption with the plain shared producer (no offset binding); the
-prevention drives a stale owner with an *older consumer generation* and asserts the newer snapshot
-survives — isolating the offset binding as the cause, not incidental fencing. Other pins: first-flush
-gating (the seed), a fenced writer fails its next flush, an open transaction neither blocks nor leaks
-into recovery, concurrent-write safety. The group commit is exercised in isolation by `GroupCommitSpec`, a unit test with a
-recording in-memory producer (no broker).
+real eager-recovery (every key recovered on assignment) and flush-on-revoke machinery. The reproduction
+shows corruption with the plain shared producer (no offset binding); the prevention drives a stale owner
+with an *older consumer generation* and asserts the newer snapshot survives — isolating the offset
+binding as the cause, not incidental fencing. Other cases covered: first-flush gating (the seed), a
+fenced writer fails its next flush, an open transaction neither blocks nor leaks into recovery,
+concurrent-write safety. The group commit is exercised in isolation by `GroupCommitSpec`, a unit test
+with a recording in-memory producer (no broker).
 
 ## Rejected alternatives
 
-- **Transactional snapshot read + write**: write only if the stored snapshot is still the expected
-  previous value, fencing a stale writer. No conditional produce on a Kafka topic, so the
-  assert-and-write cannot be atomic.
-- **Transaction per write**: correct but O(keys) round-trips on the poll path (cap = 1 above).
-- **Unbounded batches**: ~7% faster, but transaction duration then scales unbounded against the
-  coordinator timeout.
+- **Transactional snapshot read + snapshot write**: fence a stale writer with a compare-and-set on the
+  stored offset. Kafka has no conditional produce primitive, so it cannot be atomic.
 - **Producer-epoch fencing (stable `transactional.id`)**: epoch order can diverge from ownership
-  order, so it does not fully close #732 and can false-positive-fence the true owner (above).
+  order, so it does not fully close [#732](https://github.com/evolution-gaming/kafka-flow/issues/732)
+  and can false-positive-fence the true owner (above).
+- **Static partition assignment** (`assign()` instead of `subscribe()`): no consumer group, so no
+  rebalance, no overlap window, no fence needed — but it gives up automatic failover and elastic
+  reassignment, and safe *dynamic* assignment is the point of this design. (Static *membership*
+  ([KIP-345](https://cwiki.apache.org/confluence/display/KAFKA/KIP-345%3A+Introduce+static+membership+protocol+to+reduce+consumer+rebalances))
+  is not a substitute: it suppresses rebalances only for graceful restarts within `session.timeout.ms`,
+  and does not fence a stuck owner whose session expired.)
+- **Transaction per write**: correct but O(keys) round-trips on the poll path (cap = 1 above).
+- **Unbounded batches**: ~7% faster, but transaction duration scales unbounded against the coordinator
+  timeout.
 - **Transactional output produces (full exactly-once)**: out of scope; output stays at-least-once.
-- **Static partition assignment** (`assign()` instead of `subscribe()`): no consumer group, no
-  rebalance, so no overlap window and no fence needed — the workaround [#732](https://github.com/evolution-gaming/kafka-flow/issues/732)
-  itself names. Rejected because it gives up automatic failover and elastic reassignment; letting
-  users keep dynamic assignment *safely* is the point of this design. (Static *membership* (KIP-345)
-  is not an alternative here: it suppresses rebalances only for graceful restarts within
-  `session.timeout.ms`, and does not fence a stuck owner whose session expired.)
 
 ## Forward-looking
 

--- a/docs/kafka-single-writer-design.md
+++ b/docs/kafka-single-writer-design.md
@@ -169,7 +169,9 @@ isolation by a unit test with a recording in-memory producer (no broker).
 
 ## Rejected alternatives
 
-- **Cassandra-style compare-and-set**: no conditional produce on a Kafka topic.
+- **Transactional snapshot read + write**: write only if the stored snapshot is still the expected
+  previous value, fencing a stale writer. No conditional produce on a Kafka topic, so the
+  assert-and-write cannot be atomic.
 - **Transaction per write**: correct but O(keys) round-trips on the poll path (cap = 1 above).
 - **Unbounded batches**: ~7% faster, but transaction duration then scales unbounded against the
   coordinator timeout.
@@ -187,7 +189,6 @@ isolation by a unit test with a recording in-memory producer (no broker).
 
 [KIP-939 (participation in 2PC)](https://cwiki.apache.org/confluence/display/KAFKA/KIP-939:+Support+Participation+in+2PC)
 is the route to extend this fence to non-Kafka snapshot stores: a transactional producer in an
-externally-coordinated two-phase commit could bind a Cassandra/RDBMS snapshot write to the same
-generation-fenced Kafka offset commit, giving those backends the per-partition ownership guarantee
-this mode has — without the per-key compare-and-set the Cassandra backend uses today. Not actionable
-now; tracked as the convergence point for the two persistence backends.
+externally-coordinated two-phase commit could bind a snapshot write in another store (e.g. Cassandra or
+an RDBMS) to the same generation-fenced Kafka offset commit, giving that store the per-partition
+ownership guarantee this mode has. Not actionable now.

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -5,7 +5,119 @@ sidebar_label: Persistence
 ---
 
 ## Persistence modes
-TBD.
+
+kafka-flow keeps the state of each key in memory while it processes a partition. To survive a
+restart or a partition rebalance without replaying the whole input topic from the beginning, that
+state is **persisted** and recovered when the partition is next assigned. Persistence is optional —
+it is only needed when reprocessing the full journal on every recovery is too expensive — and two
+backends are provided:
+
+- **Cassandra** (`kafka-flow-persistence-cassandra`) — stores per-key *journals* (the folded
+  events) and/or *snapshots* (the latest state) in Cassandra tables. See
+  `CassandraPersistence`.
+- **Kafka** (`kafka-flow-persistence-kafka`) — stores per-key snapshots in a dedicated Kafka
+  [compacted](https://kafka.apache.org/documentation/#compaction) topic, recovered by reading that
+  topic to the end on assignment. See `KafkaPersistenceModuleOf`.
+
+Both backends recover state per key during partition assignment, relying on Kafka's guarantee that a
+partition is owned by a single consumer in the group. The [stale-writer
+protections](#protecting-against-stale-snapshot-writes) below cover the one case where that ownership
+guarantee is not enough.
+
+## Protecting against stale snapshot writes
+
+Consumer-group ownership of the input topic does **not** extend to the snapshot store. During a
+rebalance a previous owner that has not yet observed the revocation (network issue, GC pause, slow
+poll loop) keeps folding events and flushing snapshots alongside the new owner; with the default
+last-write-wins persistence a stale snapshot overwrites a newer one, and the next recovery loads stale
+state — losing the events between the two snapshots even though their offsets were committed. See
+[kafka-flow#732](https://github.com/evolution-gaming/kafka-flow/issues/732); overlaps of tens of
+seconds have been seen in production.
+
+This page is about turning the protection on and running it; for *how* it fences a stale writer, see
+the [Kafka single-writer design](kafka-single-writer-design.md).
+
+Timer settings change how often the window is hit:
+`TimerFlowOf.persistPeriodically(flushOnRevoke = true)` makes it **more** likely (revoked partitions
+flush while the new owner starts up); a higher `persistEvery` makes it **less** likely, at the cost of
+more events to replay on recovery.
+
+For the Kafka snapshot backend the protection is **transactional** snapshot writes — opt-in, off by
+default, enabled with `KafkaPersistenceModuleOf.cachingTransactional`. (A custom `SnapshotDatabase`
+can implement its own protection — see [Custom snapshot storage](#custom-snapshot-storage).)
+
+### What a rejected write looks like
+
+You do not catch the rejection yourself; it is handled for you:
+
+- **Periodic flush** — the conflict fails the stale instance's flow. That is safe (it no longer owns
+  the partition), unless you set `persistPeriodically(ignorePersistErrors = true)`, in which case it
+  is logged and swallowed.
+- **Flush-on-revoke** — the conflict surfaces as a cache-entry release error that scache logs and
+  swallows (`scache: failed to release cache entry: ...`), so the partition hands off cleanly.
+
+Either way the rejected write does not land and no offset is committed for it, so the new owner
+replays the affected events.
+
+### Transactional snapshot writes (Kafka)
+
+Enable with `KafkaPersistenceModuleOf.cachingTransactional`, built from the consumer that drives the
+flow (it reads that consumer's group metadata to fence by generation):
+
+```scala
+// allocate the driving consumer first so the module can read its group metadata (generation)
+consumer.use { consumer =>
+  val moduleOf = KafkaPersistenceModuleOf.cachingTransactional[F, State](
+    consumerOf = consumerOf,
+    producerOf = producerOf,
+    config = KafkaPersistenceModule.TransactionalConfig(
+      consumerConfig        = snapshotConsumerConfig,
+      producerConfig        = snapshotProducerConfig,
+      transactionalIdPrefix = s"$groupId-$inputTopic",
+      snapshotTopic         = stateTopic,
+      inputTopic            = inputTopic,
+    ),
+    groupMetadata = consumer.groupMetadata, // the SAME consumer that drives the flow
+  )
+  // ... wire moduleOf into the flow, driven by `consumer`
+}
+```
+
+Snapshot writes and the input-offset commit run in one Kafka transaction per assigned partition; a
+write from a stale consumer generation is fenced by the broker (KIP-447) and surfaces as
+`CommitFailedException`. Recovery reads `read_committed`, so a fenced writer's aborted records are
+never recovered. See the [design doc](kafka-single-writer-design.md) for the mechanism (and why epoch
+fencing is avoided).
+
+- **Cost** — every snapshot write goes through a Kafka transaction (a few ms against real brokers);
+  cost tracks the *number* of transactions, not byte volume. A partition's concurrent key flushes are
+  group-committed, so a burst of N dirty keys costs about N / `maxWritesPerTransaction` (default 256,
+  configurable via `TransactionalConfig`) round-trips on the poll path. On a realistic burst at the
+  default cap the measured overhead was within ~6% of the non-transactional producer (design doc).
+  Each partition also holds its own producer and transaction-coordinator state on the brokers.
+- **Output is at-least-once** — output produces stay outside the snapshot transaction, so a replayed
+  batch re-emits them; the consuming side must tolerate duplicates. Only the snapshot store and the
+  input-offset commit are kept consistent (corruption prevention, not exactly-once).
+- **Rollout** — no migration (recovery under `read_committed` still reads existing non-transactional
+  records). A rolling deploy is safe; while the two modes coexist a non-transactional instance is not
+  fenced — the same exposure you already have without this mode, gone once every instance is
+  transactional.
+
+Limitations:
+- A batch shares its transaction's outcome: if the transaction fails, every write in it fails.
+- An old owner can be fenced while flushing on revoke; its last state delta is then neither persisted
+  nor committed, so the new owner replays those events — noise, not loss.
+- The mode always uses the identity `KafkaPersistencePartitionMapper` (fencing is per input partition);
+  a non-identity mapper is not supported here.
+
+### Custom snapshot storage
+
+You can plug in your own snapshot store: implement `SnapshotDatabase` and wire it through
+`SnapshotsOf.backedBy` into `PersistenceOf.snapshotsOnly`/`restoreEvents`. A custom store is
+**last-write-wins**, so it is exposed to the same stale-writer overwrite
+([#732](https://github.com/evolution-gaming/kafka-flow/issues/732)) unless its own `persist`/`delete`
+reject a write when the store already holds a newer offset — that conditional write is the fence (the
+buffer wiring does not provide it).
 
 ## Compression
 Kafka-flow has a built-in support for compressing application's state

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -97,10 +97,11 @@ fencing is avoided).
   so a burst of N dirty keys is ≈ N / `maxWritesPerTransaction` transactions (default 256) — at the
   default cap the overhead is small (see the design doc's Measurements). Each partition also holds its
   own producer and transaction-coordinator state on the brokers.
-- **Tuning for large snapshots** — a transaction must commit within `transaction.timeout.ms` (a producer
-  config, default 1 min, kept ≤ the broker's `transaction.max.timeout.ms`). If snapshots are large or
-  brokers slow, lower `maxWritesPerTransaction` or raise the timeout — a higher timeout lengthens the
-  post-crash stall (below).
+- **Tuning for transaction time** — a transaction must commit within `transaction.timeout.ms` (a
+  producer config, default 1 min, ≤ the broker's `transaction.max.timeout.ms`). Large snapshots lengthen
+  it with the batch — lower `maxWritesPerTransaction` (at a throughput cost) or raise the timeout. Slow
+  brokers lengthen it regardless of batch, so raise the timeout, not lower the cap. A higher timeout
+  lengthens the post-crash stall (below).
 - **Output is at-least-once** — output produces stay outside the snapshot transaction, so a replayed
   batch re-emits them; the consuming side must tolerate duplicates. Only the snapshot store and the
   input-offset commit are kept consistent (corruption prevention, not exactly-once).

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -85,12 +85,14 @@ consumer.use { consumer =>
 
 `idempotence` and the per-partition `transactional.id` are set for you — don't configure them in
 `producerConfig` — and the snapshot `consumerConfig`'s isolation level is forced to `read_committed`.
+The id is regenerated per assignment, not stable per partition.
 
 Snapshot writes and the input-offset commit run in one Kafka transaction per assigned partition; a
-write from a stale consumer generation is fenced by the broker (KIP-447) and surfaces as
+write from a stale consumer generation is fenced by the broker
+([KIP-447](https://cwiki.apache.org/confluence/display/KAFKA/KIP-447%3A+Producer+scalability+for+exactly+once+semantics))
+and surfaces as
 `CommitFailedException`. Recovery reads `read_committed`, so a fenced writer's aborted records are
-never recovered. See the [design doc](kafka-single-writer-design.md) for the mechanism (and why epoch
-fencing is avoided).
+never recovered.
 
 - **Cost** — snapshot writes commit in Kafka transactions (a few ms each on real brokers), and cost
   tracks the *number* of transactions more than their size. Concurrent key flushes are group-committed,
@@ -99,9 +101,8 @@ fencing is avoided).
   own producer and transaction-coordinator state on the brokers.
 - **Tuning for transaction time** — a transaction must commit within `transaction.timeout.ms` (a
   producer config, default 1 min, ≤ the broker's `transaction.max.timeout.ms`). Large snapshots lengthen
-  it with the batch — lower `maxWritesPerTransaction` (at a throughput cost) or raise the timeout. Slow
-  brokers lengthen it regardless of batch, so raise the timeout, not lower the cap. A higher timeout
-  lengthens the post-crash stall (below).
+  it with the batch — lower `maxWritesPerTransaction` (at a throughput cost) or raise the timeout. A
+  higher timeout lengthens the post-crash stall (below).
 - **Output is at-least-once** — output produces stay outside the snapshot transaction, so a replayed
   batch re-emits them; the consuming side must tolerate duplicates. Only the snapshot store and the
   input-offset commit are kept consistent (corruption prevention, not exactly-once).
@@ -125,9 +126,11 @@ Limitations:
 You can plug in your own snapshot store: implement `SnapshotDatabase` and wire it through
 `SnapshotsOf.backedBy` into `PersistenceOf.snapshotsOnly`/`restoreEvents`. A custom store is
 **last-write-wins**, so it is exposed to the same stale-writer overwrite
-([#732](https://github.com/evolution-gaming/kafka-flow/issues/732)) unless its own `persist`/`delete`
-reject a write when the store already holds a newer offset — that conditional write is the fence (the
-buffer wiring does not provide it).
+([#732](https://github.com/evolution-gaming/kafka-flow/issues/732)) unless its `persist` rejects a
+write when the store already holds a newer offset (taken from the snapshot) — that conditional write
+is the fence (the buffer wiring does not provide it). Note that the `delete(key)` method carries no
+offset, so a delete cannot be offset-gated through this interface; a custom store's delete stays
+unconditional.
 
 ## Compression
 Kafka-flow has a built-in support for compressing application's state

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -83,18 +83,24 @@ consumer.use { consumer =>
 }
 ```
 
+`idempotence` and the per-partition `transactional.id` are set for you — don't configure them in
+`producerConfig` — and the snapshot `consumerConfig`'s isolation level is forced to `read_committed`.
+
 Snapshot writes and the input-offset commit run in one Kafka transaction per assigned partition; a
 write from a stale consumer generation is fenced by the broker (KIP-447) and surfaces as
 `CommitFailedException`. Recovery reads `read_committed`, so a fenced writer's aborted records are
 never recovered. See the [design doc](kafka-single-writer-design.md) for the mechanism (and why epoch
 fencing is avoided).
 
-- **Cost** — every snapshot write goes through a Kafka transaction (a few ms against real brokers);
-  cost tracks the *number* of transactions, not byte volume. A partition's concurrent key flushes are
-  group-committed, so a burst of N dirty keys costs about N / `maxWritesPerTransaction` (default 256,
-  configurable via `TransactionalConfig`) round-trips on the poll path. On a realistic burst at the
-  default cap the measured overhead was within ~6% of the non-transactional producer (design doc).
-  Each partition also holds its own producer and transaction-coordinator state on the brokers.
+- **Cost** — snapshot writes commit in Kafka transactions (a few ms each on real brokers), and cost
+  tracks the *number* of transactions more than their size. Concurrent key flushes are group-committed,
+  so a burst of N dirty keys is ≈ N / `maxWritesPerTransaction` transactions (default 256) — at the
+  default cap the overhead is small (see the design doc's Measurements). Each partition also holds its
+  own producer and transaction-coordinator state on the brokers.
+- **Tuning for large snapshots** — a transaction must commit within `transaction.timeout.ms` (a producer
+  config, default 1 min, kept ≤ the broker's `transaction.max.timeout.ms`). If snapshots are large or
+  brokers slow, lower `maxWritesPerTransaction` or raise the timeout — a higher timeout lengthens the
+  post-crash stall (below).
 - **Output is at-least-once** — output produces stay outside the snapshot transaction, so a replayed
   batch re-emits them; the consuming side must tolerate duplicates. Only the snapshot store and the
   input-offset commit are kept consistent (corruption prevention, not exactly-once).
@@ -107,6 +113,9 @@ Limitations:
 - A batch shares its transaction's outcome: if the transaction fails, every write in it fails.
 - An old owner can be fenced while flushing on revoke; its last state delta is then neither persisted
   nor committed, so the new owner replays those events — noise, not loss.
+- After a hard crash, the broker reclaims the failed owner's in-flight transaction only after
+  `transaction.timeout.ms`; until then a `read_committed` reader — recovery of that partition, or a
+  downstream consumer of your output — can stall behind its last-stable-offset.
 - The mode always uses the identity `KafkaPersistencePartitionMapper` (fencing is per input partition);
   a non-identity mapper is not supported here.
 

--- a/persistence-kafka-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/ForAllKafkaSuite.scala
+++ b/persistence-kafka-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/ForAllKafkaSuite.scala
@@ -1,22 +1,42 @@
 package com.evolutiongaming.kafka.flow
 
-import cats.data.NonEmptyList
-import cats.effect.IO
+import cats.data.{NonEmptyList, NonEmptySet}
+import cats.effect.{IO, Resource}
+import cats.syntax.all.*
 import com.dimafeng.testcontainers.KafkaContainer
 import com.dimafeng.testcontainers.munit.fixtures.TestContainersFixtures
 import com.evolutiongaming.catshelper.LogOf
 import com.evolutiongaming.kafka.flow.kafka.KafkaModule
-import com.evolutiongaming.skafka.CommonConfig
-import com.evolutiongaming.skafka.consumer.ConsumerConfig
+import com.evolutiongaming.skafka.{CommonConfig, Topic}
+import com.evolutiongaming.skafka.consumer.{ConsumerConfig, ConsumerGroupMetadata, RebalanceListener1}
 import com.evolutiongaming.smetrics.CollectorRegistry
 import munit.FunSuite
+import org.apache.kafka.clients.admin.{AdminClient, AdminClientConfig, NewTopic}
 
+import java.util.Properties
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
+import scala.concurrent.duration.*
+import scala.jdk.CollectionConverters.*
 
 abstract class ForAllKafkaSuite extends FunSuite with TestContainersFixtures {
   import cats.effect.unsafe.implicits.global
 
   val kafka = ForAllContainerFixture(KafkaContainer())
+
+  def createTopic(topic: String, partitions: Int): IO[Unit] = {
+    val props = new Properties
+    props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, kafka.container.bootstrapServers)
+
+    Resource
+      .make(IO.delay(AdminClient.create(props)))(cl => IO(cl.close()))
+      .use { client =>
+        IO(client.createTopics(List(new NewTopic(topic, partitions, 1.toShort)).asJava)).map(res =>
+          res.all().get(10, TimeUnit.SECONDS)
+        )
+      }
+      .void
+  }
 
   val kafkaModule = new Fixture[KafkaModule[IO]]("KafkaModule") {
     private val moduleRef = new AtomicReference[(KafkaModule[IO], IO[Unit])]()
@@ -33,6 +53,22 @@ abstract class ForAllKafkaSuite extends FunSuite with TestContainersFixtures {
 
     override def afterAll(): Unit = Option(moduleRef.get()).foreach { case (_, finalizer) => finalizer.unsafeRunSync() }
   }
+
+  /** Joins a real consumer to a fresh group and runs `f` with the group's current metadata (generation N). The consumer
+    * stays alive (heartbeating) for the duration, so the generation is stable while `f` runs. Used by transactional
+    * tests that need a real generation for `sendOffsetsToTransaction`.
+    */
+  def withJoinedConsumer[A](group: String, inputTopic: Topic)(f: ConsumerGroupMetadata => IO[A]): IO[A] =
+    kafkaModule().consumerOf(group).use { consumer =>
+      def pollUntilJoined(attempts: Int): IO[ConsumerGroupMetadata] =
+        consumer.poll(100.millis) *> consumer.groupMetadata.flatMap {
+          case Some(meta) if meta.generationId >= 1 => meta.pure[IO]
+          case meta if attempts <= 0 => IO.raiseError(new RuntimeException(s"consumer did not join the group: $meta"))
+          case _                     => IO.sleep(100.millis) *> pollUntilJoined(attempts - 1)
+        }
+
+      consumer.subscribe(NonEmptySet.of(inputTopic), RebalanceListener1.empty[IO]) *> pollUntilJoined(50).flatMap(f)
+    }
 
   override def munitFixtures: Seq[Fixture[_]] = List(kafka, kafkaModule)
 }

--- a/persistence-kafka-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/RemapKeySpec.scala
+++ b/persistence-kafka-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/RemapKeySpec.scala
@@ -13,13 +13,9 @@ import com.evolutiongaming.retry.Retry
 import com.evolutiongaming.skafka.CommonConfig
 import com.evolutiongaming.skafka.consumer.{AutoOffsetReset, ConsumerConfig, ConsumerOf, ConsumerRecord}
 import com.evolutiongaming.skafka.producer.{ProducerConfig, ProducerOf, ProducerRecord, RecordMetadata}
-import org.apache.kafka.clients.admin.{AdminClient, AdminClientConfig, NewTopic}
 import scodec.bits.ByteVector
 
-import java.util.Properties
-import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.*
-import scala.jdk.CollectionConverters.*
 import com.evolutiongaming.skafka.Partition
 import scala.util.Random
 
@@ -91,17 +87,6 @@ class RemapKeySpec extends ForAllKafkaSuite {
         } yield ()
       }
       .unsafeRunSync()
-  }
-
-  private def createTopic(topic: String, partitions: Int) = {
-    val props = new Properties
-    props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, kafka.container.bootstrapServers)
-
-    Resource.make(IO.delay(AdminClient.create(props)))(cl => IO(cl.close())).use { client =>
-      IO(client.createTopics(List(new NewTopic(topic, partitions, 1.toShort)).asJava)).map(res =>
-        res.all().get(10, TimeUnit.SECONDS)
-      )
-    }
   }
 
   private def consume(n: Int, inputTopic: String): IO[List[ConsumerRecord[String, String]]] = {

--- a/persistence-kafka-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/StatefulProcessingWithKafkaSpec.scala
+++ b/persistence-kafka-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/StatefulProcessingWithKafkaSpec.scala
@@ -8,7 +8,7 @@ import cats.syntax.all.*
 import com.evolution.playjson.jsoniter.PlayJsonJsoniter
 import com.evolutiongaming.catshelper.{Log, LogOf}
 import com.evolutiongaming.kafka.flow.StatefulProcessingWithKafkaSpec.*
-import com.evolutiongaming.kafka.flow.kafka.KafkaModule
+import com.evolutiongaming.kafka.flow.kafka.{Consumer, KafkaModule}
 import com.evolutiongaming.kafka.flow.kafkapersistence.{
   KafkaPersistenceModule,
   KafkaPersistenceModuleOf,
@@ -22,16 +22,12 @@ import com.evolutiongaming.kafka.flow.timer.{TimerFlowOf, TimersOf}
 import com.evolutiongaming.retry.Retry
 import com.evolutiongaming.skafka.consumer.{AutoOffsetReset, ConsumerConfig, ConsumerOf, ConsumerRecord}
 import com.evolutiongaming.skafka.producer.{ProducerConfig, ProducerOf, ProducerRecord, RecordMetadata}
-import com.evolutiongaming.skafka.{Bytes, CommonConfig, Partition}
-import org.apache.kafka.clients.admin.{AdminClient, AdminClientConfig, NewTopic}
+import com.evolutiongaming.skafka.{Bytes, CommonConfig, Offset, Partition}
 import play.api.libs.json.{JsResultException, Json, OFormat}
 import scodec.bits.ByteVector
 
 import java.nio.charset.StandardCharsets
-import java.util.Properties
-import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.*
-import scala.jdk.CollectionConverters.*
 import scala.util.{Failure, Success, Try}
 
 /*
@@ -72,11 +68,12 @@ class StatefulProcessingWithKafkaSpec extends ForAllKafkaSuite {
     override def keysOf: KeysOf[IO, KafkaKey] = KeysOf.memory1[IO, KafkaKey].unsafeRunSync()
     override def persistenceOf: SnapshotPersistenceOf[IO, KafkaKey, State, ConsumerRecord[String, ByteVector]] =
       snapshotPersistenceOf
+    override def scheduleCommit: Option[com.evolutiongaming.kafka.flow.kafka.ScheduleCommit[IO]] = None
   }
 
   private val inMemoryPersistenceModuleOf: KafkaPersistenceModuleOf[IO, State] =
     new KafkaPersistenceModuleOf[IO, State] {
-      override def make(partition: Partition): Resource[IO, KafkaPersistenceModule[IO, State]] =
+      override def make(partition: Partition, assignedAt: Offset): Resource[IO, KafkaPersistenceModule[IO, State]] =
         Resource.pure(inMemoryPersistenceModule)
     }
 
@@ -122,46 +119,64 @@ class StatefulProcessingWithKafkaSpec extends ForAllKafkaSuite {
   }
 
   test("stateful processing using in-memory persistence") {
-    // using unique input topic name per test as weaver is running tests in parallel
-    val inputTopic          = "in-memory-persistence-test"
-    val persistenceModuleOf = inMemoryPersistenceModuleOf
-    comboTestCase(kafkaModule(), persistenceModuleOf, inputTopic).unsafeRunSync()
+    // unique input topic per test to isolate tests (munit suites run in parallel)
+    val inputTopic = "in-memory-persistence-test"
+    comboTestCase(kafkaModule(), _ => inMemoryPersistenceModuleOf, inputTopic).unsafeRunSync()
   }
 
   test("stateful processing using kafka persistence") {
-    // using unique input topic name per test as weaver is running tests in parallel
+    // unique input topic per test to isolate tests (munit suites run in parallel)
     val inputTopic = "kafka-persistence-test"
     kafkaPersistenceModuleOf
-      .use(module => comboTestCase(kafkaModule(), module, inputTopic))
+      .use(module => comboTestCase(kafkaModule(), _ => module, inputTopic))
       .unsafeRunSync()
   }
 
-  private def createTopic(topic: String, partitions: Int) = {
-    val props = new Properties
-    props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, kafka.container.bootstrapServers)
+  test("stateful processing using transactional kafka persistence") {
+    // unique input topic per test to isolate tests (munit suites run in parallel)
+    val inputTopic = "kafka-transactional-persistence-test"
+    val stateTopic = "state-topic-tx-StatefulProcessingWithKafkaSpec"
 
-    Resource.make(IO.delay(AdminClient.create(props)))(cl => IO(cl.close())).use { client =>
-      IO(client.createTopics(List(new NewTopic(topic, partitions, 1.toShort)).asJava)).map(res =>
-        res.all().get(10, TimeUnit.SECONDS)
+    // the module reads the driving consumer's group metadata so offsets are committed transactionally with the
+    // snapshot writes; the recovery assertions below would fail if those offset commits did not land
+    def makeModuleOf(consumer: Consumer[IO]): KafkaPersistenceModuleOf[IO, State] =
+      KafkaPersistenceModuleOf.cachingTransactional[IO, State](
+        consumerOf = ConsumerOf.apply1[IO](),
+        producerOf = ProducerOf.apply1[IO](),
+        config = KafkaPersistenceModule.TransactionalConfig(
+          consumerConfig = ConsumerConfig(
+            common          = producerConfig.common,
+            autoCommit      = false,
+            autoOffsetReset = AutoOffsetReset.Earliest
+          ),
+          producerConfig        = producerConfig,
+          transactionalIdPrefix = s"$testGroupId-$inputTopic",
+          snapshotTopic         = stateTopic,
+          inputTopic            = inputTopic,
+        ),
+        groupMetadata = consumer.groupMetadata,
       )
-    }
+
+    (createTopic(stateTopic, 2) *> comboTestCase(kafkaModule(), makeModuleOf, inputTopic)).unsafeRunSync()
   }
 
+  // the module factory is built from the consumer that drives the flow so that, in transactional mode, the snapshot
+  // writer can read that consumer's group metadata (generation) for offset binding; non-transactional cases ignore it
   private def comboTestCase(
     kafka: KafkaModule[IO],
-    persistenceModuleOf: KafkaPersistenceModuleOf[IO, State],
+    makeModuleOf: Consumer[IO] => KafkaPersistenceModuleOf[IO, State],
     inputTopic: String
   ): IO[Unit] = {
     for {
       _ <- createTopic(inputTopic, 2)
-      _ <- testCase(kafka, persistenceModuleOf, inputTopic, Partition.unsafe(0), "key0")
-      _ <- testCase(kafka, persistenceModuleOf, inputTopic, Partition.unsafe(1), "key1")
+      _ <- testCase(kafka, makeModuleOf, inputTopic, Partition.unsafe(0), "key0")
+      _ <- testCase(kafka, makeModuleOf, inputTopic, Partition.unsafe(1), "key1")
     } yield ()
   }
 
   private def testCase(
     kafka: KafkaModule[IO],
-    persistenceModuleOf: KafkaPersistenceModuleOf[IO, State],
+    makeModuleOf: Consumer[IO] => KafkaPersistenceModuleOf[IO, State],
     inputTopic: String,
     partition: Partition,
     key: String
@@ -178,21 +193,26 @@ class StatefulProcessingWithKafkaSpec extends ForAllKafkaSuite {
       }
     }
 
-    def program: IO[List[Output]] = for {
-      output   <- Ref.of[IO, List[Output]](List.empty)
-      finished <- Deferred[IO, Unit]
-      flowOf   <- topicFlowOf(persistenceModuleOf, output, finished)
-      run = KafkaFlow.resource(
-        consumer = kafka.consumerOf("groupId-StatefulProcessingWithKafkaSpec"),
-        flowOf = ConsumerFlowOf[IO](
-          topic  = inputTopic,
-          flowOf = flowOf
-        )
-      )
-      // wait for records to be processed
-      _      <- run.use(_ => finished.get.timeout(5.seconds))
-      output <- output.get
-    } yield output
+    // allocate the consumer first, then build the module from it (so transactional offset binding reads this
+    // consumer's generation) and drive the flow with the same consumer instance
+    def program: IO[List[Output]] =
+      kafka.consumerOf("groupId-StatefulProcessingWithKafkaSpec").use { consumer =>
+        for {
+          output   <- Ref.of[IO, List[Output]](List.empty)
+          finished <- Deferred[IO, Unit]
+          flowOf   <- topicFlowOf(makeModuleOf(consumer), output, finished)
+          run = KafkaFlow.resource(
+            consumer = Resource.pure[IO, Consumer[IO]](consumer),
+            flowOf = ConsumerFlowOf[IO](
+              topic  = inputTopic,
+              flowOf = flowOf
+            )
+          )
+          // wait for records to be processed
+          _      <- run.use(_ => finished.get.timeout(5.seconds))
+          output <- output.get
+        } yield output
+      }
 
     for {
       _      <- produceInput(1)

--- a/persistence-kafka-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/TransactionalKafkaPersistenceSpec.scala
+++ b/persistence-kafka-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/TransactionalKafkaPersistenceSpec.scala
@@ -1,0 +1,468 @@
+package com.evolutiongaming.kafka.flow.kafkapersistence
+
+import cats.data.NonEmptyList
+import cats.effect.unsafe.IORuntime
+import cats.effect.{IO, Ref, Resource}
+import cats.syntax.all.*
+import com.evolutiongaming.catshelper.{FromTry, Log, LogOf}
+import com.evolutiongaming.kafka.flow.kafka.ScheduleCommit
+import com.evolutiongaming.kafka.flow.registry.EntityRegistry
+import com.evolutiongaming.kafka.flow.snapshot.SnapshotWriteDatabase
+import com.evolutiongaming.kafka.flow.timer.{TimerFlowOf, TimersOf}
+import com.evolutiongaming.kafka.flow.{
+  FoldOption,
+  ForAllKafkaSuite,
+  KafkaKey,
+  PartitionFlow,
+  PartitionFlowConfig,
+  PartitionFlowOf,
+  TickOption
+}
+import com.evolutiongaming.skafka.consumer.{
+  AutoOffsetReset,
+  ConsumerConfig,
+  ConsumerGroupMetadata,
+  ConsumerOf,
+  ConsumerRecord,
+  IsolationLevel,
+  WithSize
+}
+import com.evolutiongaming.skafka.producer.{Producer, ProducerConfig, ProducerOf, ProducerRecord}
+import com.evolutiongaming.skafka.{CommonConfig, Offset, Partition, TopicPartition}
+import org.apache.kafka.clients.consumer.CommitFailedException
+import scodec.bits.ByteVector
+
+import scala.concurrent.duration.*
+
+/** Reproduces the stale-writer snapshot corruption of
+  * [[https://github.com/evolution-gaming/kafka-flow/issues/732 issue #732]] through the real kafka-flow machinery
+  * (PartitionFlow, eager recovery, fold, buffered snapshots, flush-on-revoke), and proves the transactional mode
+  * prevents it. The ownership overlap is simulated by two PartitionFlows over one partition: a real overlap (the
+  * previous owner not yet aware of the revocation) is indistinguishable from the second flow being created while the
+  * first is still alive.
+  */
+class TransactionalKafkaPersistenceSpec extends ForAllKafkaSuite {
+  implicit val ioRuntime: IORuntime = IORuntime.global
+  implicit val logOf: LogOf[IO]     = LogOf.slf4j[IO].unsafeRunSync()
+  implicit val log: Log[IO]         = logOf(this.getClass).unsafeRunSync()
+  implicit val fromTry: FromTry[IO] = FromTry.lift
+
+  private val appId   = "app-id"
+  private val groupId = "group-id"
+
+  private def commonConfig =
+    CommonConfig(bootstrapServers = NonEmptyList.one(kafka.container.bootstrapServers))
+
+  private def producerConfig = ProducerConfig(common = commonConfig)
+
+  private def consumerConfig =
+    ConsumerConfig(common = commonConfig, autoCommit = false, autoOffsetReset = AutoOffsetReset.Earliest)
+
+  private def producerOf = ProducerOf.apply1[IO]()
+
+  private def consumerOf = ConsumerOf.apply1[IO]()
+
+  private def transactionalProducer(transactionalId: String): Resource[IO, Producer[IO]] =
+    producerOf(producerConfig.copy(transactionalId = transactionalId.some, idempotence = true))
+
+  /** Recovery read of the snapshot topic, as performed on partition assignment.
+    *
+    * `read_committed` matches the transactional mode; it is equally correct for reading topics written without
+    * transactions, where it behaves the same as `read_uncommitted`.
+    */
+  private def readSnapshots(stateTopic: String): IO[BytesByKey] =
+    KafkaPartitionPersistence.readSnapshots[IO](
+      consumerOf     = consumerOf,
+      consumerConfig = consumerConfig.copy(isolationLevel = IsolationLevel.ReadCommitted),
+      snapshotTopic  = stateTopic,
+      partition      = Partition.min,
+    )
+
+  private def utf8(value: String): Option[ByteVector] = ByteVector.encodeUtf8(value).toOption
+
+  /** The previous consumer generation: what a stale owner that has not observed the rebalance still holds. A commit
+    * carrying it is fenced by the broker (KIP-447).
+    */
+  private def staleGeneration(current: ConsumerGroupMetadata): ConsumerGroupMetadata =
+    current.copy(generationId = current.generationId - 1)
+
+  /** State is the comma-joined list of folded events, as a stand-in for a real aggregate. */
+  private def fold: FoldOption[IO, String, ConsumerRecord[String, ByteVector]] =
+    FoldOption.of { (state, record) =>
+      IO {
+        val event = record.value.flatMap(_.value.decodeUtf8.toOption).getOrElse(sys.error("event payload missing"))
+        state.fold(event)(s => s"$s,$event").some
+      }
+    }
+
+  private def flowOf(
+    moduleOf: KafkaPersistenceModuleOf[IO, String],
+    timerFlowOf: TimerFlowOf[IO],
+    config: PartitionFlowConfig = PartitionFlowConfig(commitOnRevoke = true),
+  ): IO[PartitionFlowOf[IO]] =
+    TimersOf.memory[IO, KafkaKey].map { timersOf =>
+      kafkaEagerRecovery[IO, String](
+        kafkaPersistenceModuleOf = moduleOf,
+        applicationId            = appId,
+        groupId                  = groupId,
+        timersOf                 = timersOf,
+        timerFlowOf              = timerFlowOf,
+        fold                     = fold,
+        tick                     = TickOption.id[IO, String],
+        partitionFlowConfig      = config,
+        registry                 = EntityRegistry.empty[IO, KafkaKey, String],
+      )
+    }
+
+  /** Snapshots are flushed only when the flow is released (flush-on-revoke), never periodically - so the moment of the
+    * stale write is controlled by the test.
+    */
+  private def flushOnRevokeOnly: TimerFlowOf[IO] =
+    TimerFlowOf.persistPeriodically[IO](fireEvery = 1.hour, persistEvery = 1.hour, flushOnRevoke = true)
+
+  private def inputRecords(
+    inputTopic: String,
+    key: String,
+    events: List[String]
+  ): List[ConsumerRecord[String, ByteVector]] =
+    events.zipWithIndex.map {
+      case (event, offset) =>
+        ConsumerRecord[String, ByteVector](
+          topicPartition   = TopicPartition(inputTopic, Partition.min),
+          offset           = Offset.unsafe(offset.toLong),
+          timestampAndType = None,
+          key              = Some(WithSize(key)),
+          value            = Some(WithSize(ByteVector.encodeUtf8(event).toOption.get)),
+        )
+    }
+
+  /** The #732 scenario: the previous owner (flow A) folds events 1..5 without flushing; the new owner (flow B) recovers
+    * (nothing was persisted or committed by A), re-folds events 1..5 plus new events 6..10, and flushes on release;
+    * then A - unaware of the handover - flushes its stale state on revoke.
+    *
+    * Returns (result of A's release, snapshot store content after A's release).
+    */
+  private def staleFlushScenario(
+    moduleOfA: KafkaPersistenceModuleOf[IO, String],
+    moduleOfB: KafkaPersistenceModuleOf[IO, String],
+    stateTopic: String,
+    key: String,
+  ): IO[(Either[Throwable, Unit], BytesByKey)] = {
+    val inputTopic = s"input-$stateTopic"
+    val tp         = TopicPartition(inputTopic, Partition.min)
+    val eventsA    = (1 to 5).toList.map(i => s"e$i")
+    val eventsB    = (1 to 10).toList.map(i => s"e$i")
+
+    def allocateFlow(moduleOf: KafkaPersistenceModuleOf[IO, String]): IO[(PartitionFlow[IO], IO[Unit])] =
+      flowOf(moduleOf, flushOnRevokeOnly).flatMap(_.apply(tp, Offset.min, ScheduleCommit.empty[IO]).allocated)
+
+    for {
+      _ <- createTopic(stateTopic, 1)
+      // the previous owner: folds events, snapshots stay buffered in memory
+      flowA             <- allocateFlow(moduleOfA)
+      (flowA_, releaseA) = flowA
+      _                 <- flowA_(inputRecords(inputTopic, key, eventsA))
+      // the new owner: eagerly recovers (finds nothing), folds all events, flushes on release
+      flowB             <- allocateFlow(moduleOfB)
+      (flowB_, releaseB) = flowB
+      _                 <- flowB_(inputRecords(inputTopic, key, eventsB))
+      _                 <- releaseB
+      newOwnerWrote     <- readSnapshots(stateTopic)
+      _                  = assertEquals(clue(newOwnerWrote.get(key)), utf8(eventsB.mkString(",")))
+      // the previous owner flushes its stale state on revoke
+      staleFlush <- releaseA.attempt
+      stored     <- readSnapshots(stateTopic)
+    } yield (staleFlush, stored)
+  }
+
+  private def causeChain(e: Throwable): List[Throwable] =
+    List.unfold(Option(e)) { current =>
+      current.map(c => (c, Option(c.getCause).filter(_ ne c)))
+    }
+
+  test("issue #732 reproduction: stale flush-on-revoke overwrites the new owner's snapshot (shared producer)") {
+    val stateTopic = "flow-732-lww-state-topic"
+    val key        = "key1"
+
+    val test = producerOf(producerConfig).use { producer =>
+      val moduleOf = KafkaPersistenceModuleOf.caching[IO, String](
+        consumerOf     = consumerOf,
+        producer       = producer,
+        consumerConfig = consumerConfig,
+        snapshotTopic  = stateTopic,
+      )
+      staleFlushScenario(moduleOf, moduleOf, stateTopic, key).map {
+        case (staleFlush, stored) =>
+          assertEquals(clue(staleFlush), Right(()))
+          // recovery now returns the STALE snapshot (events 6..10 are lost although the new owner persisted them):
+          // this assertion documents the corruption of issue #732, prevented in the paired test below
+          assertEquals(clue(stored.get(key)), utf8("e1,e2,e3,e4,e5"))
+      }
+    }
+
+    test.unsafeRunSync()
+  }
+
+  test("issue #732 prevention: stale flush-on-revoke is fenced (transactional)") {
+    val stateTopic = "flow-732-tx-state-topic"
+    val inputTopic = s"input-$stateTopic"
+    val group      = s"$groupId-flush-on-revoke"
+    val key        = "key1"
+
+    def moduleOf(gm: ConsumerGroupMetadata): KafkaPersistenceModuleOf[IO, String] =
+      KafkaPersistenceModuleOf.cachingTransactional[IO, String](
+        consumerOf = consumerOf,
+        producerOf = producerOf,
+        config = KafkaPersistenceModule.TransactionalConfig(
+          consumerConfig        = consumerConfig,
+          producerConfig        = producerConfig,
+          transactionalIdPrefix = s"$group-$inputTopic",
+          snapshotTopic         = stateTopic,
+          inputTopic            = inputTopic,
+        ),
+        groupMetadata = IO.pure(gm.some),
+      )
+
+    // the previous owner (flow A) carries a stale generation; the new owner (flow B) carries the current one
+    val test = createTopic(inputTopic, 1) *> withJoinedConsumer(group, inputTopic) { current =>
+      val stale = staleGeneration(current)
+      staleFlushScenario(moduleOf(stale), moduleOf(current), stateTopic, key).map {
+        case (staleFlush, stored) =>
+          // the release itself succeeds: the rejected write surfaces as a logged-and-swallowed cache entry release
+          // error ("scache: failed to release cache entry: ... CommitFailedException"), which is the desired
+          // outcome for a partition that is being given away anyway
+          assertEquals(clue(staleFlush), Right(()))
+          // the protection: the stale (older-generation) write did not land, the new owner's snapshot survived
+          assertEquals(clue(stored.get(key)), utf8((1 to 10).map(i => s"e$i").mkString(",")))
+      }
+    }
+
+    test.unsafeRunSync()
+  }
+
+  test("issue #732 prevention: a fenced stale writer fails fast on its next periodic flush (transactional)") {
+    val stateTopic = "flow-732-tx-failfast-state-topic"
+    val inputTopic = s"input-$stateTopic"
+    val group      = s"$groupId-failfast"
+    val tp         = TopicPartition(inputTopic, Partition.min)
+    val key        = "key1"
+
+    // the owner starts current and persists fine; a rebalance then leaves it on a stale generation (simulated by
+    // flipping the metadata it reads), so its next flush is generation-fenced and fails fast
+    val test = createTopic(stateTopic, 1) *> createTopic(inputTopic, 1) *> withJoinedConsumer(group, inputTopic) {
+      current =>
+        for {
+          gmRef <- Ref.of[IO, ConsumerGroupMetadata](current)
+          moduleOf = KafkaPersistenceModuleOf.cachingTransactional[IO, String](
+            consumerOf = consumerOf,
+            producerOf = producerOf,
+            config = KafkaPersistenceModule.TransactionalConfig(
+              consumerConfig        = consumerConfig,
+              producerConfig        = producerConfig,
+              transactionalIdPrefix = s"$group-$inputTopic",
+              snapshotTopic         = stateTopic,
+              inputTopic            = inputTopic,
+            ),
+            groupMetadata = gmRef.get.map(_.some),
+          )
+          // flush on every records application, so the writer hits the conflict on its next poll cycle
+          flow <- flowOf(
+            moduleOf,
+            TimerFlowOf.persistPeriodically[IO](fireEvery = 0.seconds, persistEvery = 0.seconds),
+            PartitionFlowConfig(triggerTimersInterval     = 0.seconds),
+          ).flatMap(_.apply(tp, Offset.min, ScheduleCommit.empty[IO]).allocated)
+          (flow_, release) = flow
+          // persists fine while the generation is current
+          _ <- flow_(inputRecords(inputTopic, key, List("e1", "e2", "e3")))
+          // the partition is reassigned: the owner's captured generation is now stale
+          _ <- gmRef.set(staleGeneration(current))
+          // the next periodic flush must fail fast with the conflict
+          staleResult <- flow_(inputRecords(inputTopic, key, List("e1", "e2", "e3", "e4")).drop(3)).attempt
+          _           <- release.attempt // the fenced writer's flush-on-revoke error is logged and swallowed
+        } yield staleResult match {
+          case Left(e) =>
+            assert(
+              clue(causeChain(e)).exists(_.isInstanceOf[CommitFailedException]),
+              s"expected CommitFailedException in the cause chain of $e",
+            )
+          case Right(()) => fail("expected the fenced writer's periodic flush to fail fast, but it succeeded")
+        }
+    }
+
+    test.unsafeRunSync()
+  }
+
+  test("issue #732 prevention: a stale consumer generation is fenced from committing offsets transactionally") {
+    val stateTopic = "flow-732-tx-stale-generation-state-topic"
+    val inputTopic = s"input-$stateTopic"
+    val group      = s"$groupId-stale-generation"
+    val tp         = TopicPartition(inputTopic, Partition.min)
+
+    val test = for {
+      _ <- createTopic(stateTopic, 1)
+      _ <- createTopic(inputTopic, 1)
+      result <- withJoinedConsumer(group, inputTopic) { current =>
+        // a previous-generation owner: the broker rejects a transactional offset commit whose generation is not the
+        // current one (KIP-447), which aborts the transaction (and, in a real flow, the snapshot writes within it)
+        val stale = staleGeneration(current)
+        transactionalProducer(s"$group-tx").use { producer =>
+          for {
+            _ <- producer.initTransactions
+            tx <- KafkaSnapshotWriteDatabase.transactional[IO, String](
+              snapshotTopicPartition = TopicPartition(stateTopic, Partition.min),
+              producer               = producer,
+              inputTopicPartition    = tp,
+              groupMetadata          = IO.pure(stale.some),
+              assignedOffset         = Offset.min,
+            )
+            attempt <- tx.scheduleCommit.schedule(Offset.unsafe(5)).attempt
+          } yield attempt
+        }
+      }
+      stored <- readSnapshots(stateTopic)
+    } yield {
+      result match {
+        case Left(e) =>
+          // the stale generation is rejected on sendOffsetsToTransaction with CommitFailedException
+          val chain = causeChain(e)
+          assert(
+            chain.exists(_.isInstanceOf[CommitFailedException]),
+            s"expected CommitFailedException in the cause chain, " +
+              s"got ${chain.map(_.getClass.getName)}: ${chain.map(_.getMessage)}",
+          )
+        case Right(()) => fail("expected the stale-generation offset commit to be rejected, but it succeeded")
+      }
+      // the rejected commit aborted: nothing landed in the snapshot store
+      assertEquals(clue(stored), BytesByKey.empty)
+    }
+
+    test.unsafeRunSync()
+  }
+
+  test("issue #732 prevention: a stale writer's very first snapshot flush is generation-gated by the seeded offset") {
+    val stateTopic = "flow-732-tx-none-window-state-topic"
+    val inputTopic = s"input-$stateTopic"
+    val group      = s"$groupId-none-window"
+    val tp         = TopicPartition(inputTopic, Partition.min)
+    val key        = KafkaKey(appId, groupId, tp, "key1")
+
+    val test = for {
+      _ <- createTopic(stateTopic, 1)
+      _ <- createTopic(inputTopic, 1)
+      result <- withJoinedConsumer(group, inputTopic) { current =>
+        val stale = staleGeneration(current)
+        transactionalProducer(s"$group-tx").use { producer =>
+          for {
+            _ <- producer.initTransactions
+            tx <- KafkaSnapshotWriteDatabase.transactional[IO, String](
+              snapshotTopicPartition = TopicPartition(stateTopic, Partition.min),
+              producer               = producer,
+              inputTopicPartition    = tp,
+              groupMetadata          = IO.pure(stale.some),
+              // seeded: so even the FIRST write (below, with no prior scheduleCommit) carries the offset and is
+              // generation-gated. Without the seed this would be the ungated "None window" and the stale write
+              // would land.
+              assignedOffset = Offset.unsafe(3),
+            )
+            // the very first write, no scheduleCommit beforehand - relies entirely on the seed for gating
+            attempt <- tx.writeDatabase.persist(key, "stale-state").attempt
+          } yield attempt
+        }
+      }
+      stored <- readSnapshots(stateTopic)
+    } yield {
+      result match {
+        case Left(e) =>
+          // even the first write carries the seeded offset, so the stale generation is rejected with CommitFailedException
+          val chain = causeChain(e)
+          assert(
+            chain.exists(_.isInstanceOf[CommitFailedException]),
+            s"expected the stale first flush to be generation-fenced (CommitFailedException), " +
+              s"got ${chain.map(_.getClass.getName)}: ${chain.map(_.getMessage)}",
+          )
+        case Right(()) =>
+          fail("expected the stale writer's first (seeded) flush to be generation-fenced, but it landed")
+      }
+      // the stale first flush did not land
+      assertEquals(clue(stored), BytesByKey.empty)
+    }
+
+    test.unsafeRunSync()
+  }
+
+  // the assertions cover safety (all writes land), not grouping - grouping is opportunistic and its effect is
+  // demonstrated by TransactionalWriteThroughputSpec; also exercised with maxWritesPerTransaction = 1, where the
+  // group commit degenerates to a transaction per write
+  List(KafkaSnapshotWriteDatabase.DefaultMaxWritesPerTransaction, 1).foreach { maxWritesPerTransaction =>
+    test(
+      s"concurrent writes of different keys are safe on the shared transactional producer " +
+        s"(maxWritesPerTransaction = $maxWritesPerTransaction)"
+    ) {
+      val stateTopic = s"tx-concurrent-$maxWritesPerTransaction-state-topic"
+      val inputTopic = s"input-$stateTopic"
+      val group      = s"$groupId-concurrent-$maxWritesPerTransaction"
+      val keys       = (1 to 10).toList.map(i => s"key$i")
+
+      def kafkaKey(key: String): KafkaKey =
+        KafkaKey(appId, groupId, TopicPartition(inputTopic, Partition.min), key)
+
+      def writeDatabase(
+        producer: Producer[IO],
+        gm: ConsumerGroupMetadata
+      ): IO[SnapshotWriteDatabase[IO, KafkaKey, String]] =
+        KafkaSnapshotWriteDatabase
+          .transactional[IO, String](
+            snapshotTopicPartition  = TopicPartition(stateTopic, Partition.min),
+            producer                = producer,
+            inputTopicPartition     = TopicPartition(inputTopic, Partition.min),
+            groupMetadata           = IO.pure(gm.some),
+            assignedOffset          = Offset.min,
+            maxWritesPerTransaction = maxWritesPerTransaction,
+          )
+          .map(_.writeDatabase)
+
+      // a real generation is needed because every transaction commits the (seeded) offset
+      val test = createTopic(stateTopic, 1) *> createTopic(inputTopic, 1) *>
+        withJoinedConsumer(group, inputTopic) { current =>
+          transactionalProducer(s"tx-concurrent-$maxWritesPerTransaction").use { producer =>
+            for {
+              _        <- producer.initTransactions
+              database <- writeDatabase(producer, current)
+              // kafka-flow flushes keys of a partition in parallel by default: this must not corrupt or crash
+              _      <- keys.parTraverse_(key => database.persist(kafkaKey(key), s"state-of-$key"))
+              stored <- readSnapshots(stateTopic)
+            } yield keys.foreach { key =>
+              assertEquals(clue(stored.get(key)), utf8(s"state-of-$key"))
+            }
+          }
+        }
+
+      test.unsafeRunSync()
+    }
+  }
+
+  test("an open transaction of a fenced writer neither blocks nor leaks into recovery") {
+    val stateTopic = "tx-open-state-topic"
+
+    val record = new ProducerRecord(
+      topic     = stateTopic,
+      partition = Partition.min.some,
+      key       = "key-uncommitted".some,
+      value     = "uncommitted".some,
+    )
+
+    val test = createTopic(stateTopic, 1) *>
+      transactionalProducer("tx-open").use { producerA =>
+        for {
+          _ <- producerA.initTransactions
+          _ <- producerA.beginTransaction
+          _ <- producerA.send(record).flatten
+          // producerA's transaction is left open: initTransactions of the new producer aborts it
+          _      <- transactionalProducer("tx-open").use(_.initTransactions)
+          stored <- readSnapshots(stateTopic).timeout(30.seconds)
+        } yield assertEquals(clue(stored.get("key-uncommitted")), none[ByteVector])
+      }
+
+    test.unsafeRunSync()
+  }
+}

--- a/persistence-kafka-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/TransactionalWriteThroughputSpec.scala
+++ b/persistence-kafka-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/TransactionalWriteThroughputSpec.scala
@@ -1,0 +1,295 @@
+package com.evolutiongaming.kafka.flow.kafkapersistence
+
+import cats.data.NonEmptyList
+import cats.effect.IO
+import cats.effect.unsafe.IORuntime
+import cats.syntax.all.*
+import com.evolutiongaming.catshelper.{FromTry, Log, LogOf}
+import com.evolutiongaming.kafka.flow.snapshot.SnapshotWriteDatabase
+import com.evolutiongaming.kafka.flow.{ForAllKafkaSuite, KafkaKey}
+import com.evolutiongaming.skafka.consumer.{
+  AutoOffsetReset,
+  ConsumerConfig,
+  ConsumerGroupMetadata,
+  ConsumerOf,
+  IsolationLevel
+}
+import com.evolutiongaming.skafka.producer.{ProducerConfig, ProducerOf}
+import com.evolutiongaming.skafka.{CommonConfig, Offset, Partition, TopicPartition}
+
+import scala.concurrent.duration.*
+
+/** Measures the cost of transactional snapshot writes for capacity planning (numbers feed
+  * `docs/kafka-single-writer-design.md`) and demonstrates the failure mode motivating the cap: a transaction outliving
+  * `transaction.timeout.ms` is aborted by the coordinator. Single-node testcontainers numbers are a floor (no network,
+  * replication factor 1); the assertions are sanity-only.
+  */
+class TransactionalWriteThroughputSpec extends ForAllKafkaSuite {
+
+  // Performance/rationale experiment, not a regression test: it adds no coverage beyond
+  // TransactionalKafkaPersistenceSpec and is expensive, so it is excluded from the default test run.
+  // Run on demand to refresh the numbers in docs/kafka-single-writer-design.md:
+  //   KAFKA_FLOW_PERF=1 sbt "persistence-kafka-it-tests/testOnly *TransactionalWriteThroughputSpec"
+  override def munitIgnore: Boolean = !sys.env.contains("KAFKA_FLOW_PERF")
+
+  // repeated interleaved bursts (esp. the cap=1 sweep) run well past munit's 30s default
+  override def munitTimeout: Duration = 5.minutes
+
+  implicit val ioRuntime: IORuntime = IORuntime.global
+  implicit val logOf: LogOf[IO]     = LogOf.slf4j[IO].unsafeRunSync()
+  implicit val log: Log[IO]         = logOf(this.getClass).unsafeRunSync()
+  implicit val fromTry: FromTry[IO] = FromTry.lift
+
+  private val keyCount = 500
+
+  private def commonConfig =
+    CommonConfig(bootstrapServers = NonEmptyList.one(kafka.container.bootstrapServers))
+
+  private def producerConfig = ProducerConfig(common = commonConfig)
+
+  private def producerOf = ProducerOf.apply1[IO]()
+
+  private def kafkaKey(stateTopic: String, key: String): KafkaKey =
+    KafkaKey("app-id", "group-id", TopicPartition(s"input-$stateTopic", Partition.min), key)
+
+  private def readSnapshots(stateTopic: String): IO[BytesByKey] =
+    KafkaPartitionPersistence.readSnapshots[IO](
+      consumerOf = ConsumerOf.apply1[IO](),
+      consumerConfig = ConsumerConfig(
+        common          = commonConfig,
+        autoCommit      = false,
+        autoOffsetReset = AutoOffsetReset.Earliest,
+        isolationLevel  = IsolationLevel.ReadCommitted,
+      ),
+      snapshotTopic = stateTopic,
+      partition     = Partition.min,
+    )
+
+  private def timed(io: IO[Unit]): IO[FiniteDuration] =
+    for {
+      started <- IO.monotonic
+      _       <- io
+      ended   <- IO.monotonic
+    } yield ended - started
+
+  private def persistSequentially(
+    stateTopic: String,
+    database: SnapshotWriteDatabase[IO, KafkaKey, String],
+  ): IO[FiniteDuration] =
+    timed((1 to keyCount).toList.traverse_(i => database.persist(kafkaKey(stateTopic, s"key$i"), s"state$i")))
+
+  // a burst of concurrent key flushes, as produced by PartitionFlow's parallel timer triggering
+  private def persistConcurrently(
+    stateTopic: String,
+    database: SnapshotWriteDatabase[IO, KafkaKey, String],
+  ): IO[FiniteDuration] =
+    timed((1 to keyCount).toList.parTraverse_(i => database.persist(kafkaKey(stateTopic, s"key$i"), s"state$i")))
+
+  // measured repeats per configuration; the min discards the cold first sample and transient broker/disk
+  // contention, leaving a stable floor (matching the "floor" framing in docs/kafka-single-writer-design.md)
+  private val iterations = 3
+
+  // min elapsed over `iterations` runs, each on its own fresh state topic ("<label>-<i>-state-topic")
+  private def best(label: String)(measureOnce: String => IO[FiniteDuration]): IO[FiniteDuration] =
+    (1 to iterations).toList.traverse(i => measureOnce(s"$label-$i-state-topic")).map(_.minBy(_.toNanos))
+
+  // demonstrates the failure mode that motivates the maxWritesPerTransaction bound: a transaction kept open past
+  // transaction.timeout.ms is aborted by the coordinator and its commit fails on a perfectly healthy producer
+  // (the exact exception varies with broker/client version: InvalidTxnState / InvalidProducerEpoch / ProducerFenced)
+  test("a transaction exceeding transaction.timeout.ms is aborted by the coordinator") {
+    val stateTopic = "tx-timeout-state-topic"
+
+    val record = new com.evolutiongaming.skafka.producer.ProducerRecord(
+      topic     = stateTopic,
+      partition = Partition.min.some,
+      key       = "key1".some,
+      value     = "state1".some,
+    )
+
+    val test = createTopic(stateTopic, 1) *>
+      producerOf(
+        producerConfig.copy(
+          transactionalId    = "tx-timeout".some,
+          idempotence        = true,
+          transactionTimeout = 1.second,
+        )
+      ).use { producer =>
+        // the coordinator aborts the expired transaction lazily (abort-checker interval
+        // transaction.abort.timed.out.transaction.cleanup.interval.ms, 10s default): probe with non-committing
+        // sends until the abort is observed instead of relying on a fixed sleep margin
+        def awaitAbort(attemptsLeft: Int): IO[Unit] =
+          IO.sleep(3.seconds) *> producer.send(record).flatten.attempt.flatMap {
+            case Left(_)                       => IO.unit
+            case Right(_) if attemptsLeft <= 1 => IO(fail("transaction was not aborted within the probe budget"))
+            case Right(_)                      => awaitAbort(attemptsLeft - 1)
+          }
+
+        for {
+          _      <- producer.initTransactions
+          _      <- producer.beginTransaction
+          _      <- producer.send(record).flatten
+          _      <- awaitAbort(attemptsLeft = 10)
+          result <- producer.commitTransaction.attempt
+        } yield result match {
+          case Left(e) =>
+            // println instead of log: the test logback config suppresses info level
+            println(s"timed-out transaction commit failed with: ${e.getClass.getName}: ${e.getMessage}")
+            assert(
+              clue(e).isInstanceOf[org.apache.kafka.common.errors.InvalidTxnStateException] ||
+                clue(e).isInstanceOf[org.apache.kafka.common.errors.InvalidProducerEpochException] ||
+                clue(e).isInstanceOf[org.apache.kafka.common.errors.ProducerFencedException],
+              s"expected a transactional-state exception, got $e",
+            )
+          case Right(_) => fail("expected the timed-out transaction commit to fail, but it succeeded")
+        }
+      }
+
+    test.unsafeRunSync()
+  }
+
+  // burst cost at different batch caps, with payloads closer to real snapshots; numbers feed
+  // docs/kafka-single-writer-design.md
+  test("persist a burst of snapshots at different maxWritesPerTransaction values") {
+    val burst   = 2000
+    val payload = "x" * 10240 // 10 KiB, in the ballpark of a real serialized aggregate
+
+    // the transactional configs do not consume - the input topic is only the offset-commit target and the source
+    // of a real generation - so a single joined consumer (heartbeating throughout, so its generation is stable)
+    // serves all of them
+    val sharedInput = "tx-burst-input-topic"
+    val sharedGroup = "tx-burst-group"
+
+    // safety-off baseline: the same burst on a plain shared batched producer (no transactions)
+    def measurePlain(stateTopic: String): IO[FiniteDuration] =
+      createTopic(stateTopic, 1) *>
+        producerOf(producerConfig).use { producer =>
+          val database = KafkaSnapshotWriteDatabase.of[IO, String](TopicPartition(stateTopic, Partition.min), producer)
+          for {
+            _ <- database.persist(kafkaKey(stateTopic, "warm-up"), payload)
+            elapsed <- timed(
+              (1 to burst).toList.parTraverse_(i => database.persist(kafkaKey(stateTopic, s"key$i"), payload))
+            )
+            stored <- readSnapshots(stateTopic)
+            _       = assertEquals(clue(stored.size), burst + 1)
+          } yield elapsed
+        }
+
+    def measureTx(cap: Int, current: ConsumerGroupMetadata)(stateTopic: String): IO[FiniteDuration] =
+      createTopic(stateTopic, 1) *>
+        producerOf(producerConfig.copy(transactionalId = s"$stateTopic-tx".some, idempotence = true)).use { producer =>
+          for {
+            _ <- producer.initTransactions
+            // each transaction also commits the seeded offset with the current generation - part of the measured cost
+            database <- KafkaSnapshotWriteDatabase
+              .transactional[IO, String](
+                snapshotTopicPartition  = TopicPartition(stateTopic, Partition.min),
+                producer                = producer,
+                inputTopicPartition     = TopicPartition(sharedInput, Partition.min),
+                groupMetadata           = IO.pure(current.some),
+                assignedOffset          = Offset.min,
+                maxWritesPerTransaction = cap,
+              )
+              .map(_.writeDatabase)
+            _ <- database.persist(kafkaKey(stateTopic, "warm-up"), payload)
+            elapsed <- timed(
+              (1 to burst).toList.parTraverse_(i => database.persist(kafkaKey(stateTopic, s"key$i"), payload))
+            )
+            stored <- readSnapshots(stateTopic)
+            _       = assertEquals(clue(stored.size), burst + 1)
+          } yield elapsed
+        }
+
+    val test = createTopic(sharedInput, 1) *> withJoinedConsumer(sharedGroup, sharedInput) { current =>
+      val configs: List[(String, String => IO[FiniteDuration])] = List(
+        "shared batched producer"         -> measurePlain,
+        "maxWritesPerTransaction=1"       -> measureTx(1, current),
+        "maxWritesPerTransaction=16"      -> measureTx(16, current),
+        "maxWritesPerTransaction=256"     -> measureTx(256, current),
+        s"maxWritesPerTransaction=$burst" -> measureTx(burst, current),
+      )
+      for {
+        // discarded warm-up burst: warms JIT, the producer connection and the transaction path before timing
+        _ <- measureTx(burst, current)("tx-burst-warm-up-state-topic")
+        // interleave - each iteration runs every config once on a fresh topic, so no config is systematically
+        // penalised by accumulated broker load; the per-config min then picks its least-contended sample
+        samples <- (1 to iterations).toList.flatTraverse { i =>
+          configs.zipWithIndex.traverse {
+            case ((label, measureOnce), idx) =>
+              measureOnce(s"tx-burst-c$idx-i$i-state-topic").map(label -> _)
+          }
+        }
+        _ <- IO.println {
+          configs
+            .map {
+              case (label, _) =>
+                s"$label: ${samples.collect { case (`label`, d) => d }.minBy(_.toNanos).toMillis} ms"
+            }
+            .mkString(s"burst of $burst x ${payload.length / 1024} KiB snapshots (min of $iterations): ", ", ", "")
+        }
+      } yield ()
+    }
+
+    test.unsafeRunSync()
+  }
+
+  test(s"persist $keyCount snapshots: shared batched producer vs transactions") {
+    // one shared joined consumer for the transactional measurements (see Experiment B above)
+    val sharedInput = "throughput-input-topic"
+    val sharedGroup = "throughput-group"
+
+    def plainSequential(stateTopic: String): IO[FiniteDuration] =
+      createTopic(stateTopic, 1) *>
+        producerOf(producerConfig).use { producer =>
+          val database = KafkaSnapshotWriteDatabase.of[IO, String](TopicPartition(stateTopic, Partition.min), producer)
+          database.persist(kafkaKey(stateTopic, "warm-up"), "warm-up") *> persistSequentially(stateTopic, database)
+        }
+
+    // builds a transactional database on a fresh state topic, does an untimed warm-up write, then times `measure`
+    def measureTx(stateTopic: String, current: ConsumerGroupMetadata)(
+      measure: SnapshotWriteDatabase[IO, KafkaKey, String] => IO[FiniteDuration]
+    ): IO[FiniteDuration] =
+      createTopic(stateTopic, 1) *>
+        producerOf(producerConfig.copy(transactionalId = s"$stateTopic-tx".some, idempotence = true)).use { producer =>
+          for {
+            _ <- producer.initTransactions
+            database <- KafkaSnapshotWriteDatabase
+              .transactional[IO, String](
+                snapshotTopicPartition = TopicPartition(stateTopic, Partition.min),
+                producer               = producer,
+                inputTopicPartition    = TopicPartition(sharedInput, Partition.min),
+                groupMetadata          = IO.pure(current.some),
+                assignedOffset         = Offset.min,
+              )
+              .map(_.writeDatabase)
+            _       <- database.persist(kafkaKey(stateTopic, "warm-up"), "warm-up")
+            elapsed <- measure(database)
+          } yield elapsed
+        }
+
+    val test = createTopic(sharedInput, 1) *> withJoinedConsumer(sharedGroup, sharedInput) { current =>
+      for {
+        // discarded warm-up: warms JIT and the transaction path before timing
+        _ <- measureTx("throughput-warm-up-state-topic", current)(db =>
+          persistConcurrently("throughput-warm-up-state-topic", db)
+        )
+        plain      <- best("throughput-plain")(plainSequential)
+        sequential <- best("throughput-tx-seq")(t => measureTx(t, current)(db => persistSequentially(t, db)))
+        concurrent <- best("throughput-tx-conc")(t => measureTx(t, current)(db => persistConcurrently(t, db)))
+        // println instead of log: the test logback config suppresses info level
+        _ <- IO.println(
+          s"persisted $keyCount snapshots (min of $iterations): shared batched producer in ${plain.toMillis} ms, " +
+            s"sequential transactions in ${sequential.toMillis} ms " +
+            s"(${(sequential / keyCount.toLong).toMicros} us per transaction), " +
+            s"concurrent group-committed transactions in ${concurrent.toMillis} ms"
+        )
+      } yield {
+        // sanity only: all modes complete, and the numbers are usable (non-zero measurements)
+        assert(clue(plain) > Duration.Zero)
+        assert(clue(sequential) > Duration.Zero)
+        assert(clue(concurrent) > Duration.Zero)
+      }
+    }
+
+    test.unsafeRunSync()
+  }
+}

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPartitionPersistence.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPartitionPersistence.scala
@@ -61,7 +61,7 @@ object KafkaPartitionPersistence {
     consumerOf: ConsumerOf[F],
     consumerConfig: ConsumerConfig,
     snapshotTopic: Topic,
-    partition: Partition
+    partition: Partition,
   )(implicit fromBytes: FromBytes[F, String]): F[BytesByKey] = {
     consumerOf
       .apply[String, ByteVector](

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModule.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModule.scala
@@ -1,30 +1,83 @@
 package com.evolutiongaming.kafka.flow.kafkapersistence
 
 import cats.Parallel
-import cats.effect.{Concurrent, Resource}
+import cats.effect.{Async, Concurrent, Resource}
 import cats.syntax.all.*
 import com.evolution.scache.Cache
-import com.evolutiongaming.catshelper.{FromTry, Log, LogOf, Runtime}
+import com.evolutiongaming.catshelper.{FromTry, LogOf, Runtime}
+import com.evolutiongaming.kafka.flow.kafka.ScheduleCommit
 import com.evolutiongaming.kafka.flow.key.{Keys, KeysOf}
 import com.evolutiongaming.kafka.flow.metrics.syntax.*
 import com.evolutiongaming.kafka.flow.persistence.{PersistenceOf, SnapshotPersistenceOf}
-import com.evolutiongaming.kafka.flow.snapshot.{SnapshotDatabase, SnapshotsOf}
+import com.evolutiongaming.kafka.flow.snapshot.{SnapshotDatabase, SnapshotWriteDatabase, SnapshotsOf}
 import com.evolutiongaming.kafka.flow.{FlowMetrics, KafkaKey}
-import com.evolutiongaming.skafka.consumer.{ConsumerConfig, ConsumerOf}
-import com.evolutiongaming.skafka.producer.Producer
-import com.evolutiongaming.skafka.{FromBytes, ToBytes, TopicPartition}
+import com.evolutiongaming.skafka.consumer.{ConsumerConfig, ConsumerGroupMetadata, ConsumerOf, IsolationLevel}
+import com.evolutiongaming.skafka.producer.{Producer, ProducerConfig, ProducerOf}
+import com.evolutiongaming.skafka.{FromBytes, Offset, Partition, ToBytes, Topic, TopicPartition}
 import com.evolutiongaming.sstream.Stream
 import scodec.bits.ByteVector
 import com.evolutiongaming.skafka.consumer.ConsumerRecord
+
+import java.util.UUID
 
 /** A module, necessary to create a Kafka snapshot persistence.
   */
 trait KafkaPersistenceModule[F[_], S] {
   def keysOf: KeysOf[F, KafkaKey]
   def persistenceOf: SnapshotPersistenceOf[F, KafkaKey, S, ConsumerRecord[String, ByteVector]]
+
+  /** A `ScheduleCommit` that commits input offsets transactionally with the snapshot writes, when the module provides
+    * single-writer offset binding (transactional mode). `None` means offsets are committed the default way (by the
+    * consumer). See [[cachingTransactional]].
+    */
+  def scheduleCommit: Option[ScheduleCommit[F]]
 }
 
 object KafkaPersistenceModule {
+
+  /** Settings for [[cachingTransactional]].
+    *
+    * @param consumerConfig
+    *   config for the snapshot-reading consumer; recovery forces `read_committed` regardless of this value
+    * @param producerConfig
+    *   base config for the snapshot producer; `transactionalId` and `idempotence` are overridden per producer and
+    *   `clientId` is suffixed with it
+    * @param transactionalIdPrefix
+    *   prefix for `transactional.id` (partition number and a unique per-producer suffix are appended). Fencing is by
+    *   consumer generation, not this id, so it is just a readable label; `s"$groupId-$inputTopic"` is fine.
+    * @param snapshotTopic
+    *   snapshot topic name (should be configured as a 'compacted' topic) to read/write snapshots
+    * @param inputTopic
+    *   the input topic kafka-flow consumes; its offsets are committed transactionally with the snapshot writes (same
+    *   partition number as the snapshot partition - the mode forces the identity mapping)
+    * @param maxWritesPerTransaction
+    *   upper bound of snapshot writes group committed in one transaction, see
+    *   [[KafkaSnapshotWriteDatabase.transactional]]
+    */
+  final case class TransactionalConfig(
+    consumerConfig: ConsumerConfig,
+    producerConfig: ProducerConfig,
+    transactionalIdPrefix: String,
+    snapshotTopic: Topic,
+    inputTopic: Topic,
+    maxWritesPerTransaction: Int = KafkaSnapshotWriteDatabase.DefaultMaxWritesPerTransaction,
+  )
+
+  /** The per-assignment context [[cachingTransactional]] needs to fence stale writers.
+    *
+    * @param partition
+    *   the assigned partition (used for both the snapshot and the input topic-partition)
+    * @param assignedAt
+    *   the offset the partition was assigned at; seeds the offset-to-commit so even the first write is generation-gated
+    * @param groupMetadata
+    *   group metadata of the SAME consumer that drives this flow (use `Consumer.groupMetadata`); its generation is what
+    *   fences a stale owner (KIP-447). `None` means the consumer is not joined.
+    */
+  final case class PartitionAssignment[F[_]](
+    partition: Partition,
+    assignedAt: Offset,
+    groupMetadata: F[Option[ConsumerGroupMetadata]],
+  )
 
   def caching[F[_]: LogOf: Concurrent: Parallel: Runtime, S](
     consumerOf: ConsumerOf[F],
@@ -90,74 +143,203 @@ object KafkaPersistenceModule {
     toBytesState: ToBytes[F, S]
   ): Resource[F, KafkaPersistenceModule[F, S]] = {
     implicit val fromTry: FromTry[F] = FromTry.lift
+    of(
+      consumerOf             = consumerOf,
+      consumerConfig         = consumerConfig,
+      snapshotTopicPartition = snapshotTopicPartition,
+      metrics                = metrics,
+      partitionMapper        = partitionMapper,
+      writeDatabase          = KafkaSnapshotWriteDatabase.of[F, S](snapshotTopicPartition, producer, partitionMapper),
+    ).map {
+      // non-transactional: offsets are committed the default way (by the consumer), see package.scala
+      case (keysOf, persistenceOf) => module(keysOf, persistenceOf, commit = None)
+    }
+  }
 
-    def readPartitionData(implicit log: Log[F]): F[BytesByKey] = {
-      val targetPartition = partitionMapper.getStatePartition(snapshotTopicPartition.partition)
-      KafkaPartitionPersistence
-        .readSnapshots[F](
-          consumerOf     = consumerOf,
-          consumerConfig = consumerConfig,
-          snapshotTopic  = snapshotTopicPartition.topic,
-          partition      = targetPartition
+  /** Variant of [[caching]] protecting the snapshot topic from stale writers by binding the input-offset commit into
+    * the snapshot transaction. Each assigned partition gets a transactional producer with a unique `transactional.id`;
+    * snapshot writes run in group-committed transactions (see [[KafkaSnapshotWriteDatabase.transactional]]) that also
+    * commit the input offset. A stale consumer generation is rejected by the broker (KIP-447), aborting the
+    * transaction, so a stale owner can neither advance offsets nor overwrite a newer snapshot. Recovery reads with
+    * `read_committed`, and unlike [[caching]] the identity partition mapping is always used; output stays
+    * at-least-once. See the "Protecting against stale snapshot writes" persistence docs and
+    * `docs/kafka-single-writer-design.md` for limitations, costs and rollout.
+    */
+  def cachingTransactional[F[_]: LogOf: Async: Parallel: Runtime, S](
+    consumerOf: ConsumerOf[F],
+    producerOf: ProducerOf[F],
+    config: TransactionalConfig,
+    assignment: PartitionAssignment[F],
+    metrics: FlowMetrics[F] = FlowMetrics.empty[F],
+  )(
+    implicit fromBytesKey: FromBytes[F, String],
+    fromBytesState: FromBytes[F, S],
+    toBytesState: ToBytes[F, S]
+  ): Resource[F, KafkaPersistenceModule[F, S]] = {
+    val snapshotTopicPartition = TopicPartition(config.snapshotTopic, assignment.partition)
+    for {
+      transactional <- transactionalWriteDatabase[F, S](producerOf, config, assignment, snapshotTopicPartition)
+      // records of aborted transactions (e.g. of a fenced previous owner) must not be recovered as snapshots
+      parts <- of(
+        consumerOf             = consumerOf,
+        consumerConfig         = config.consumerConfig.copy(isolationLevel = IsolationLevel.ReadCommitted),
+        snapshotTopicPartition = snapshotTopicPartition,
+        metrics                = metrics,
+        partitionMapper        = KafkaPersistencePartitionMapper.identity,
+        writeDatabase          = transactional.writeDatabase,
+      )
+    } yield {
+      val (keysOf, persistenceOf) = parts
+      // transactional mode binds the input-offset commit into the snapshot transaction (see package.scala)
+      module(keysOf, persistenceOf, transactional.scheduleCommit.some)
+    }
+  }
+
+  /** Builds the per-assignment transactional producer (unique `transactional.id`) and the group-committing write
+    * database that binds the input-offset commit into each snapshot transaction. See [[cachingTransactional]].
+    */
+  private def transactionalWriteDatabase[F[_]: Async, S](
+    producerOf: ProducerOf[F],
+    config: TransactionalConfig,
+    assignment: PartitionAssignment[F],
+    snapshotTopicPartition: TopicPartition,
+  )(
+    implicit toBytesState: ToBytes[F, S]
+  ): Resource[F, KafkaSnapshotWriteDatabase.Transactional[F, S]] = {
+    implicit val fromTry: FromTry[F] = FromTry.lift
+    import config.{inputTopic, maxWritesPerTransaction, producerConfig, transactionalIdPrefix}
+    import assignment.{assignedAt, groupMetadata, partition}
+
+    // offsets are committed for the input partition with the same number as the assigned (snapshot) partition - the
+    // mode forces the identity mapping
+    val inputTopicPartition = TopicPartition(inputTopic, partition)
+
+    for {
+      // unique per producer: fencing is by consumer generation, not this id, so a fresh id per assignment is fine
+      shortId        <- Resource.eval(Async[F].delay(UUID.randomUUID().toString.take(8)))
+      transactionalId = s"$transactionalIdPrefix-${partition.value}-$shortId"
+      transactionalProducerConfig = producerConfig.copy(
+        transactionalId = transactionalId.some,
+        idempotence     = true,
+        common = producerConfig
+          .common
+          .copy(clientId = producerConfig.common.clientId.map(cid => s"$cid-snapshot-${partition.value}"))
+      )
+      producer <- producerOf(transactionalProducerConfig)
+      // required to open transactions; the guard is the per-transaction offset commit (see transactional)
+      _ <- Resource.eval(producer.initTransactions)
+      transactional <- Resource.eval(
+        KafkaSnapshotWriteDatabase.transactional[F, S](
+          snapshotTopicPartition  = snapshotTopicPartition,
+          producer                = producer,
+          inputTopicPartition     = inputTopicPartition,
+          groupMetadata           = groupMetadata,
+          assignedOffset          = assignedAt,
+          maxWritesPerTransaction = maxWritesPerTransaction,
         )
-        .map { snapshots =>
-          snapshots
-            .view
-            .filterKeys { key =>
-              partitionMapper.isStateKeyOwned(key, snapshotTopicPartition.partition)
-            }
-            .toMap
-        }
+      )
+    } yield transactional
+  }
+
+  /** Builds the cached `keysOf` + `persistenceOf` for a partition; the module's `scheduleCommit` is attached by the
+    * caller via [[module]] (transactional binds the offset, caching defers to the consumer).
+    */
+  private def of[F[_]: LogOf: Concurrent: Parallel: Runtime, S](
+    consumerOf: ConsumerOf[F],
+    consumerConfig: ConsumerConfig,
+    snapshotTopicPartition: TopicPartition,
+    metrics: FlowMetrics[F],
+    partitionMapper: KafkaPersistencePartitionMapper,
+    writeDatabase: SnapshotWriteDatabase[F, KafkaKey, S],
+  )(
+    implicit fromBytesKey: FromBytes[F, String],
+    fromBytesState: FromBytes[F, S],
+  ): Resource[F, (KeysOf[F, KafkaKey], SnapshotPersistenceOf[F, KafkaKey, S, ConsumerRecord[String, ByteVector]])] =
+    for {
+      partitionDataCache <- Cache.loading[F, String, ByteVector]
+      keysOf <- Resource.eval(
+        makeKeysOf(partitionDataCache, consumerOf, consumerConfig, snapshotTopicPartition, partitionMapper)
+      )
+      persistenceOf <- Resource.eval(
+        makeSnapshotPersistenceOf(keysOf, partitionDataCache, snapshotTopicPartition, metrics, writeDatabase)
+      )
+    } yield (keysOf, persistenceOf)
+
+  private def module[F[_], S](
+    keys: KeysOf[F, KafkaKey],
+    persistence: SnapshotPersistenceOf[F, KafkaKey, S, ConsumerRecord[String, ByteVector]],
+    commit: Option[ScheduleCommit[F]],
+  ): KafkaPersistenceModule[F, S] =
+    new KafkaPersistenceModule[F, S] {
+      override def keysOf: KeysOf[F, KafkaKey] = keys
+
+      override def persistenceOf: SnapshotPersistenceOf[F, KafkaKey, S, ConsumerRecord[String, ByteVector]] =
+        persistence
+
+      override def scheduleCommit: Option[ScheduleCommit[F]] = commit
     }
 
-    def makeKeysOf(cache: Cache[F, String, ByteVector]): F[KeysOf[F, KafkaKey]] = {
-      LogOf[F].apply(classOf[KeysOf[F, KafkaKey]]).map { implicit log =>
-        new KeysOf[F, KafkaKey] {
-          def apply(key: KafkaKey): Keys[F] =
-            Keys.empty[F]
+  private def makeKeysOf[F[_]: LogOf: Concurrent](
+    cache: Cache[F, String, ByteVector],
+    consumerOf: ConsumerOf[F],
+    consumerConfig: ConsumerConfig,
+    snapshotTopicPartition: TopicPartition,
+    partitionMapper: KafkaPersistencePartitionMapper,
+  )(implicit fromBytesKey: FromBytes[F, String]): F[KeysOf[F, KafkaKey]] =
+    LogOf[F].apply(classOf[KeysOf[F, KafkaKey]]).map { implicit log =>
+      def readPartitionData: F[BytesByKey] = {
+        val targetPartition = partitionMapper.getStatePartition(snapshotTopicPartition.partition)
+        KafkaPartitionPersistence
+          .readSnapshots[F](
+            consumerOf     = consumerOf,
+            consumerConfig = consumerConfig,
+            snapshotTopic  = snapshotTopicPartition.topic,
+            partition      = targetPartition,
+          )
+          .map { snapshots =>
+            snapshots
+              .view
+              .filterKeys(key => partitionMapper.isStateKeyOwned(key, snapshotTopicPartition.partition))
+              .toMap
+          }
+      }
 
-          def all(applicationId: String, groupId: String, topicPartition: TopicPartition): Stream[F, KafkaKey] = {
-            Stream.fromF {
-              readPartitionData
-                .map(_.map { case (key, value) => KafkaKey(applicationId, groupId, topicPartition, key) -> value })
-                .flatTap(_.toList.traverse_ { case (k, v) => cache.put(k.key, v) })
-                .map(_.keys)
-            }
+      new KeysOf[F, KafkaKey] {
+        def apply(key: KafkaKey): Keys[F] =
+          Keys.empty[F]
+
+        def all(applicationId: String, groupId: String, topicPartition: TopicPartition): Stream[F, KafkaKey] = {
+          Stream.fromF {
+            readPartitionData
+              .map(_.map { case (key, value) => KafkaKey(applicationId, groupId, topicPartition, key) -> value })
+              .flatTap(_.toList.traverse_ { case (k, v) => cache.put(k.key, v) })
+              .map(_.keys)
           }
         }
       }
     }
 
-    def makeSnapshotPersistenceOf(
-      keysOf: KeysOf[F, KafkaKey],
-      cache: Cache[F, String, ByteVector],
-      producer: Producer[F]
-    ): F[SnapshotPersistenceOf[F, KafkaKey, S, ConsumerRecord[String, ByteVector]]] = {
-      LogOf[F].apply(classOf[KafkaPersistenceModule[F, S]]).map { implicit log =>
-        val read =
-          KafkaSnapshotReadDatabase.of[F, S](snapshotTopicPartition.topic, getState = key => cache.remove(key).flatten)
+  private def makeSnapshotPersistenceOf[F[_]: LogOf: Concurrent, S](
+    keysOf: KeysOf[F, KafkaKey],
+    cache: Cache[F, String, ByteVector],
+    snapshotTopicPartition: TopicPartition,
+    metrics: FlowMetrics[F],
+    writeDatabase: SnapshotWriteDatabase[F, KafkaKey, S],
+  )(
+    implicit fromBytesState: FromBytes[F, S]
+  ): F[SnapshotPersistenceOf[F, KafkaKey, S, ConsumerRecord[String, ByteVector]]] =
+    LogOf[F].apply(classOf[KafkaPersistenceModule[F, S]]).map { implicit log =>
+      val read =
+        KafkaSnapshotReadDatabase.of[F, S](snapshotTopicPartition.topic, getState = key => cache.remove(key).flatten)
 
-        val snapshotDatabase = SnapshotDatabase(
-          read  = read,
-          write = KafkaSnapshotWriteDatabase.of[F, S](snapshotTopicPartition, producer, partitionMapper)
-        ).withMetricsK(metrics.snapshotDatabaseMetrics)
+      val snapshotDatabase = SnapshotDatabase(
+        read  = read,
+        write = writeDatabase
+      ).withMetricsK(metrics.snapshotDatabaseMetrics)
 
-        PersistenceOf.snapshotsOnly[F, KafkaKey, S, ConsumerRecord[String, ByteVector]](
-          keysOf      = keysOf,
-          snapshotsOf = SnapshotsOf.backedBy[F, KafkaKey, S](snapshotDatabase)
-        )
-      }
+      PersistenceOf.snapshotsOnly[F, KafkaKey, S, ConsumerRecord[String, ByteVector]](
+        keysOf      = keysOf,
+        snapshotsOf = SnapshotsOf.backedBy[F, KafkaKey, S](snapshotDatabase)
+      )
     }
-
-    for {
-      partitionDataCache <- Cache.loading[F, String, ByteVector]
-      keysOf_            <- Resource.eval(makeKeysOf(partitionDataCache))
-      persistence_       <- Resource.eval(makeSnapshotPersistenceOf(keysOf_, partitionDataCache, producer))
-    } yield new KafkaPersistenceModule[F, S] {
-      override def keysOf: KeysOf[F, KafkaKey] = keysOf_
-
-      override def persistenceOf: SnapshotPersistenceOf[F, KafkaKey, S, ConsumerRecord[String, ByteVector]] =
-        persistence_
-    }
-  }
 }

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModule.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModule.scala
@@ -162,8 +162,8 @@ object KafkaPersistenceModule {
     * commit the input offset. A stale consumer generation is rejected by the broker (KIP-447), aborting the
     * transaction, so a stale owner can neither advance offsets nor overwrite a newer snapshot. Recovery reads with
     * `read_committed`, and unlike [[caching]] the identity partition mapping is always used; output stays
-    * at-least-once. See the "Protecting against stale snapshot writes" persistence docs and
-    * `docs/kafka-single-writer-design.md` for limitations, costs and rollout.
+    * at-least-once. See the "Protecting against stale snapshot writes" persistence docs for guarantees,
+    * limitations, costs and rollout, and `docs/kafka-single-writer-design.md` for the mechanism.
     */
   def cachingTransactional[F[_]: LogOf: Async: Parallel: Runtime, S](
     consumerOf: ConsumerOf[F],

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModule.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModule.scala
@@ -26,9 +26,9 @@ trait KafkaPersistenceModule[F[_], S] {
   def keysOf: KeysOf[F, KafkaKey]
   def persistenceOf: SnapshotPersistenceOf[F, KafkaKey, S, ConsumerRecord[String, ByteVector]]
 
-  /** A `ScheduleCommit` that commits input offsets transactionally with the snapshot writes, when the module provides
-    * single-writer offset binding (transactional mode). `None` means offsets are committed the default way (by the
-    * consumer). See [[cachingTransactional]].
+  /** A `ScheduleCommit` that overrides the default way input offsets are committed (by the consumer), binding them to
+    * the snapshot writes for single-writer offset safety. `None` means the module does not override it and offsets are
+    * committed the default way. See [[cachingTransactional]].
     */
   def scheduleCommit: Option[ScheduleCommit[F]]
 }

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModule.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModule.scala
@@ -51,7 +51,7 @@ object KafkaPersistenceModule {
     *   the input topic kafka-flow consumes; its offsets are committed transactionally with the snapshot writes (same
     *   partition number as the snapshot partition - the mode forces the identity mapping)
     * @param maxWritesPerTransaction
-    *   upper bound of snapshot writes group committed in one transaction, see
+    *   upper bound of snapshot writes group committed in one per-partition, serialized transaction, see
     *   [[KafkaSnapshotWriteDatabase.transactional]]
     */
   final case class TransactionalConfig(
@@ -162,8 +162,8 @@ object KafkaPersistenceModule {
     * commit the input offset. A stale consumer generation is rejected by the broker (KIP-447), aborting the
     * transaction, so a stale owner can neither advance offsets nor overwrite a newer snapshot. Recovery reads with
     * `read_committed`, and unlike [[caching]] the identity partition mapping is always used; output stays
-    * at-least-once. See the "Protecting against stale snapshot writes" persistence docs for guarantees,
-    * limitations, costs and rollout, and `docs/kafka-single-writer-design.md` for the mechanism.
+    * at-least-once. See the "Protecting against stale snapshot writes" persistence docs for guarantees, limitations,
+    * costs and rollout, and `docs/kafka-single-writer-design.md` for the mechanism.
     */
   def cachingTransactional[F[_]: LogOf: Async: Parallel: Runtime, S](
     consumerOf: ConsumerOf[F],

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModuleOf.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModuleOf.scala
@@ -1,16 +1,19 @@
 package com.evolutiongaming.kafka.flow.kafkapersistence
 
 import cats.Parallel
-import cats.effect.{Concurrent, Resource}
+import cats.effect.{Async, Concurrent, Resource}
 import com.evolutiongaming.catshelper.{LogOf, Runtime}
 import com.evolutiongaming.kafka.flow.FlowMetrics
-import com.evolutiongaming.skafka.consumer.{ConsumerConfig, ConsumerOf}
-import com.evolutiongaming.skafka.producer.Producer
+import com.evolutiongaming.skafka.consumer.{ConsumerConfig, ConsumerGroupMetadata, ConsumerOf}
+import com.evolutiongaming.skafka.producer.{Producer, ProducerOf}
 import com.evolutiongaming.skafka.*
 
-/** Convenience factory trait to create an instance of [[KafkaPersistenceModule]] for an assigned partition */
+/** Convenience factory trait to create an instance of [[KafkaPersistenceModule]] for an assigned partition.
+  * `assignedAt` is the offset the partition was assigned at; the transactional module seeds it as the initial
+  * offset-to-commit (ignored by the non-transactional caching module).
+  */
 trait KafkaPersistenceModuleOf[F[_], S] {
-  def make(partition: Partition): Resource[F, KafkaPersistenceModule[F, S]]
+  def make(partition: Partition, assignedAt: Offset): Resource[F, KafkaPersistenceModule[F, S]]
 }
 
 object KafkaPersistenceModuleOf {
@@ -43,14 +46,16 @@ object KafkaPersistenceModuleOf {
     fromBytesState: FromBytes[F, S],
     toBytesState: ToBytes[F, S]
   ): KafkaPersistenceModuleOf[F, S] = new KafkaPersistenceModuleOf[F, S] {
-    override def make(partition: Partition): Resource[F, KafkaPersistenceModule[F, S]] = KafkaPersistenceModule.caching(
-      consumerOf             = consumerOf,
-      producer               = producer,
-      consumerConfig         = consumerConfig,
-      snapshotTopicPartition = TopicPartition(snapshotTopic, partition),
-      metrics                = metrics,
-      partitionMapper        = partitionMapper,
-    )
+    // assignedAt is unused: the non-transactional caching module does not commit offsets through a producer
+    override def make(partition: Partition, assignedAt: Offset): Resource[F, KafkaPersistenceModule[F, S]] =
+      KafkaPersistenceModule.caching(
+        consumerOf             = consumerOf,
+        producer               = producer,
+        consumerConfig         = consumerConfig,
+        snapshotTopicPartition = TopicPartition(snapshotTopic, partition),
+        metrics                = metrics,
+        partitionMapper        = partitionMapper,
+      )
   }
 
   def caching[F[_]: LogOf: Concurrent: Parallel: Runtime, S](
@@ -65,4 +70,32 @@ object KafkaPersistenceModuleOf {
   ): KafkaPersistenceModuleOf[F, S] =
     caching(consumerOf, producer, consumerConfig, snapshotTopic, FlowMetrics.empty[F])
 
+  /** Create a [[KafkaPersistenceModuleOf]] factory producing transactional [[KafkaPersistenceModule]]s that protect the
+    * snapshot topic from stale writers. See `KafkaPersistenceModule.cachingTransactional` for semantics and trade-offs.
+    * The snapshot and input topics are part of `config` (see [[KafkaPersistenceModule.TransactionalConfig]]).
+    *
+    * @param groupMetadata
+    *   group metadata of the SAME consumer that drives this flow (use `Consumer.groupMetadata`); its generation is what
+    *   fences a stale owner (KIP-447)
+    */
+  def cachingTransactional[F[_]: LogOf: Async: Parallel: Runtime, S](
+    consumerOf: ConsumerOf[F],
+    producerOf: ProducerOf[F],
+    config: KafkaPersistenceModule.TransactionalConfig,
+    groupMetadata: F[Option[ConsumerGroupMetadata]],
+    metrics: FlowMetrics[F] = FlowMetrics.empty[F],
+  )(
+    implicit fromBytesKey: FromBytes[F, String],
+    fromBytesState: FromBytes[F, S],
+    toBytesState: ToBytes[F, S]
+  ): KafkaPersistenceModuleOf[F, S] = new KafkaPersistenceModuleOf[F, S] {
+    override def make(partition: Partition, assignedAt: Offset): Resource[F, KafkaPersistenceModule[F, S]] =
+      KafkaPersistenceModule.cachingTransactional(
+        consumerOf = consumerOf,
+        producerOf = producerOf,
+        config     = config,
+        assignment = KafkaPersistenceModule.PartitionAssignment(partition, assignedAt, groupMetadata),
+        metrics    = metrics,
+      )
+  }
 }

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaSnapshotWriteDatabase.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaSnapshotWriteDatabase.scala
@@ -1,18 +1,183 @@
 package com.evolutiongaming.kafka.flow.kafkapersistence
 
 import cats.Monad
+import cats.data.NonEmptyMap
+import cats.effect.std.{Queue, Semaphore}
+import cats.effect.syntax.all.*
+import cats.effect.{Concurrent, Deferred, Outcome, Poll, Ref}
 import cats.syntax.all.*
 import com.evolutiongaming.catshelper.FromTry
 import com.evolutiongaming.kafka.flow.KafkaKey
+import com.evolutiongaming.kafka.flow.kafka.ScheduleCommit
 import com.evolutiongaming.kafka.flow.snapshot.SnapshotWriteDatabase
+import com.evolutiongaming.skafka.consumer.ConsumerGroupMetadata
 import com.evolutiongaming.skafka.producer.{Producer, ProducerRecord}
-import com.evolutiongaming.skafka.{ToBytes, TopicPartition}
+import com.evolutiongaming.skafka.{Offset, OffsetAndMetadata, ToBytes, TopicPartition}
 
 object KafkaSnapshotWriteDatabase {
+
   def of[F[_]: FromTry: Monad, S: ToBytes[F, *]](
     snapshotTopicPartition: TopicPartition,
     producer: Producer[F],
     partitionMapper: KafkaPersistencePartitionMapper = KafkaPersistencePartitionMapper.identity,
+  ): SnapshotWriteDatabase[F, KafkaKey, S] =
+    apply(snapshotTopicPartition, partitionMapper, record => producer.send(record).flatten.void)
+
+  /** Result of [[transactional]]: the snapshot write database plus a [[ScheduleCommit]] that routes input offset
+    * commits through the same per-partition transactions as the snapshot writes.
+    */
+  final case class Transactional[F[_], S](
+    writeDatabase: SnapshotWriteDatabase[F, KafkaKey, S],
+    scheduleCommit: ScheduleCommit[F],
+  )
+
+  /** Variant of [[of]] performing writes as group-committed Kafka transactions that also commit the input offset. The
+    * producer must be transactional with `initTransactions` already called. A stale consumer generation is rejected by
+    * the broker (KIP-447), aborting the transaction so neither the writes nor the offset land. See
+    * `docs/kafka-single-writer-design.md`.
+    *
+    * @param groupMetadata
+    *   current consumer group metadata (generation); see `Consumer.groupMetadata`. `None` (consumer not yet joined) is
+    *   unreachable on the flow path and fails loudly rather than committing ungated.
+    * @param assignedOffset
+    *   seeds the offset-to-commit so even the first write is gated; committing it is a no-op.
+    * @param maxWritesPerTransaction
+    *   bounds a transaction's duration below `transaction.timeout.ms`; bytes scale with this times the snapshot size.
+    */
+  def transactional[F[_]: FromTry: Concurrent, S: ToBytes[F, *]](
+    snapshotTopicPartition: TopicPartition,
+    producer: Producer[F],
+    inputTopicPartition: TopicPartition,
+    groupMetadata: F[Option[ConsumerGroupMetadata]],
+    assignedOffset: Offset,
+    maxWritesPerTransaction: Int = DefaultMaxWritesPerTransaction,
+  ): F[Transactional[F, S]] =
+    for {
+      _ <- new IllegalArgumentException(s"maxWritesPerTransaction must be positive, got $maxWritesPerTransaction")
+        .raiseError[F, Unit]
+        .whenA(maxWritesPerTransaction < 1)
+      transactionLock <- Semaphore[F](1)
+      pending         <- Queue.unbounded[F, Pending[F, S]]
+      // seed with the assigned offset so the first flush already carries an offset and is generation-gated
+      offsetToCommit <- Ref[F].of(assignedOffset)
+      groupCommit = new GroupCommit(
+        producer,
+        maxWritesPerTransaction,
+        transactionLock,
+        pending,
+        offsetToCommit,
+        inputTopicPartition,
+        groupMetadata,
+      )
+    } yield Transactional(
+      // identity only: the single-writer/offset-binding guarantee assumes one input partition maps to one snapshot
+      // partition owned by one writer; a non-identity mapper breaks that, so it is not configurable here
+      writeDatabase  = apply(snapshotTopicPartition, KafkaPersistencePartitionMapper.identity, groupCommit.sendWrite),
+      scheduleCommit = groupCommit.scheduleCommit,
+    )
+
+  /** Group-commit machinery backing [[transactional]]. The producer allows one open transaction at a time, so
+    * `transactionLock` serializes them and each holder group-commits everything queued (up to
+    * `maxWritesPerTransaction`) in one transaction, binding the latest offset to gate it. The over-cap backlog, empty
+    * batches and cancellation are handled at the methods below; all paths are safe - an interrupted flush never
+    * advances the offset. See `docs/kafka-single-writer-design.md`.
+    */
+  private final class GroupCommit[F[_]: FromTry: Concurrent, S: ToBytes[F, *]](
+    producer: Producer[F],
+    maxWritesPerTransaction: Int,
+    transactionLock: Semaphore[F],
+    pending: Queue[F, Pending[F, S]],
+    offsetToCommit: Ref[F, Offset],
+    inputTopicPartition: TopicPartition,
+    groupMetadata: F[Option[ConsumerGroupMetadata]],
+  ) {
+
+    val sendWrite: ProducerRecord[String, S] => F[Unit] =
+      record => submit(record.some)
+
+    // offset-only marker: commits the offset even with no writes pending (e.g. on revoke)
+    val scheduleCommit: ScheduleCommit[F] =
+      (offset: Offset) => offsetToCommit.set(offset) *> submit(none)
+
+    // this item's `done` is completed by whichever holder's batch happens to take it, not necessarily this caller's
+    private def submit(record: Option[ProducerRecord[String, S]]): F[Unit] =
+      Deferred[F, Either[Throwable, Unit]].flatMap { done =>
+        val item = Pending(record, done)
+        pending.offer(item) *>
+          transactionLock.permit.use(_ => commitQueued) *>
+          done.get.rethrow
+      }
+
+    // empty means a prior holder already took our item; uncancelable (except the ack await) so a holder never drops a
+    // queued item without delivering its outcome
+    private def commitQueued: F[Unit] =
+      Concurrent[F].uncancelable { poll =>
+        pending.tryTakeN(maxWritesPerTransaction.some).flatMap {
+          case Nil   => ().pure[F]
+          case batch => commitBatch(poll, batch)
+        }
+      }
+
+    private def commitBatch(poll: Poll[F], batch: List[Pending[F, S]]): F[Unit] = {
+      // enqueue all sends, then await all acks (offset-only markers carry no record)
+      val sendAll =
+        batch
+          .flatMap(_.record)
+          .traverse(record => producer.send(record))
+          .flatMap(_.sequence_)
+
+      // only the ack await is cancelable (`poll`); begin/offsets/commit and the abort cleanup stay masked
+      val transaction =
+        (producer.beginTransaction *> poll(sendAll) *> commitOffsets *> producer.commitTransaction).guaranteeCase {
+          case Outcome.Succeeded(_) => ().pure[F]
+          // abort can fail on the very paths that trigger it (fenced, or begin never opened a transaction); voidError
+          // keeps that from masking the original error
+          case Outcome.Errored(_) | Outcome.Canceled() => producer.abortTransaction.voidError
+        }
+
+      def complete(result: Either[Throwable, Unit]): F[Unit] =
+        batch.traverse_(_.done.complete(result).void)
+
+      transaction
+        .attempt
+        .flatMap(complete)
+        .onCancel(complete(new InterruptedException("snapshot write batch canceled").asLeft))
+    }
+
+    // every transaction commits an offset, so the broker's generation check (KIP-447) gates every write. Committing
+    // the *latest* offset is safe across capped batches: each persist blocks until durable before its offset is
+    // scheduled, so the committed offset never leads durable state.
+    private def commitOffsets: F[Unit] =
+      for {
+        offset <- offsetToCommit.get
+        meta   <- groupMetadata
+        _ <- meta match {
+          case Some(meta) =>
+            producer.sendOffsetsToTransaction(NonEmptyMap.of(inputTopicPartition -> OffsetAndMetadata(offset)), meta)
+          case None =>
+            // invariant: the consumer joins (capturing metadata) before any flush, so None is unreachable; fail loud
+            // rather than commit ungated
+            new IllegalStateException(
+              s"cannot bind input offset $offset: the driving consumer has not joined a group " +
+                "(group metadata is None); transactional snapshot mode requires the flow's own consumer"
+            ).raiseError[F, Unit]
+        }
+      } yield ()
+  }
+
+  /** Default upper bound of snapshot writes committed in one transaction, see [[transactional]]. */
+  val DefaultMaxWritesPerTransaction: Int = 256
+
+  // a write carries its record; an offset-only marker carries None (see scheduleCommit)
+  private final case class Pending[F[_], S](
+    record: Option[ProducerRecord[String, S]],
+    done: Deferred[F, Either[Throwable, Unit]],
+  )
+
+  private def apply[F[_], S](
+    snapshotTopicPartition: TopicPartition,
+    partitionMapper: KafkaPersistencePartitionMapper,
+    send: ProducerRecord[String, S] => F[Unit],
   ): SnapshotWriteDatabase[F, KafkaKey, S] = new SnapshotWriteDatabase[F, KafkaKey, S] {
     override def persist(key: KafkaKey, snapshot: S): F[Unit] = produce(key, snapshot.some)
 
@@ -26,8 +191,7 @@ object KafkaSnapshotWriteDatabase {
         key       = key.key.some,
         value     = snapshot
       )
-
-      producer.send(record).flatten.void
+      send(record)
     }
   }
 }

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaSnapshotWriteDatabase.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaSnapshotWriteDatabase.scala
@@ -42,7 +42,8 @@ object KafkaSnapshotWriteDatabase {
     * @param assignedOffset
     *   seeds the offset-to-commit so even the first write is gated; committing it is a no-op.
     * @param maxWritesPerTransaction
-    *   bounds a transaction's duration below `transaction.timeout.ms`; bytes scale with this times the snapshot size.
+    *   bounds the per-partition, serialized transaction's duration below `transaction.timeout.ms`; bytes scale with
+    *   this times the snapshot size.
     */
   def transactional[F[_]: FromTry: Concurrent, S: ToBytes[F, *]](
     snapshotTopicPartition: TopicPartition,
@@ -57,14 +58,18 @@ object KafkaSnapshotWriteDatabase {
         .raiseError[F, Unit]
         .whenA(maxWritesPerTransaction < 1)
       transactionLock <- Semaphore[F](1)
-      pending         <- Queue.unbounded[F, Pending[F, S]]
+      // writes are bounded by maxWritesPerTransaction per transaction; offset-only markers ride on a separate
+      // unbounded lane so they never consume a write slot (periodic offset commits must not cut write throughput)
+      writes  <- Queue.unbounded[F, Pending[F, S]]
+      markers <- Queue.unbounded[F, Pending[F, S]]
       // seed with the assigned offset so the first flush already carries an offset and is generation-gated
       offsetToCommit <- Ref[F].of(assignedOffset)
       groupCommit = new GroupCommit(
         producer,
         maxWritesPerTransaction,
         transactionLock,
-        pending,
+        writes,
+        markers,
         offsetToCommit,
         inputTopicPartition,
         groupMetadata,
@@ -77,45 +82,53 @@ object KafkaSnapshotWriteDatabase {
     )
 
   /** Group-commit machinery backing [[transactional]]. The producer allows one open transaction at a time, so
-    * `transactionLock` serializes them and each holder group-commits everything queued (up to
-    * `maxWritesPerTransaction`) in one transaction, binding the latest offset to gate it. The over-cap backlog, empty
-    * batches and cancellation are handled at the methods below; all paths are safe - an interrupted flush never
-    * advances the offset. See `docs/kafka-single-writer-design.md`.
+    * `transactionLock` serializes them and each holder group-commits up to `maxWritesPerTransaction` writes plus all
+    * queued offset-only markers in one transaction, binding the latest offset to gate it. Markers ride a separate lane
+    * so they never consume a write slot. The over-cap backlog, empty batches and cancellation are handled at the
+    * methods below; all paths are safe - an interrupted flush never advances the offset. See
+    * `docs/kafka-single-writer-design.md`.
     */
   private final class GroupCommit[F[_]: FromTry: Concurrent, S: ToBytes[F, *]](
     producer: Producer[F],
     maxWritesPerTransaction: Int,
     transactionLock: Semaphore[F],
-    pending: Queue[F, Pending[F, S]],
+    writes: Queue[F, Pending[F, S]],
+    markers: Queue[F, Pending[F, S]],
     offsetToCommit: Ref[F, Offset],
     inputTopicPartition: TopicPartition,
     groupMetadata: F[Option[ConsumerGroupMetadata]],
   ) {
 
     val sendWrite: ProducerRecord[String, S] => F[Unit] =
-      record => submit(record.some)
+      record => submit(writes, record.some)
 
-    // offset-only marker: commits the offset even with no writes pending (e.g. on revoke)
+    // offset-only marker: commits the offset even with no writes pending (e.g. on revoke). It rides the markers
+    // lane, not `writes`, so periodic offset commits never displace writes from the per-transaction cap
     val scheduleCommit: ScheduleCommit[F] =
-      (offset: Offset) => offsetToCommit.set(offset) *> submit(none)
+      (offset: Offset) => offsetToCommit.set(offset) *> submit(markers, none)
 
     // this item's `done` is completed by whichever holder's batch happens to take it, not necessarily this caller's
-    private def submit(record: Option[ProducerRecord[String, S]]): F[Unit] =
+    private def submit(queue: Queue[F, Pending[F, S]], record: Option[ProducerRecord[String, S]]): F[Unit] =
       Deferred[F, Either[Throwable, Unit]].flatMap { done =>
         val item = Pending(record, done)
-        pending.offer(item) *>
+        queue.offer(item) *>
           transactionLock.permit.use(_ => commitQueued) *>
           done.get.rethrow
       }
 
-    // empty means a prior holder already took our item; uncancelable (except the ack await) so a holder never drops a
-    // queued item without delivering its outcome
+    // a holder drains up to `maxWritesPerTransaction` writes plus *all* queued offset-only markers (they only
+    // commit the latest offset, so any number collapse into the one `commitOffsets`). empty means a prior holder
+    // already took everything; uncancelable (except the ack await) so a holder never drops a queued item undelivered
     private def commitQueued: F[Unit] =
       Concurrent[F].uncancelable { poll =>
-        pending.tryTakeN(maxWritesPerTransaction.some).flatMap {
-          case Nil   => ().pure[F]
-          case batch => commitBatch(poll, batch)
-        }
+        for {
+          writeBatch  <- writes.tryTakeN(maxWritesPerTransaction.some)
+          markerBatch <- markers.tryTakeN(none)
+          _ <- (writeBatch ++ markerBatch) match {
+            case Nil   => ().pure[F]
+            case batch => commitBatch(poll, batch)
+          }
+        } yield ()
       }
 
     private def commitBatch(poll: Poll[F], batch: List[Pending[F, S]]): F[Unit] = {

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/package.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/package.scala
@@ -148,7 +148,9 @@ package object kafkapersistence {
         for {
           // TODO: per-partition persistence module with 'String -> ByteVector' cache or global persistence module with 'KafkaKey -> ByteVector' cache?
           // Latter would require initialization of PartitionFlowOf as a Resource
-          kafkaPersistenceModule <- kafkaPersistenceModuleOf.make(topicPartition.partition)
+          kafkaPersistenceModule <- kafkaPersistenceModuleOf.make(topicPartition.partition, assignedAt)
+          // transactional mode commits offsets through its own producer transaction; otherwise fall back to consumer commit
+          effectiveScheduleCommit = kafkaPersistenceModule.scheduleCommit.getOrElse(scheduleCommit)
           partitionFlowOf = PartitionFlowOf.apply[F](
             keyStateOf = KeyStateOf.eagerRecovery(
               applicationId = applicationId,
@@ -168,7 +170,7 @@ package object kafkapersistence {
             filter   = filter,
             remapKey = remapKey,
           )
-          partitionFlow <- partitionFlowOf(topicPartition, assignedAt, scheduleCommit)
+          partitionFlow <- partitionFlowOf(topicPartition, assignedAt, effectiveScheduleCommit)
         } yield partitionFlow
       }
     }

--- a/persistence-kafka/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/GroupCommitSpec.scala
+++ b/persistence-kafka/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/GroupCommitSpec.scala
@@ -1,0 +1,243 @@
+package com.evolutiongaming.kafka.flow.kafkapersistence
+
+import cats.data.NonEmptyMap
+import cats.effect.unsafe.implicits.global
+import cats.effect.{IO, Ref}
+import cats.syntax.all.*
+import com.evolutiongaming.catshelper.FromTry
+import com.evolutiongaming.kafka.flow.KafkaKey
+import com.evolutiongaming.kafka.flow.kafkapersistence.GroupCommitSpec.*
+import com.evolutiongaming.skafka.consumer.ConsumerGroupMetadata
+import com.evolutiongaming.skafka.producer.{Producer, ProducerRecord, RecordMetadata}
+import com.evolutiongaming.skafka.{Offset, OffsetAndMetadata, Partition, ToBytes, Topic, TopicPartition}
+import munit.FunSuite
+
+import scala.concurrent.duration.FiniteDuration
+
+/** Local (no broker) tests of the group-commit orchestration behind `KafkaSnapshotWriteDatabase.transactional`:
+  * batching under the cap, committing the input offset on every transaction, the offset-only commit marker, the seeded
+  * first offset, and the abort / fail-loud paths. A recording in-memory `Producer` stands in for the broker - this is
+  * orchestration logic, independent of any broker behavior. The broker's generation fencing (the part that genuinely
+  * needs Kafka) is covered by `TransactionalKafkaPersistenceSpec`.
+  */
+class GroupCommitSpec extends FunSuite {
+
+  private implicit val fromTry: FromTry[IO] = FromTry.lift
+
+  private val snapshotTopicPartition = TopicPartition("snapshots", Partition.min)
+  private val inputTopicPartition    = TopicPartition("input", Partition.min)
+
+  private def kafkaKey(key: String): KafkaKey = KafkaKey("app", "group", inputTopicPartition, key)
+
+  private def generation(generationId: Int): ConsumerGroupMetadata =
+    ConsumerGroupMetadata(groupId = "group", generationId = generationId, memberId = "member", groupInstanceId = none)
+
+  private def buildTransactional(
+    producer: Producer[IO],
+    groupMetadata: Option[ConsumerGroupMetadata],
+    maxWritesPerTransaction: Int,
+    assignedOffset: Offset = Offset.min,
+  ): IO[KafkaSnapshotWriteDatabase.Transactional[IO, String]] =
+    KafkaSnapshotWriteDatabase.transactional[IO, String](
+      snapshotTopicPartition  = snapshotTopicPartition,
+      producer                = producer,
+      inputTopicPartition     = inputTopicPartition,
+      groupMetadata           = IO.pure(groupMetadata),
+      assignedOffset          = assignedOffset,
+      maxWritesPerTransaction = maxWritesPerTransaction,
+    )
+
+  // transactions never interleave (the group-commit lock serializes them), so the event log splits into transactions
+  // at each Begin; this counts the records sent within each one
+  private def sentPerTransaction(events: Vector[Event]): List[Int] =
+    events
+      .foldLeft(List.empty[Int]) {
+        case (acc, Event.Begin)            => 0 :: acc
+        case (head :: tail, Event.Sent(_)) => (head + 1) :: tail
+        case (acc, _)                      => acc
+      }
+      .reverse
+
+  private def offsetsCommitted(events: Vector[Event]): List[Offset] =
+    events.collect { case Event.Offsets(o, _) => o }.toList
+  private def sentKeys(events: Vector[Event]): List[String] =
+    events.collect { case Event.Sent(k) => k }.flatten.toList
+
+  List(1, KafkaSnapshotWriteDatabase.DefaultMaxWritesPerTransaction).foreach { cap =>
+    test(s"every queued write commits exactly once with its input offset, respecting the cap (cap=$cap)") {
+      val keys = (1 to 20).toList.map(i => s"key$i")
+      val test = for {
+        events  <- Ref.of[IO, Vector[Event]](Vector.empty)
+        tx      <- buildTransactional(recordingProducer(events), ConsumerGroupMetadata.Empty.some, cap)
+        results <- keys.parTraverse(k => tx.writeDatabase.persist(kafkaKey(k), s"state-$k").attempt)
+        log     <- events.get
+      } yield {
+        assert(results.forall(_.isRight), s"all writes complete: $results")
+        assertEquals(sentKeys(log).toSet, keys.toSet) // each key sent
+        assertEquals(sentKeys(log).size, keys.size) // exactly once
+        val begins  = log.count(_ == Event.Begin)
+        val commits = log.count(_ == Event.Commit)
+        assertEquals(begins, commits) // every started transaction committed
+        assertEquals(
+          offsetsCommitted(log).size,
+          commits
+        ) // every transaction committed the input offset (never skipped)
+        assertEquals(log.count(_ == Event.Abort), 0)
+        assert(sentPerTransaction(log).forall(_ <= cap), s"cap respected: ${sentPerTransaction(log)}")
+      }
+      test.unsafeRunSync()
+    }
+  }
+
+  test("an offset-only commit forces a transaction with no writes (e.g. on revoke)") {
+    val test = for {
+      events <- Ref.of[IO, Vector[Event]](Vector.empty)
+      tx <- buildTransactional(
+        recordingProducer(events),
+        ConsumerGroupMetadata.Empty.some,
+        maxWritesPerTransaction = 256
+      )
+      _   <- tx.scheduleCommit.schedule(Offset.unsafe(7))
+      log <- events.get
+    } yield {
+      assertEquals(sentKeys(log), Nil) // no writes
+      assertEquals(offsetsCommitted(log), List(Offset.unsafe(7)))
+      assertEquals(log.count(_ == Event.Commit), 1)
+      assertEquals(log.count(_ == Event.Abort), 0)
+    }
+    test.unsafeRunSync()
+  }
+
+  test("the first write commits the seeded assigned offset") {
+    val test = for {
+      events <- Ref.of[IO, Vector[Event]](Vector.empty)
+      tx <- buildTransactional(
+        recordingProducer(events),
+        ConsumerGroupMetadata.Empty.some,
+        maxWritesPerTransaction = 256,
+        assignedOffset          = Offset.unsafe(3),
+      )
+      _   <- tx.writeDatabase.persist(kafkaKey("key1"), "state-1")
+      log <- events.get
+    } yield {
+      assertEquals(offsetsCommitted(log), List(Offset.unsafe(3)))
+      assertEquals(log.count(_ == Event.Commit), 1)
+    }
+    test.unsafeRunSync()
+  }
+
+  test("the committed offset never leads the writes it covers (flush-blocks-then-schedule, cap=1)") {
+    // The flow blocks on each persist (write made durable) before scheduling the offset commit, so the
+    // committed input offset never runs ahead of the writes it covers. At cap=1 each persist is its own
+    // transaction committing the seeded Offset.min; the later scheduleCommit(10) is the only transaction
+    // that advances the offset - and only after all three writes are already durable.
+    val keys = List("key1", "key2", "key3")
+    val test = for {
+      events <- Ref.of[IO, Vector[Event]](Vector.empty)
+      tx <- buildTransactional(recordingProducer(events), ConsumerGroupMetadata.Empty.some, maxWritesPerTransaction = 1)
+      _  <- keys.parTraverse(k => tx.writeDatabase.persist(kafkaKey(k), s"state-$k"))
+      _  <- tx.scheduleCommit.schedule(Offset.unsafe(10))
+      log <- events.get
+    } yield {
+      val committed = offsetsCommitted(log)
+      assertEquals(sentKeys(log).toSet, keys.toSet) // all three writes sent
+      // each write's transaction committed the seeded offset; only the trailing schedule advances to 10
+      assertEquals(committed.dropRight(1), List.fill(keys.size)(Offset.min))
+      assertEquals(committed.lastOption, Offset.unsafe(10).some)
+    }
+    test.unsafeRunSync()
+  }
+
+  test("missing group metadata fails loudly and aborts without committing") {
+    val test = for {
+      events <- Ref.of[IO, Vector[Event]](Vector.empty)
+      tx     <- buildTransactional(recordingProducer(events), groupMetadata = none, maxWritesPerTransaction = 256)
+      result <- tx.writeDatabase.persist(kafkaKey("key1"), "state-1").attempt
+      log    <- events.get
+    } yield {
+      assert(result.left.exists(_.isInstanceOf[IllegalStateException]), s"fail-loud: $result")
+      assertEquals(log.count(_ == Event.Commit), 0)
+      assertEquals(offsetsCommitted(log), Nil) // no ungated offset commit
+      assert(log.contains(Event.Abort), s"aborted: $log")
+    }
+    test.unsafeRunSync()
+  }
+
+  test("each transaction reads the consumer generation live (the writer never caches it)") {
+    // the generation that fences the commit is read fresh per transaction, so a legitimate owner that survives a
+    // generation bump commits under the current generation rather than a cached one
+    val test = for {
+      events <- Ref.of[IO, Vector[Event]](Vector.empty)
+      gmRef  <- Ref.of[IO, Option[ConsumerGroupMetadata]](generation(1).some)
+      tx <- KafkaSnapshotWriteDatabase.transactional[IO, String](
+        snapshotTopicPartition  = snapshotTopicPartition,
+        producer                = recordingProducer(events),
+        inputTopicPartition     = inputTopicPartition,
+        groupMetadata           = gmRef.get,
+        assignedOffset          = Offset.min,
+        maxWritesPerTransaction = 256,
+      )
+      _   <- tx.writeDatabase.persist(kafkaKey("key1"), "state-1") // commits under generation 1
+      _   <- gmRef.set(generation(2).some) // a rebalance advances the generation
+      _   <- tx.writeDatabase.persist(kafkaKey("key2"), "state-2") // must commit under generation 2, not a cached 1
+      log <- events.get
+    } yield assertEquals(log.collect { case Event.Offsets(_, generation) => generation }.toList, List(1, 2))
+    test.unsafeRunSync()
+  }
+
+  test("a commit failure aborts the transaction and surfaces to the caller") {
+    val test = for {
+      events <- Ref.of[IO, Vector[Event]](Vector.empty)
+      tx     <- buildTransactional(recordingProducer(events, failCommit = true), ConsumerGroupMetadata.Empty.some, 256)
+      result <- tx.writeDatabase.persist(kafkaKey("key1"), "state-1").attempt
+      log    <- events.get
+    } yield {
+      assert(result.isLeft, s"error surfaced: $result")
+      assertEquals(log.count(_ == Event.Commit), 0)
+      assert(log.contains(Event.Abort), s"aborted: $log")
+    }
+    test.unsafeRunSync()
+  }
+}
+
+object GroupCommitSpec {
+
+  sealed trait Event
+  object Event {
+    case object Begin extends Event
+    final case class Sent(key: Option[String]) extends Event
+    final case class Offsets(offset: Offset, generation: Int) extends Event
+    case object Commit extends Event
+    case object Abort extends Event
+  }
+
+  private val CommitBoom = new RuntimeException("commit boom")
+
+  /** A `Producer` that records the transactional calls into `events` and delegates everything else to a no-op producer
+    * (which also fabricates the `RecordMetadata` for `send`). `failCommit` makes `commitTransaction` raise.
+    */
+  def recordingProducer(events: Ref[IO, Vector[Event]], failCommit: Boolean = false): Producer[IO] = {
+    val base = Producer.empty[IO]
+    new Producer[IO] {
+      def initTransactions: IO[Unit]  = base.initTransactions
+      def beginTransaction: IO[Unit]  = events.update(_ :+ Event.Begin)
+      def commitTransaction: IO[Unit] = if (failCommit) IO.raiseError(CommitBoom) else events.update(_ :+ Event.Commit)
+      def abortTransaction: IO[Unit]  = events.update(_ :+ Event.Abort)
+
+      def sendOffsetsToTransaction(
+        offsets: NonEmptyMap[TopicPartition, OffsetAndMetadata],
+        consumerGroupMetadata: ConsumerGroupMetadata,
+      ): IO[Unit] = events.update(_ :+ Event.Offsets(offsets.head._2.offset, consumerGroupMetadata.generationId))
+
+      def send[K, V](
+        record: ProducerRecord[K, V]
+      )(implicit toBytesK: ToBytes[IO, K], toBytesV: ToBytes[IO, V]): IO[IO[RecordMetadata]] =
+        events.update(_ :+ Event.Sent(record.key.map(_.toString))) *> base.send(record)
+
+      def partitions(topic: Topic)                  = base.partitions(topic)
+      def flush: IO[Unit]                           = base.flush
+      def clientMetrics                             = base.clientMetrics
+      def clientInstanceId(timeout: FiniteDuration) = base.clientInstanceId(timeout)
+    }
+  }
+}

--- a/persistence-kafka/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/GroupCommitSpec.scala
+++ b/persistence-kafka/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/GroupCommitSpec.scala
@@ -1,8 +1,9 @@
 package com.evolutiongaming.kafka.flow.kafkapersistence
 
 import cats.data.NonEmptyMap
+import cats.effect.testkit.TestControl
 import cats.effect.unsafe.implicits.global
-import cats.effect.{IO, Ref}
+import cats.effect.{Deferred, IO, Ref}
 import cats.syntax.all.*
 import com.evolutiongaming.catshelper.FromTry
 import com.evolutiongaming.kafka.flow.KafkaKey
@@ -12,7 +13,7 @@ import com.evolutiongaming.skafka.producer.{Producer, ProducerRecord, RecordMeta
 import com.evolutiongaming.skafka.{Offset, OffsetAndMetadata, Partition, ToBytes, Topic, TopicPartition}
 import munit.FunSuite
 
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration.*
 
 /** Local (no broker) tests of the group-commit orchestration behind `KafkaSnapshotWriteDatabase.transactional`:
   * batching under the cap, committing the input offset on every transaction, the offset-only commit marker, the seeded
@@ -106,6 +107,42 @@ class GroupCommitSpec extends FunSuite {
       assertEquals(log.count(_ == Event.Abort), 0)
     }
     test.unsafeRunSync()
+  }
+
+  test("offset-only markers ride a write transaction without consuming the write cap") {
+    // Deterministic under TestControl (virtual time): hold the first transaction open, queue a marker then `cap`
+    // writes behind the lock, release. Markers share the commit's outcome but live off the write lane, so one drain
+    // takes all `cap` writes in a single transaction; if markers counted against the cap, the marker would displace
+    // a write into another transaction. The virtual `IO.sleep` is the enqueue barrier - TestControl runs every
+    // ready fiber (each `submit` offers then blocks on the held lock) before advancing the clock.
+    val cap = 4
+    val program = for {
+      events     <- Ref.of[IO, Vector[Event]](Vector.empty)
+      began      <- Ref.of[IO, Int](0)
+      firstBegun <- Deferred[IO, Unit]
+      release    <- Deferred[IO, Unit]
+      gateFirstBegin =
+        began.getAndUpdate(_ + 1).flatMap(n => if (n == 0) firstBegun.complete(()) *> release.get else IO.unit)
+      tx <- buildTransactional(
+        recordingProducer(events, onBeginTransaction = gateFirstBegin),
+        ConsumerGroupMetadata.Empty.some,
+        maxWritesPerTransaction = cap,
+      )
+      f0  <- tx.writeDatabase.persist(kafkaKey("w0"), "s0").start // opens and holds the first transaction
+      _   <- firstBegun.get
+      fm  <- tx.scheduleCommit.schedule(Offset.unsafe(9)).start // marker queued first, behind the held lock
+      fw  <- (1 to cap).toList.parTraverse(i => tx.writeDatabase.persist(kafkaKey(s"w$i"), s"s$i").start)
+      _   <- IO.sleep(1.second) // virtual: lets the marker + writes enqueue and block on the lock before release
+      _   <- release.complete(())
+      _   <- (f0 :: fm :: fw).traverse_(_.joinWithNever)
+      log <- events.get
+    } yield {
+      assertEquals(sentKeys(log).size, cap + 1) // w0..w{cap} each sent once
+      assertEquals(log.count(_ == Event.Abort), 0)
+      // the marker did not displace a write: a single transaction still carries all `cap` writes
+      assert(sentPerTransaction(log).contains(cap), s"a transaction holds all $cap writes: ${sentPerTransaction(log)}")
+    }
+    TestControl.executeEmbed(program).unsafeRunSync()
   }
 
   test("the first write commits the seeded assigned offset") {
@@ -216,11 +253,15 @@ object GroupCommitSpec {
   /** A `Producer` that records the transactional calls into `events` and delegates everything else to a no-op producer
     * (which also fabricates the `RecordMetadata` for `send`). `failCommit` makes `commitTransaction` raise.
     */
-  def recordingProducer(events: Ref[IO, Vector[Event]], failCommit: Boolean = false): Producer[IO] = {
+  def recordingProducer(
+    events: Ref[IO, Vector[Event]],
+    failCommit: Boolean          = false,
+    onBeginTransaction: IO[Unit] = IO.unit,
+  ): Producer[IO] = {
     val base = Producer.empty[IO]
     new Producer[IO] {
       def initTransactions: IO[Unit]  = base.initTransactions
-      def beginTransaction: IO[Unit]  = events.update(_ :+ Event.Begin)
+      def beginTransaction: IO[Unit]  = events.update(_ :+ Event.Begin) *> onBeginTransaction
       def commitTransaction: IO[Unit] = if (failCommit) IO.raiseError(CommitBoom) else events.update(_ :+ Event.Commit)
       def abortTransaction: IO[Unit]  = events.update(_ :+ Event.Abort)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   val catsHelperLogback = "com.evolutiongaming" %% "cats-helper-logback" % "3.12.2"
   val smetrics          = "com.evolutiongaming" %% "smetrics"            % "2.4.4"
   val scache            = "com.evolution"       %% "scache"              % "6.0.1"
-  val skafka            = "com.evolutiongaming" %% "skafka"              % "20.1.0"
+  val skafka            = "com.evolutiongaming" %% "skafka"              % "20.2.0"
   val sstream           = "com.evolutiongaming" %% "sstream"             % "1.1.0"
   val scassandra        = "com.evolutiongaming" %% "scassandra"          % "5.5.0"
   val cassandraSync     = "com.evolutiongaming" %% "cassandra-sync"      % "4.0.0"

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -1,5 +1,5 @@
 {
   "docs": {
-    "Kafka-Flow": ["overview", "setup", "faq", "styleguide", "persistence"]
+    "Kafka-Flow": ["overview", "setup", "faq", "styleguide", "persistence", "kafka-single-writer-design"]
   }
 }

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -1,5 +1,6 @@
 {
   "docs": {
-    "Kafka-Flow": ["overview", "setup", "faq", "styleguide", "persistence", "kafka-single-writer-design"]
+    "Kafka-Flow": ["overview", "setup", "faq", "styleguide", "persistence"],
+    "Design notes": ["kafka-single-writer-design"]
   }
 }


### PR DESCRIPTION
Breaks out the Kafka part of #828, see it for description. Solves #732 fully for Kafka persistence storage.