### PR TITLE
Protect Cassandra snapshot writes from stale writers (full compare-and-set fence)

### DIFF
--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/persistence/Persistence.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/persistence/Persistence.scala
@@ -11,6 +11,7 @@ import com.evolutiongaming.kafka.flow.key.Keys
 import com.evolutiongaming.kafka.flow.snapshot.SnapshotReader
 import com.evolutiongaming.kafka.flow.snapshot.Snapshots
 import com.evolutiongaming.kafka.flow.timer.Timestamps
+import com.evolutiongaming.skafka.Offset
 
 /** Provides persistence for keys, events and snapshots.
   *
@@ -35,8 +36,10 @@ trait Buffers[F[_], S, E] extends WriteToBuffers[F, S, E] {
     *
     * @param persist
     *   if `true` then also calls underlying database, flushes buffers only otherwise.
+    * @param offset
+    *   offset of the state being deleted, forwarded to the snapshot database for stale-writer protection.
     */
-  def delete(persist: Boolean): F[Unit]
+  def delete(persist: Boolean, offset: Offset): F[Unit]
 
   /** Initialize an already persisted state, used to store a state in buffers that was fetched from the database.
     *
@@ -105,19 +108,23 @@ object Persistence {
     def appendEvent(event: E)  = buffers.appendEvent(event)
     def replaceState(state: S) = buffers.replaceState(state)
 
-    // We avoid persisting `delete` unless the state is in a database, i.e.
-    // we did `flush` or actually read it from the database using `read`.
+    // We pass `persist = false` when the state was never put in a database (no `flush`, no `read`), so a
+    // buffer-only delete causes less calls to the storage and avoids producing unnecessary tombstones.
     //
-    // It causes less calls to the storage and avoid producing unnecessary
-    // tombstones in such databases as Cassandra.
-    def delete = Timestamps[F].persistedAt flatMap { persistedAt =>
-      if (persistedAt.isDefined) {
-        Timestamps[F].onPersisted *>
-          buffers.delete(true)
-      } else {
-        buffers.delete(false)
-      }
-    }
+    // A fencing snapshot store overrides this and writes the tombstone anyway (see `Snapshots.delete`): there the
+    // tombstone is the offset gate that stops a zombie resurrecting a never-persisted, just-deleted key, so it is
+    // not unnecessary. `persist` is honored as-is by the unfenced (last-write-wins) store.
+    def delete = for {
+      persistedAt <- Timestamps[F].persistedAt
+      current     <- Timestamps[F].current
+      _ <-
+        if (persistedAt.isDefined) {
+          Timestamps[F].onPersisted *>
+            buffers.delete(true, current.offset)
+        } else {
+          buffers.delete(false, current.offset)
+        }
+    } yield ()
 
     def flush = Timestamps[F].persistedAt flatMap { persistedAt =>
       val flushAll = if (persistedAt.isEmpty) {
@@ -140,12 +147,12 @@ object Persistence {
 object Buffers {
 
   def empty[F[_]: Applicative, S, E]: Buffers[F, S, E] = new Buffers[F, S, E] {
-    def appendEvent(event: E)        = ().pure[F]
-    def replaceState(state: S)       = ().pure[F]
-    def initPersistedState(state: S) = ().pure[F]
-    def flushKeys                    = ().pure[F]
-    def flushState                   = ().pure[F]
-    def delete(persist: Boolean)     = ().pure[F]
+    def appendEvent(event: E)                    = ().pure[F]
+    def replaceState(state: S)                   = ().pure[F]
+    def initPersistedState(state: S)             = ().pure[F]
+    def flushKeys                                = ().pure[F]
+    def flushState                               = ().pure[F]
+    def delete(persist: Boolean, offset: Offset) = ().pure[F]
   }
 
   def apply[F[_]: Monad, S, E](
@@ -160,8 +167,8 @@ object Buffers {
 
     def initPersistedState(state: S) = snapshots.initPersisted(state)
 
-    def delete(persist: Boolean) =
-      snapshots.delete(persist) *> journals.delete(persist) *> keys.delete(persist)
+    def delete(persist: Boolean, offset: Offset) =
+      snapshots.delete(persist, offset) *> journals.delete(persist) *> keys.delete(persist)
 
     def flushKeys =
       keys.flush
@@ -188,6 +195,50 @@ object ReadState {
       recover.last map (_.flatten)
     }
 
+  }
+
+  /** Restores state from previously saved events, folded onto the fenced snapshot store's view of the key.
+    *
+    * When the buffer fences, `snapshots.read` runs first and seeds the buffer cell from the snapshot store: a live
+    * snapshot becomes the recovery BASE the journal folds onto, a deletion tombstone's offset the replay-window floor
+    * (without it a replayed event below the tombstone would be re-derived and persisted, which a compare-and-set store
+    * rejects as stale though the owner is legitimate -- the deleted-key self-fence). Journal events whose offset (via
+    * `offsetOf`) is at or below the store's floor (`snapshots.floor`) are NOT folded: the journal is unfenced -- a
+    * zombie's replayed appends can land after a delete cleared it, and a journal TTL can reap rows the snapshot already
+    * carries -- so a below-floor row is either already reflected in the base or stale residue of a deleted key, and
+    * folding it would durably resurrect pre-delete state or regress a live key (the design doc's journal revive).
+    * Filtering events by offset at the seam, rather than comparing fold results after the fact, is what makes the guard
+    * hold at EVERY recovery: legitimate appends advance the journal past the store's offset, but the residue stays
+    * below the floor forever. An unfenced buffer has no trustworthy store to compare against, so the read is skipped
+    * (no wasted per-key round-trip) and the fold runs from scratch over the whole journal, exactly as before the fence
+    * existed. See docs/cassandra-single-writer-design.md.
+    */
+  def apply[F[_]: Monad: Log, S, E](
+    journals: JournalReader[F, E],
+    fold: FoldOption[F, S, E],
+    snapshots: Snapshots[F, S],
+    offsetOf: E => Offset,
+  ): ReadState[F, S] = new ReadState[F, S] {
+    def read =
+      if (snapshots.fenced)
+        for {
+          base  <- snapshots.read
+          floor <- snapshots.floor
+          events = floor.fold(journals.read)(floor => journals.read.filter(event => offsetOf(event) > floor))
+          state <- events
+            .foldLeftM(base) { (state, event) =>
+              Log[F].info(s"Restoring: $event") *> fold(state, event)
+            }
+            .last
+            .map {
+              // `last` is None exactly when no event survived the filter: the store's view IS the state (an
+              // all-reaped or residue-only journal must not erase the base). A folded Some(none) is different -
+              // the fold itself cleared the state - and stands.
+              case Some(folded) => folded
+              case None         => base
+            }
+        } yield state
+      else ReadState(journals, fold).read
   }
 
   /** Restores state using previously saved snapshot */

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/persistence/Persistence.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/persistence/Persistence.scala
@@ -197,20 +197,25 @@ object ReadState {
   }
 
   /** Restores state from previously saved events, after seeding the snapshot buffer's replay-window floor from the
-    * snapshot store. A delete clears a key's journal, so events-recovery alone cannot reconstruct a deleted key's
-    * high-water offset; reading the snapshot store surfaces the deletion tombstone's offset as the floor. Without it a
-    * replayed event below that offset would be re-derived and persisted, which a compare-and-set snapshot store rejects
-    * as stale though the owner is legitimate -- the deleted-key replay-window self-fence. A live key needs no floor
-    * here (its journal is intact, so the fold reconstructs the high-water). See docs/cassandra-single-writer-design.md.
+    * snapshot store when (and only when) the buffer fences stale writers. A delete clears a key's journal, so
+    * events-recovery alone cannot reconstruct a deleted key's high-water offset; reading the snapshot store surfaces
+    * the deletion tombstone's offset as the floor. Without it a replayed event below that offset would be re-derived
+    * and persisted, which a compare-and-set snapshot store rejects as stale though the owner is legitimate -- the
+    * deleted-key replay-window self-fence. A live key needs no floor here (its journal is intact, so the fold
+    * reconstructs the high-water). See docs/cassandra-single-writer-design.md.
     */
   def apply[F[_]: Monad: Log, S, E](
     journals: JournalReader[F, E],
     fold: FoldOption[F, S, E],
-    snapshots: SnapshotReader[F, S],
+    snapshots: Snapshots[F, S],
   ): ReadState[F, S] = new ReadState[F, S] {
-    // `snapshots.read` is run for its floor side-effect only (it sets the buffer floor on a recovered tombstone); the
-    // recovered state comes from folding the journal, the events-recovery source, so its returned value is discarded.
-    def read = snapshots.read *> ReadState(journals, fold).read
+    // When the buffer fences, `snapshots.read` is run for its floor side-effect only (it sets the buffer floor on a
+    // recovered tombstone); the recovered state always comes from folding the journal, the events-recovery source, so
+    // its returned value is discarded. An unfenced buffer never reads back a tombstone, so the read is skipped to avoid
+    // a wasted per-key round-trip on recovery.
+    def read =
+      (if (snapshots.fenced) snapshots.read.void else ().pure[F]) *>
+        ReadState(journals, fold).read
   }
 
   /** Restores state using previously saved snapshot */

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/persistence/Persistence.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/persistence/Persistence.scala
@@ -196,6 +196,23 @@ object ReadState {
 
   }
 
+  /** Restores state from previously saved events, after seeding the snapshot buffer's replay-window floor from the
+    * snapshot store. A delete clears a key's journal, so events-recovery alone cannot reconstruct a deleted key's
+    * high-water offset; reading the snapshot store surfaces the deletion tombstone's offset as the floor. Without it a
+    * replayed event below that offset would be re-derived and persisted, which a compare-and-set snapshot store rejects
+    * as stale though the owner is legitimate -- the deleted-key replay-window self-fence. A live key needs no floor
+    * here (its journal is intact, so the fold reconstructs the high-water). See docs/cassandra-single-writer-design.md.
+    */
+  def apply[F[_]: Monad: Log, S, E](
+    journals: JournalReader[F, E],
+    fold: FoldOption[F, S, E],
+    snapshots: SnapshotReader[F, S],
+  ): ReadState[F, S] = new ReadState[F, S] {
+    // `snapshots.read` is run for its floor side-effect only (it sets the buffer floor on a recovered tombstone); the
+    // recovered state comes from folding the journal, the events-recovery source, so its returned value is discarded.
+    def read = snapshots.read *> ReadState(journals, fold).read
+  }
+
   /** Restores state using previously saved snapshot */
   def apply[F[_], S](
     snapshots: SnapshotReader[F, S]

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/persistence/Persistence.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/persistence/Persistence.scala
@@ -11,6 +11,7 @@ import com.evolutiongaming.kafka.flow.key.Keys
 import com.evolutiongaming.kafka.flow.snapshot.SnapshotReader
 import com.evolutiongaming.kafka.flow.snapshot.Snapshots
 import com.evolutiongaming.kafka.flow.timer.Timestamps
+import com.evolutiongaming.skafka.Offset
 
 /** Provides persistence for keys, events and snapshots.
   *
@@ -35,8 +36,10 @@ trait Buffers[F[_], S, E] extends WriteToBuffers[F, S, E] {
     *
     * @param persist
     *   if `true` then also calls underlying database, flushes buffers only otherwise.
+    * @param offset
+    *   offset of the state being deleted, forwarded to the snapshot database for stale-writer protection.
     */
-  def delete(persist: Boolean): F[Unit]
+  def delete(persist: Boolean, offset: Offset): F[Unit]
 
   /** Initialize an already persisted state, used to store a state in buffers that was fetched from the database.
     *
@@ -110,14 +113,17 @@ object Persistence {
     //
     // It causes less calls to the storage and avoid producing unnecessary
     // tombstones in such databases as Cassandra.
-    def delete = Timestamps[F].persistedAt flatMap { persistedAt =>
-      if (persistedAt.isDefined) {
-        Timestamps[F].onPersisted *>
-          buffers.delete(true)
-      } else {
-        buffers.delete(false)
-      }
-    }
+    def delete = for {
+      persistedAt <- Timestamps[F].persistedAt
+      current     <- Timestamps[F].current
+      _ <-
+        if (persistedAt.isDefined) {
+          Timestamps[F].onPersisted *>
+            buffers.delete(true, current.offset)
+        } else {
+          buffers.delete(false, current.offset)
+        }
+    } yield ()
 
     def flush = Timestamps[F].persistedAt flatMap { persistedAt =>
       val flushAll = if (persistedAt.isEmpty) {
@@ -140,12 +146,12 @@ object Persistence {
 object Buffers {
 
   def empty[F[_]: Applicative, S, E]: Buffers[F, S, E] = new Buffers[F, S, E] {
-    def appendEvent(event: E)        = ().pure[F]
-    def replaceState(state: S)       = ().pure[F]
-    def initPersistedState(state: S) = ().pure[F]
-    def flushKeys                    = ().pure[F]
-    def flushState                   = ().pure[F]
-    def delete(persist: Boolean)     = ().pure[F]
+    def appendEvent(event: E)                    = ().pure[F]
+    def replaceState(state: S)                   = ().pure[F]
+    def initPersistedState(state: S)             = ().pure[F]
+    def flushKeys                                = ().pure[F]
+    def flushState                               = ().pure[F]
+    def delete(persist: Boolean, offset: Offset) = ().pure[F]
   }
 
   def apply[F[_]: Monad, S, E](
@@ -160,8 +166,8 @@ object Buffers {
 
     def initPersistedState(state: S) = snapshots.initPersisted(state)
 
-    def delete(persist: Boolean) =
-      snapshots.delete(persist) *> journals.delete(persist) *> keys.delete(persist)
+    def delete(persist: Boolean, offset: Offset) =
+      snapshots.delete(persist, offset) *> journals.delete(persist) *> keys.delete(persist)
 
     def flushKeys =
       keys.flush

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/persistence/PersistenceModule.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/persistence/PersistenceModule.scala
@@ -7,7 +7,7 @@ import com.evolutiongaming.catshelper.LogOf
 import com.evolutiongaming.kafka.flow.KafkaKey
 import com.evolutiongaming.kafka.flow.journal.JournalDatabase
 import com.evolutiongaming.kafka.flow.key.KeyDatabase
-import com.evolutiongaming.kafka.flow.snapshot.{KafkaSnapshot, SnapshotDatabase}
+import com.evolutiongaming.kafka.flow.snapshot.{KafkaSnapshot, SnapshotDatabase, SnapshotsOf}
 import com.evolutiongaming.skafka.consumer.ConsumerRecord
 import scodec.bits.ByteVector
 
@@ -18,15 +18,31 @@ trait PersistenceModule[F[_], S] {
   def journals: JournalDatabase[F, KafkaKey, ConsumerRecord[String, ByteVector]]
   def snapshots: SnapshotDatabase[F, KafkaKey, KafkaSnapshot[S]]
 
+  /** How `snapshots` wires into the per-key buffer. Fenced on `KafkaSnapshot.offset` by default, which is right for a
+    * store that gates writes on the offset (see `CassandraSnapshots` compare-and-set mode). A module over a
+    * last-write-wins store should override to the unfenced `SnapshotsOf.backedBy(snapshots)`: such a store never
+    * returns a tombstone floor, so the fenced buffer would only change buffering semantics and make events-recovery pay
+    * a per-key floor read it can never profit from.
+    */
+  def snapshotsOf(
+    implicit F: Sync[F],
+    logOf: LogOf[F]
+  ): F[SnapshotsOf[F, KafkaKey, KafkaSnapshot[S]]] = snapshots.snapshotsOf
+
   /** Saves both events and snapshots, restores state from events */
   def restoreEvents(
     implicit F: Sync[F],
     logOf: LogOf[F]
   ): Resource[F, PersistenceOf[F, KafkaKey, KafkaSnapshot[S], ConsumerRecord[String, ByteVector]]] = for {
-    keysOf        <- Resource.eval(keys.toKeysOf)
-    journalsOf    <- Resource.eval(journals.journalsOf)
-    snapshotsOf   <- Resource.eval(snapshots.snapshotsOf)
-    persistenceOf <- PersistenceOf.restoreEvents(keysOf, journalsOf, snapshotsOf)
+    keysOf      <- Resource.eval(keys.toKeysOf)
+    journalsOf  <- Resource.eval(journals.journalsOf)
+    snapshotsOf <- Resource.eval(snapshotsOf)
+    persistenceOf <- PersistenceOf.restoreEvents(
+      keysOf,
+      journalsOf,
+      snapshotsOf,
+      (record: ConsumerRecord[String, ByteVector]) => record.offset
+    )
   } yield persistenceOf
 
   /** Saves both events and snapshots, restores state from snapshots */
@@ -34,19 +50,19 @@ trait PersistenceModule[F[_], S] {
     implicit F: Sync[F],
     logOf: LogOf[F]
   ): F[SnapshotPersistenceOf[F, KafkaKey, KafkaSnapshot[S], ConsumerRecord[String, ByteVector]]] = for {
-    keysOf      <- keys.toKeysOf
-    journalsOf  <- journals.journalsOf
-    snapshotsOf <- snapshots.snapshotsOf
-  } yield PersistenceOf.restoreSnapshots(keysOf, journalsOf, snapshotsOf)
+    keysOf       <- keys.toKeysOf
+    journalsOf   <- journals.journalsOf
+    _snapshotsOf <- snapshotsOf
+  } yield PersistenceOf.restoreSnapshots(keysOf, journalsOf, _snapshotsOf)
 
   /** Saves snapshots only, restores state from snapshots */
   def snapshotsOnly(
     implicit F: Sync[F],
     logOf: LogOf[F]
   ): F[SnapshotPersistenceOf[F, KafkaKey, KafkaSnapshot[S], ConsumerRecord[String, ByteVector]]] = for {
-    keysOf      <- keys.toKeysOf
-    snapshotsOf <- snapshots.snapshotsOf
-  } yield PersistenceOf.snapshotsOnly(keysOf, snapshotsOf)
+    keysOf       <- keys.toKeysOf
+    _snapshotsOf <- snapshotsOf
+  } yield PersistenceOf.snapshotsOnly(keysOf, _snapshotsOf)
 
 }
 

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/persistence/PersistenceOf.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/persistence/PersistenceOf.scala
@@ -11,6 +11,7 @@ import com.evolutiongaming.kafka.flow.journal.JournalsOf
 import com.evolutiongaming.kafka.flow.key.KeysOf
 import com.evolutiongaming.kafka.flow.snapshot.SnapshotsOf
 import com.evolutiongaming.kafka.flow.timer.Timestamps
+import com.evolutiongaming.skafka.Offset
 
 /** Creates generic persistence for a key */
 trait PersistenceOf[F[_], K, S, A] {
@@ -55,11 +56,20 @@ trait SnapshotPersistenceOf[F[_], K, S, A] extends PersistenceOf[F, K, S, A] { s
 }
 object PersistenceOf {
 
-  /** Saves both events and snapshots, restores state from events */
+  /** Saves both events and snapshots, restores state from events.
+    *
+    * @param offsetOf
+    *   the offset an event was consumed at. When the snapshot store fences stale writers, recovery folds the journal
+    *   onto the store's view of the key: a live snapshot is the base, a deletion tombstone's offset the floor, and
+    *   journal events at or below the store's offset are skipped -- they are already reflected in the base, or stale
+    *   residue of a deleted key that would otherwise be folded back to life (the journal is unfenced). See `ReadState`
+    *   and docs/cassandra-single-writer-design.md (the journal revive). Unfenced stores ignore it.
+    */
   def restoreEvents[F[_]: Monad: LogOf, K, S, A](
     keysOf: KeysOf[F, K],
     journalsOf: JournalsOf[F, K, A],
-    snapshotsOf: SnapshotsOf[F, K, S]
+    snapshotsOf: SnapshotsOf[F, K, S],
+    offsetOf: A => Offset,
   ): Resource[F, PersistenceOf[F, K, S, A]] = {
     val log = LogOf[F].apply(PersistenceOf.getClass)
     Resource.eval(log) map { implicit log => (key, fold, timestamps) =>
@@ -69,7 +79,7 @@ object PersistenceOf {
         snapshots <- snapshotsOf(key)
         keys       = keysOf(key)
       } yield Persistence(
-        readState = ReadState(journals, fold),
+        readState = ReadState(journals, fold, snapshots, offsetOf),
         buffers   = Buffers(keys, journals, snapshots)
       )
     }

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/persistence/PersistenceOf.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/persistence/PersistenceOf.scala
@@ -69,7 +69,10 @@ object PersistenceOf {
         snapshots <- snapshotsOf(key)
         keys       = keysOf(key)
       } yield Persistence(
-        readState = ReadState(journals, fold),
+        // seed the replay-window floor from the snapshot store (a deleted key's tombstone offset) before folding the
+        // journal: a delete clears the journal, so without this a compare-and-set snapshot store would self-fence the
+        // legitimate owner on a deleted-key replay. See ReadState and docs/cassandra-single-writer-design.md.
+        readState = ReadState(journals, fold, snapshots),
         buffers   = Buffers(keys, journals, snapshots)
       )
     }

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotDatabase.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotDatabase.scala
@@ -17,7 +17,7 @@ trait SnapshotDatabase[F[_], K, S] extends SnapshotReadDatabase[F, K, S] with Sn
   * One type carries both the live snapshot and the tombstone across the read, the write and the per-key buffer - so a
   * delete is just a write of a [[Stored.Tombstone]], and recovery of a tombstone is just a read of one whose value is
   * absent but whose offset survives. This replaces the previous `persist`/`delete` write pair and the `get`/`recover`
-  * (`Recovered`) read pair, and lets [[Snapshots]] reason about one monotonic cell. As an ADT it admits no nonsensical
+  * (`Recovered`) read pair, and lets `Snapshots` reason about one monotonic cell. As an ADT it admits no nonsensical
   * "no value and no offset" state. See `docs/cassandra-single-writer-design.md`.
   */
 sealed trait Stored[+S] {
@@ -63,8 +63,8 @@ trait SnapshotWriteDatabase[F[_], K, S] {
   /** Adds, replaces or tombstones the snapshot for the key.
     *
     * A [[Stored.Live]] persists a snapshot; a [[Stored.Tombstone]] writes a tombstone (a delete). A database protecting
-    * against stale writers (see [[com.evolutiongaming.kafka.flow.snapshot.CassandraSnapshots]] compare-and-set mode)
-    * gates the write on `stored.offset`, so a stale writer cannot erase or overwrite a newer owner's snapshot.
+    * against stale writers (see `CassandraSnapshots` compare-and-set mode) gates the write on `stored.offset`, so a
+    * stale writer cannot erase or overwrite a newer owner's snapshot.
     */
   def write(key: K, stored: Stored[S]): F[Unit]
 

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotDatabase.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotDatabase.scala
@@ -11,54 +11,62 @@ import com.evolutiongaming.skafka.Offset
 
 trait SnapshotDatabase[F[_], K, S] extends SnapshotReadDatabase[F, K, S] with SnapshotWriteDatabase[F, K, S]
 
-/** Outcome of recovering a key from the snapshot store.
+/** What the snapshot store holds for a key: a live snapshot, or an offset-carrying tombstone (the absence of a row is
+  * an outer `None`, so a never-written key is not a `Stored`).
   *
-  * A compare-and-set store (see [[CassandraSnapshots]]) keeps a deleted key as an offset-carrying logical tombstone: it
-  * reads back as absent, but its stored offset still fences a later write. Recovery must surface that offset as the
-  * replay-window floor (`Deleted`) rather than collapse it to "nothing there" (`Absent`) - otherwise the buffer starts
-  * with no high-water and a legitimate owner re-persisting (or deleting) below it self-fences with a write conflict, a
-  * livelock. See `docs/cassandra-single-writer-design.md`.
+  * One type carries both the live snapshot and the tombstone across the read, the write and the per-key buffer - so a
+  * delete is just a write of a [[Stored.Tombstone]], and recovery of a tombstone is just a read of one whose value is
+  * absent but whose offset survives. This replaces the previous `persist`/`delete` write pair and the `get`/`recover`
+  * (`Recovered`) read pair, and lets [[Snapshots]] reason about one monotonic cell. As an ADT it admits no nonsensical
+  * "no value and no offset" state. See `docs/cassandra-single-writer-design.md`.
   */
-sealed trait Recovered[+S]
-object Recovered {
+sealed trait Stored[+S] {
 
-  /** A live snapshot was recovered. */
-  final case class Present[S](snapshot: S) extends Recovered[S]
+  /** The offset the unit sits at, for an offset-carrying (compare-and-set) store; `None` for an unfenced
+    * last-write-wins store, which does not track one (the buffer is then non-monotonic and never consults it). A
+    * tombstone always carries one - only a fencing store deletes via a tombstone.
+    */
+  def offset: Option[Offset]
 
-  /** The key was deleted; the store kept an offset-carrying tombstone at `offset` (reads back as absent). */
-  final case class Deleted(offset: Offset) extends Recovered[Nothing]
+  /** The live snapshot, or `None` for a tombstone. */
+  def value: Option[S]
+}
+object Stored {
 
-  /** No row for the key at all (never written, or the tombstone was reaped). */
-  case object Absent extends Recovered[Nothing]
+  /** A live snapshot; `offset` is set iff the store fences on it. */
+  final case class Live[S](snapshot: S, offset: Option[Offset]) extends Stored[S] {
+    def value: Option[S] = snapshot.some
+  }
+
+  /** An offset-carrying tombstone: a deleted key whose offset still fences a later write. */
+  final case class Tombstone(at: Offset) extends Stored[Nothing] {
+    def offset: Option[Offset] = at.some
+    def value: Option[Nothing] = none
+  }
 }
 
 trait SnapshotReadDatabase[F[_], K, S] {
 
-  /** Restores snapshot for the key, if any */
-  def get(key: K): F[Option[S]]
-
-  /** Recovers the key, distinguishing an offset-carrying tombstone ([[Recovered.Deleted]]) from a truly absent key
-    * ([[Recovered.Absent]]). The default derives from [[get]] and never reports `Deleted` - a store that keeps deleted
-    * keys as offset-carrying tombstones (compare-and-set [[CassandraSnapshots]]) overrides it so recovery can
-    * re-establish the replay-window floor for a deleted key. A wrapper (e.g. metrics) must delegate to the underlying
-    * `recover`, or it silently downgrades a tombstone to `Absent` through its own `get`.
+  /** Recovers the stored unit for the key, distinguishing a live snapshot, an offset-carrying tombstone and an absent
+    * key:
+    *   - `None` - no row (never written, or a tombstone reaped by TTL);
+    *   - `Some(Stored.Tombstone(offset))` - a deleted key (a compare-and-set store keeps the offset as the
+    *     replay-window floor even though the value reads back as absent);
+    *   - `Some(Stored.Live(snapshot, offset))` - a live snapshot.
     */
-  def recover(key: K)(implicit F: Functor[F]): F[Recovered[S]] =
-    get(key).map(_.fold(Recovered.Absent: Recovered[S])(Recovered.Present(_)))
+  def read(key: K): F[Option[Stored[S]]]
+
 }
 
-trait SnapshotWriteDatabase[F[_], K, S] { self =>
+trait SnapshotWriteDatabase[F[_], K, S] {
 
-  /** Adds or replaces the snapshot in a database */
-  def persist(key: K, snapshot: S): F[Unit]
-
-  /** Deletes snapshot for the key, if any.
+  /** Adds, replaces or tombstones the snapshot for the key.
     *
-    * `offset` is the offset of the state being deleted; a database protecting against stale writers (see
-    * [[com.evolutiongaming.kafka.flow.snapshot.CassandraSnapshots]] compare-and-set mode) gates the delete on it, so a
-    * stale writer cannot erase a newer owner's snapshot.
+    * A [[Stored.Live]] persists a snapshot; a [[Stored.Tombstone]] writes a tombstone (a delete). A database protecting
+    * against stale writers (see [[com.evolutiongaming.kafka.flow.snapshot.CassandraSnapshots]] compare-and-set mode)
+    * gates the write on `stored.offset`, so a stale writer cannot erase or overwrite a newer owner's snapshot.
     */
-  def delete(key: K, offset: Offset): F[Unit]
+  def write(key: K, stored: Stored[S]): F[Unit]
 
 }
 
@@ -75,40 +83,36 @@ object SnapshotDatabase {
   /** Creates in-memory database implementation.
     *
     * The data will survive destruction of specific `Snapshots` instance, but will not survive destruction of specific
-    * `SnapshotDatabase` instance.
+    * `SnapshotDatabase` instance. Last-write-wins: a tombstone write removes the row (the offset is not tracked), so
+    * `read` never reports a tombstone.
     */
   def memory[F[_]: Functor, K, S](storage: Stateful[F, Map[K, S]]): SnapshotDatabase[F, K, S] =
     new SnapshotDatabase[F, K, S] {
 
-      def persist(key: K, snapshot: S) =
-        storage modify (_ + (key -> snapshot))
+      def write(key: K, stored: Stored[S]) =
+        stored match {
+          case Stored.Live(value, _) => storage modify (_ + (key -> value))
+          case Stored.Tombstone(_)   => storage modify (_ - key)
+        }
 
-      def get(key: K) =
-        storage.get map (_ get key)
-
-      def delete(key: K, offset: Offset) =
-        storage modify (_ - key)
+      def read(key: K) =
+        storage.get map (_.get(key).map(value => Stored.Live(value, none)))
 
     }
 
-  // TODO: clean up this code (coming from `kafka-flow-persistence-kafka`?)
   def apply[F[_], K, S](
-    read: SnapshotReadDatabase[F, K, S],
-    write: SnapshotWriteDatabase[F, K, S]
+    readDatabase: SnapshotReadDatabase[F, K, S],
+    writeDatabase: SnapshotWriteDatabase[F, K, S]
   ): SnapshotDatabase[F, K, S] =
     new SnapshotDatabase[F, K, S] {
-      override def persist(key: K, snapshot: S): F[Unit] = write.persist(key, snapshot)
-
-      override def delete(key: K, offset: Offset): F[Unit] = write.delete(key, offset)
-
-      override def get(key: K): F[Option[S]] = read.get(key)
+      override def read(key: K): F[Option[Stored[S]]]        = readDatabase.read(key)
+      override def write(key: K, stored: Stored[S]): F[Unit] = writeDatabase.write(key, stored)
     }
 
   def empty[F[_]: Applicative, K, S]: SnapshotDatabase[F, K, S] =
     new SnapshotDatabase[F, K, S] {
-      def get(key: K)                    = none[S].pure
-      def persist(key: K, snapshot: S)   = ().pure
-      def delete(key: K, offset: Offset) = ().pure
+      def read(key: K)                     = none[Stored[S]].pure
+      def write(key: K, stored: Stored[S]) = ().pure
     }
 
   implicit class SnapshotDatabaseKafkaSnapshotOps[F[_], K, S](

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotDatabase.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotDatabase.scala
@@ -7,6 +7,7 @@ import cats.{Applicative, Functor, Monad}
 import com.evolutiongaming.catshelper.LogOf
 import com.evolutiongaming.kafka.flow.LogPrefix
 import com.evolutiongaming.kafka.flow.effect.CatsEffectMtlInstances.*
+import com.evolutiongaming.skafka.Offset
 
 trait SnapshotDatabase[F[_], K, S] extends SnapshotReadDatabase[F, K, S] with SnapshotWriteDatabase[F, K, S]
 
@@ -21,8 +22,13 @@ trait SnapshotWriteDatabase[F[_], K, S] { self =>
   /** Adds or replaces the snapshot in a database */
   def persist(key: K, snapshot: S): F[Unit]
 
-  /** Deletes snapshot for they key, if any */
-  def delete(key: K): F[Unit]
+  /** Deletes snapshot for the key, if any.
+    *
+    * `offset` is the offset of the state being deleted; a database protecting against stale writers (see
+    * [[com.evolutiongaming.kafka.flow.snapshot.CassandraSnapshots]] compare-and-set mode) gates the delete on it, so a
+    * stale writer cannot erase a newer owner's snapshot.
+    */
+  def delete(key: K, offset: Offset): F[Unit]
 
 }
 
@@ -50,7 +56,7 @@ object SnapshotDatabase {
       def get(key: K) =
         storage.get map (_ get key)
 
-      def delete(key: K) =
+      def delete(key: K, offset: Offset) =
         storage modify (_ - key)
 
     }
@@ -63,16 +69,16 @@ object SnapshotDatabase {
     new SnapshotDatabase[F, K, S] {
       override def persist(key: K, snapshot: S): F[Unit] = write.persist(key, snapshot)
 
-      override def delete(key: K): F[Unit] = write.delete(key)
+      override def delete(key: K, offset: Offset): F[Unit] = write.delete(key, offset)
 
       override def get(key: K): F[Option[S]] = read.get(key)
     }
 
   def empty[F[_]: Applicative, K, S]: SnapshotDatabase[F, K, S] =
     new SnapshotDatabase[F, K, S] {
-      def get(key: K)                  = none[S].pure
-      def persist(key: K, snapshot: S) = ().pure
-      def delete(key: K)               = ().pure
+      def get(key: K)                    = none[S].pure
+      def persist(key: K, snapshot: S)   = ().pure
+      def delete(key: K, offset: Offset) = ().pure
     }
 
   implicit class SnapshotDatabaseKafkaSnapshotOps[F[_], K, S](
@@ -84,7 +90,9 @@ object SnapshotDatabase {
       logOf: LogOf[F],
       logPrefix: LogPrefix[K]
     ): F[SnapshotsOf[F, K, KafkaSnapshot[S]]] =
-      logOf(SnapshotDatabase.getClass) map { implicit log => key => Snapshots.of(key, self) }
+      // pass KafkaSnapshot.offset so the buffer fences a delete on the key's high-water offset (see
+      // Snapshots.append/delete)
+      logOf(SnapshotDatabase.getClass) map { implicit log => key => Snapshots.of(key, self, _.offset) }
 
   }
 

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotDatabase.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotDatabase.scala
@@ -7,22 +7,66 @@ import cats.{Applicative, Functor, Monad}
 import com.evolutiongaming.catshelper.LogOf
 import com.evolutiongaming.kafka.flow.LogPrefix
 import com.evolutiongaming.kafka.flow.effect.CatsEffectMtlInstances.*
+import com.evolutiongaming.skafka.Offset
 
 trait SnapshotDatabase[F[_], K, S] extends SnapshotReadDatabase[F, K, S] with SnapshotWriteDatabase[F, K, S]
 
-trait SnapshotReadDatabase[F[_], K, S] {
+/** What the snapshot store holds for a key: a live snapshot, or an offset-carrying tombstone (the absence of a row is
+  * an outer `None`, so a never-written key is not a `Stored`).
+  *
+  * One type carries both the live snapshot and the tombstone across the read, the write and the per-key buffer - so a
+  * delete is just a write of a [[Stored.Tombstone]], and recovery of a tombstone is just a read of one whose value is
+  * absent but whose offset survives. This replaces the previous `persist`/`delete` write pair and the `get`/`recover`
+  * (`Recovered`) read pair, and lets `Snapshots` reason about one monotonic cell. As an ADT it admits no nonsensical
+  * "no value and no offset" state. See `docs/cassandra-single-writer-design.md`.
+  */
+sealed trait Stored[+S] {
 
-  /** Restores snapshot for the key, if any */
-  def get(key: K): F[Option[S]]
+  /** The offset the unit sits at, for an offset-carrying (compare-and-set) store; `None` for an unfenced
+    * last-write-wins store, which does not track one (the buffer is then non-monotonic and never consults it). A
+    * tombstone always carries one - only a fencing store deletes via a tombstone.
+    */
+  def offset: Option[Offset]
+
+  /** The live snapshot, or `None` for a tombstone. */
+  def value: Option[S]
+}
+object Stored {
+
+  /** A live snapshot; `offset` is set iff the store fences on it. */
+  final case class Live[S](snapshot: S, offset: Option[Offset]) extends Stored[S] {
+    def value: Option[S] = snapshot.some
+  }
+
+  /** An offset-carrying tombstone: a deleted key whose offset still fences a later write. */
+  final case class Tombstone(at: Offset) extends Stored[Nothing] {
+    def offset: Option[Offset] = at.some
+    def value: Option[Nothing] = none
+  }
 }
 
-trait SnapshotWriteDatabase[F[_], K, S] { self =>
+trait SnapshotReadDatabase[F[_], K, S] {
 
-  /** Adds or replaces the snapshot in a database */
-  def persist(key: K, snapshot: S): F[Unit]
+  /** Recovers the stored unit for the key, distinguishing a live snapshot, an offset-carrying tombstone and an absent
+    * key:
+    *   - `None` - no row (never written, or a tombstone reaped by TTL);
+    *   - `Some(Stored.Tombstone(offset))` - a deleted key (a compare-and-set store keeps the offset as the
+    *     replay-window floor even though the value reads back as absent);
+    *   - `Some(Stored.Live(snapshot, offset))` - a live snapshot.
+    */
+  def read(key: K): F[Option[Stored[S]]]
 
-  /** Deletes snapshot for they key, if any */
-  def delete(key: K): F[Unit]
+}
+
+trait SnapshotWriteDatabase[F[_], K, S] {
+
+  /** Adds, replaces or tombstones the snapshot for the key.
+    *
+    * A [[Stored.Live]] persists a snapshot; a [[Stored.Tombstone]] writes a tombstone (a delete). A database protecting
+    * against stale writers (see `CassandraSnapshots` compare-and-set mode) gates the write on `stored.offset`, so a
+    * stale writer cannot erase or overwrite a newer owner's snapshot.
+    */
+  def write(key: K, stored: Stored[S]): F[Unit]
 
 }
 
@@ -39,40 +83,36 @@ object SnapshotDatabase {
   /** Creates in-memory database implementation.
     *
     * The data will survive destruction of specific `Snapshots` instance, but will not survive destruction of specific
-    * `SnapshotDatabase` instance.
+    * `SnapshotDatabase` instance. Last-write-wins: a tombstone write removes the row (the offset is not tracked), so
+    * `read` never reports a tombstone.
     */
   def memory[F[_]: Functor, K, S](storage: Stateful[F, Map[K, S]]): SnapshotDatabase[F, K, S] =
     new SnapshotDatabase[F, K, S] {
 
-      def persist(key: K, snapshot: S) =
-        storage modify (_ + (key -> snapshot))
+      def write(key: K, stored: Stored[S]) =
+        stored match {
+          case Stored.Live(value, _) => storage modify (_ + (key -> value))
+          case Stored.Tombstone(_)   => storage modify (_ - key)
+        }
 
-      def get(key: K) =
-        storage.get map (_ get key)
-
-      def delete(key: K) =
-        storage modify (_ - key)
+      def read(key: K) =
+        storage.get map (_.get(key).map(value => Stored.Live(value, none)))
 
     }
 
-  // TODO: clean up this code (coming from `kafka-flow-persistence-kafka`?)
   def apply[F[_], K, S](
-    read: SnapshotReadDatabase[F, K, S],
-    write: SnapshotWriteDatabase[F, K, S]
+    readDatabase: SnapshotReadDatabase[F, K, S],
+    writeDatabase: SnapshotWriteDatabase[F, K, S]
   ): SnapshotDatabase[F, K, S] =
     new SnapshotDatabase[F, K, S] {
-      override def persist(key: K, snapshot: S): F[Unit] = write.persist(key, snapshot)
-
-      override def delete(key: K): F[Unit] = write.delete(key)
-
-      override def get(key: K): F[Option[S]] = read.get(key)
+      override def read(key: K): F[Option[Stored[S]]]        = readDatabase.read(key)
+      override def write(key: K, stored: Stored[S]): F[Unit] = writeDatabase.write(key, stored)
     }
 
   def empty[F[_]: Applicative, K, S]: SnapshotDatabase[F, K, S] =
     new SnapshotDatabase[F, K, S] {
-      def get(key: K)                  = none[S].pure
-      def persist(key: K, snapshot: S) = ().pure
-      def delete(key: K)               = ().pure
+      def read(key: K)                     = none[Stored[S]].pure
+      def write(key: K, stored: Stored[S]) = ().pure
     }
 
   implicit class SnapshotDatabaseKafkaSnapshotOps[F[_], K, S](
@@ -84,7 +124,11 @@ object SnapshotDatabase {
       logOf: LogOf[F],
       logPrefix: LogPrefix[K]
     ): F[SnapshotsOf[F, K, KafkaSnapshot[S]]] =
-      logOf(SnapshotDatabase.getClass) map { implicit log => key => Snapshots.of(key, self) }
+      // fence on KafkaSnapshot.offset (Some): the buffer stays monotonic and a delete is gated on the key's
+      // high-water offset (see Snapshots.append/delete)
+      logOf(SnapshotDatabase.getClass) map { implicit log => key =>
+        Snapshots.of(key, self, Some[KafkaSnapshot[S] => Offset](_.offset))
+      }
 
   }
 

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotDatabase.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotDatabase.scala
@@ -120,9 +120,11 @@ object SnapshotDatabase {
       logOf: LogOf[F],
       logPrefix: LogPrefix[K]
     ): F[SnapshotsOf[F, K, KafkaSnapshot[S]]] =
-      // pass KafkaSnapshot.offset so the buffer fences a delete on the key's high-water offset (see
-      // Snapshots.append/delete)
-      logOf(SnapshotDatabase.getClass) map { implicit log => key => Snapshots.of(key, self, _.offset) }
+      // fence on KafkaSnapshot.offset (Some): the buffer stays monotonic and a delete is gated on the key's
+      // high-water offset (see Snapshots.append/delete)
+      logOf(SnapshotDatabase.getClass) map { implicit log => key =>
+        Snapshots.of(key, self, Some[KafkaSnapshot[S] => Offset](_.offset))
+      }
 
   }
 

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotDatabase.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotDatabase.scala
@@ -11,10 +11,40 @@ import com.evolutiongaming.skafka.Offset
 
 trait SnapshotDatabase[F[_], K, S] extends SnapshotReadDatabase[F, K, S] with SnapshotWriteDatabase[F, K, S]
 
+/** Outcome of recovering a key from the snapshot store.
+  *
+  * A compare-and-set store (see [[CassandraSnapshots]]) keeps a deleted key as an offset-carrying logical tombstone: it
+  * reads back as absent, but its stored offset still fences a later write. Recovery must surface that offset as the
+  * replay-window floor (`Deleted`) rather than collapse it to "nothing there" (`Absent`) - otherwise the buffer starts
+  * with no high-water and a legitimate owner re-persisting (or deleting) below it self-fences with a write conflict, a
+  * livelock. See `docs/cassandra-single-writer-design.md`.
+  */
+sealed trait Recovered[+S]
+object Recovered {
+
+  /** A live snapshot was recovered. */
+  final case class Present[S](snapshot: S) extends Recovered[S]
+
+  /** The key was deleted; the store kept an offset-carrying tombstone at `offset` (reads back as absent). */
+  final case class Deleted(offset: Offset) extends Recovered[Nothing]
+
+  /** No row for the key at all (never written, or the tombstone was reaped). */
+  case object Absent extends Recovered[Nothing]
+}
+
 trait SnapshotReadDatabase[F[_], K, S] {
 
   /** Restores snapshot for the key, if any */
   def get(key: K): F[Option[S]]
+
+  /** Recovers the key, distinguishing an offset-carrying tombstone ([[Recovered.Deleted]]) from a truly absent key
+    * ([[Recovered.Absent]]). The default derives from [[get]] and never reports `Deleted` - a store that keeps deleted
+    * keys as offset-carrying tombstones (compare-and-set [[CassandraSnapshots]]) overrides it so recovery can
+    * re-establish the replay-window floor for a deleted key. A wrapper (e.g. metrics) must delegate to the underlying
+    * `recover`, or it silently downgrades a tombstone to `Absent` through its own `get`.
+    */
+  def recover(key: K)(implicit F: Functor[F]): F[Recovered[S]] =
+    get(key).map(_.fold(Recovered.Absent: Recovered[S])(Recovered.Present(_)))
 }
 
 trait SnapshotWriteDatabase[F[_], K, S] { self =>

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/Snapshots.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/Snapshots.scala
@@ -52,6 +52,19 @@ trait SnapshotWriter[F[_], S] {
 }
 object Snapshots {
 
+  /** The per-key buffer cell: a live snapshot (with its `persisted` flag), a value-less high-water floor recovered from
+    * or left by a delete, or nothing yet. Folding the live snapshot and the tombstone floor into one monotonic cell
+    * lets `read`/`append`/`delete` reason about a single high-water (see `highWater`), so a deleted key's offset is
+    * held even though it carries no value. Parallels [[Recovered]] but keeps the `persisted` flag `flush` needs, so it
+    * is a separate type.
+    */
+  private[flow] sealed trait Buffered[+S]
+  private[flow] object Buffered {
+    final case class Live[S](snapshot: Snapshot[S]) extends Buffered[S]
+    final case class Deleted(offset: Offset) extends Buffered[Nothing]
+    case object Empty extends Buffered[Nothing]
+  }
+
   /** Per-key snapshot buffer over `database`.
     *
     * @param offsetOf
@@ -65,87 +78,73 @@ object Snapshots {
     database: SnapshotDatabase[F, K, S],
     offsetOf: Option[S => Offset],
   )(implicit log: Log[F]): F[Snapshots[F, S]] =
-    for {
-      buffer <- Ref.of[F, Option[Snapshot[S]]](None)
-      // the high-water offset recovered for a key that has no buffered snapshot (a deleted key recovered from an
-      // offset-carrying tombstone). A buffered snapshot carries its own high-water via `offsetOf`; this floor covers
-      // the value-less case. See `read`/`append`/`delete` and docs/cassandra-single-writer-design.md.
-      floor <- Ref.of[F, Option[Offset]](None)
-    } yield Snapshots(key, database, buffer.stateInstance, floor.stateInstance, offsetOf)
+    Ref.of[F, Buffered[S]](Buffered.Empty).map(state => Snapshots(key, database, state.stateInstance, offsetOf))
 
   private[snapshot] def apply[F[_]: Monad, K: LogPrefix, S](
     key: K,
     database: SnapshotDatabase[F, K, S],
-    buffer: Stateful[F, Option[Snapshot[S]]],
-    floor: Stateful[F, Option[Offset]],
+    state: Stateful[F, Buffered[S]],
     offsetOf: Option[S => Offset],
   )(implicit log: Log[F]): Snapshots[F, S] = new Snapshots[F, S] {
     private val prefixLog: Log[F] = log.prefixed(LogPrefix[K].extract(key))
 
-    // the replay-window high-water: the buffered snapshot's offset (when fenced), else the recovered tombstone floor.
-    private def highWater(buffered: Option[Snapshot[S]], floored: Option[Offset]): Option[Offset] =
-      buffered.flatMap(s => offsetOf.map(_(s.value))) orElse floored
+    // the replay-window high-water: a live snapshot's offset (when fenced), or the recovered/left tombstone floor.
+    private def highWater(current: Buffered[S]): Option[Offset] = current match {
+      case Buffered.Live(s)    => offsetOf.map(_(s.value))
+      case Buffered.Deleted(o) => o.some
+      case Buffered.Empty      => none
+    }
 
     def read =
       database.recover(key).flatMap {
-        case Recovered.Present(snapshot) => snapshot.some.pure[F]
+        case Recovered.Present(snapshot) => snapshot.some.pure[F] // `initPersistedState` seeds `Live` right after
         // a tombstone reads back absent, but its offset is the replay-window floor: hold it so a re-derived snapshot
         // (or delete) below it is dropped rather than persisted as a stale, self-fencing write. See
         // docs/cassandra-single-writer-design.md.
-        case Recovered.Deleted(offset) => floor.set(offset.some).as(none[S])
+        case Recovered.Deleted(offset) => state.set(Buffered.Deleted(offset)).as(none[S])
         case Recovered.Absent          => none[S].pure[F]
       }
 
     def append(snapshot: S) =
-      floor.get.flatMap { floored =>
-        buffer.modify {
-          // keep the buffer monotonic in offset: a lower-offset append is replay onto a recovered snapshot (a no-op
-          // under deterministic folds), so dropping it holds the high-water offset that fences `delete`. See
-          // docs/cassandra-single-writer-design.md.
-          case Some(s) if offsetOf.exists(f => f(snapshot) < f(s.value)) => s.some
-          case Some(s)                                                   => s.updateValue(snapshot).some
-          // a fresh buffer below the recovered tombstone floor is a replayed event onto a deleted key: drop it so the
-          // floor holds and the re-derived snapshot is not persisted below it (the self-fence).
-          case None if floored.exists(o => offsetOf.exists(f => f(snapshot) < o)) => none
-          case None                                                               => Snapshot.init(snapshot).some
-        }
+      // keep the buffer monotonic in offset: a lower-offset append is replay onto a recovered snapshot (a no-op under
+      // deterministic folds), so dropping it holds the high-water offset that fences `delete` and drops a re-derived
+      // snapshot below a recovered tombstone floor. See docs/cassandra-single-writer-design.md.
+      state.modify { current =>
+        val below = (offsetOf.map(_(snapshot)), highWater(current)).mapN(_ < _).getOrElse(false)
+        if (below) current
+        else
+          current match {
+            // an unchanged value keeps the existing cell (and its `persisted` flag); anything else becomes a fresh,
+            // not-yet-persisted live snapshot. (Matches `Snapshot.updateValue`, without reanchoring the covariant type.)
+            case Buffered.Live(existing) if existing.value == snapshot => current
+            case _                                                     => Buffered.Live(Snapshot.init(snapshot))
+          }
       }
 
     def initPersisted(snapshot: S) =
-      buffer.set(Snapshot.initPersisted(snapshot).some)
+      state.set(Buffered.Live(Snapshot.initPersisted(snapshot)))
 
-    def flush = {
-      for {
-        snapshot <- buffer.get
-        _ <- snapshot traverse_ { snapshot =>
-          if (!snapshot.persisted) {
-            for {
-              _ <- database.persist(key, snapshot.value)
-              _ <- buffer.set(snapshot.copy(persisted = true).some)
-            } yield ()
-          } else ().pure[F]
-        }
-      } yield ()
-    }
-
-    def delete(persist: Boolean, offset: Offset) = {
-      (buffer.get, floor.get).tupled.flatMap {
-        case (buffered, floored) =>
-          // fence on the key's high-water offset (the buffered snapshot's, or the recovered tombstone floor), not
-          // `offset`: after recovery a key's snapshot can lead the partition's processing offset, and a compare-and-set
-          // backend would reject a delete gated below it as stale though the owner is legitimate. A genuinely stale
-          // writer only reached its own lower offset.
-          val fenceOffset = highWater(buffered, floored).fold(offset)(offset max _)
-          val delete = if (persist) {
-            database.delete(key, fenceOffset) *> prefixLog.info("deleted snapshot")
-          } else {
-            ().pure[F]
-          }
-          // the delete writes a tombstone at `fenceOffset`; hold it as the floor so a later replayed re-persist below it
-          // is still dropped (the buffer is cleared and no longer carries the high-water).
-          buffer.set(None) *> floor.set(fenceOffset.some) *> delete
+    def flush =
+      state.get.flatMap {
+        case Buffered.Live(snapshot) if !snapshot.persisted =>
+          database.persist(key, snapshot.value) *> state.set(Buffered.Live(snapshot.copy(persisted = true)))
+        case _ => ().pure[F]
       }
-    }
+
+    def delete(persist: Boolean, offset: Offset) =
+      state.get.flatMap { current =>
+        // fence on the key's high-water offset (the live snapshot's, or the recovered/left tombstone floor), not
+        // `offset`: after recovery a key's snapshot can lead the partition's processing offset, and a compare-and-set
+        // backend would reject a delete gated below it as stale though the owner is legitimate. A genuinely stale
+        // writer only reached its own lower offset.
+        val fenceOffset = highWater(current).fold(offset)(offset max _)
+        val delete =
+          if (persist) database.delete(key, fenceOffset) *> prefixLog.info("deleted snapshot")
+          else ().pure[F]
+        // leave the tombstone offset as the floor so a later replayed re-persist below it is still dropped (the cell no
+        // longer carries a live snapshot's high-water).
+        state.set(Buffered.Deleted(fenceOffset)) *> delete
+      }
 
   }
 

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/Snapshots.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/Snapshots.scala
@@ -52,15 +52,15 @@ trait SnapshotWriter[F[_], S] {
 }
 object Snapshots {
 
-  /** The per-key buffer cell: a live snapshot (with its `persisted` flag), a value-less high-water floor recovered from
-    * or left by a delete, or nothing yet. Folding the live snapshot and the tombstone floor into one monotonic cell
-    * lets `read`/`append`/`delete` reason about a single high-water (see `highWater`), so a deleted key's offset is
-    * held even though it carries no value. Parallels [[Recovered]] but keeps the `persisted` flag `flush` needs, so it
-    * is a separate type.
+  /** The per-key buffer cell: a live snapshot value (with whether it is already persisted), a value-less high-water
+    * floor recovered from or left by a delete, or nothing yet. Folding the live snapshot and the tombstone floor into
+    * one monotonic cell lets `read`/`append`/`delete` reason about a single high-water (see `highWater`), so a deleted
+    * key's offset is held even though it carries no value. Parallels [[Recovered]], but `Live` also carries the
+    * `persisted` flag `flush` needs.
     */
   private[flow] sealed trait Buffered[+S]
   private[flow] object Buffered {
-    final case class Live[S](snapshot: Snapshot[S]) extends Buffered[S]
+    final case class Live[S](value: S, persisted: Boolean) extends Buffered[S]
     final case class Deleted(offset: Offset) extends Buffered[Nothing]
     case object Empty extends Buffered[Nothing]
   }
@@ -90,9 +90,9 @@ object Snapshots {
 
     // the replay-window high-water: a live snapshot's offset (when fenced), or the recovered/left tombstone floor.
     private def highWater(current: Buffered[S]): Option[Offset] = current match {
-      case Buffered.Live(s)    => offsetOf.map(_(s.value))
-      case Buffered.Deleted(o) => o.some
-      case Buffered.Empty      => none
+      case Buffered.Live(value, _) => offsetOf.map(_(value))
+      case Buffered.Deleted(o)     => o.some
+      case Buffered.Empty          => none
     }
 
     def read =
@@ -115,19 +115,19 @@ object Snapshots {
         else
           current match {
             // an unchanged value keeps the existing cell (and its `persisted` flag); anything else becomes a fresh,
-            // not-yet-persisted live snapshot. (Matches `Snapshot.updateValue`, without reanchoring the covariant type.)
-            case Buffered.Live(existing) if existing.value == snapshot => current
-            case _                                                     => Buffered.Live(Snapshot.init(snapshot))
+            // not-yet-persisted live snapshot
+            case Buffered.Live(existing, _) if existing == snapshot => current
+            case _                                                  => Buffered.Live(snapshot, persisted = false)
           }
       }
 
     def initPersisted(snapshot: S) =
-      state.set(Buffered.Live(Snapshot.initPersisted(snapshot)))
+      state.set(Buffered.Live(snapshot, persisted = true))
 
     def flush =
       state.get.flatMap {
-        case Buffered.Live(snapshot) if !snapshot.persisted =>
-          database.persist(key, snapshot.value) *> state.set(Buffered.Live(snapshot.copy(persisted = true)))
+        case Buffered.Live(value, false) =>
+          database.persist(key, value) *> state.set(Buffered.Live(value, persisted = true))
         case _ => ().pure[F]
       }
 
@@ -154,17 +154,6 @@ object Snapshots {
     def initPersisted(event: S)                  = ().pure[F]
     def flush                                    = ().pure[F]
     def delete(persist: Boolean, offset: Offset) = ().pure[F]
-  }
-
-  final case class Snapshot[S](value: S, persisted: Boolean) { self =>
-    def updateValue(newValue: S): Snapshot[S] =
-      if (value == newValue) self
-      else copy(value = newValue, persisted = false)
-  }
-
-  object Snapshot {
-    def init[S](value: S): Snapshot[S]          = Snapshot(value, persisted = false)
-    def initPersisted[S](value: S): Snapshot[S] = Snapshot(value, persisted = true)
   }
 
 }

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/Snapshots.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/Snapshots.scala
@@ -55,15 +55,15 @@ object Snapshots {
   /** Per-key snapshot buffer over `database`.
     *
     * @param offsetOf
-    *   the offset a snapshot sits at, used to keep the buffer monotonic and to fence a delete on the key's high-water
-    *   offset (see [[apply]]'s `append`/`delete`). A `KafkaSnapshot`-backed store passes `_.offset` (see
-    *   [[SnapshotDatabase.snapshotsOf]]); other stores pass `_ => Offset.min`, which makes the fence inert
-    *   (last-write-wins).
+    *   how to read the offset a snapshot sits at, when this store fences stale writers. `Some(f)` keeps the buffer
+    *   monotonic and gates a delete on the key's high-water offset (see [[apply]]'s `append`/`delete`); `None` is
+    *   unfenced (last-write-wins). A `KafkaSnapshot`-backed store passes `Some(_.offset)` (see
+    *   [[SnapshotDatabase.snapshotsOf]]).
     */
   private[flow] def of[F[_]: Ref.Make: Monad, K: LogPrefix, S](
     key: K,
     database: SnapshotDatabase[F, K, S],
-    offsetOf: S => Offset,
+    offsetOf: Option[S => Offset],
   )(implicit log: Log[F]): F[Snapshots[F, S]] =
     for {
       buffer <- Ref.of[F, Option[Snapshot[S]]](None)
@@ -78,13 +78,13 @@ object Snapshots {
     database: SnapshotDatabase[F, K, S],
     buffer: Stateful[F, Option[Snapshot[S]]],
     floor: Stateful[F, Option[Offset]],
-    offsetOf: S => Offset,
+    offsetOf: Option[S => Offset],
   )(implicit log: Log[F]): Snapshots[F, S] = new Snapshots[F, S] {
     private val prefixLog: Log[F] = log.prefixed(LogPrefix[K].extract(key))
 
-    // the replay-window high-water: the buffered snapshot's offset, else the recovered tombstone floor.
+    // the replay-window high-water: the buffered snapshot's offset (when fenced), else the recovered tombstone floor.
     private def highWater(buffered: Option[Snapshot[S]], floored: Option[Offset]): Option[Offset] =
-      buffered.map(s => offsetOf(s.value)) orElse floored
+      buffered.flatMap(s => offsetOf.map(_(s.value))) orElse floored
 
     def read =
       database.recover(key).flatMap {
@@ -102,12 +102,12 @@ object Snapshots {
           // keep the buffer monotonic in offset: a lower-offset append is replay onto a recovered snapshot (a no-op
           // under deterministic folds), so dropping it holds the high-water offset that fences `delete`. See
           // docs/cassandra-single-writer-design.md.
-          case Some(s) if offsetOf(snapshot) < offsetOf(s.value) => s.some
-          case Some(s)                                           => s.updateValue(snapshot).some
+          case Some(s) if offsetOf.exists(f => f(snapshot) < f(s.value)) => s.some
+          case Some(s)                                                   => s.updateValue(snapshot).some
           // a fresh buffer below the recovered tombstone floor is a replayed event onto a deleted key: drop it so the
           // floor holds and the re-derived snapshot is not persisted below it (the self-fence).
-          case None if floored.exists(offsetOf(snapshot) < _) => none
-          case None                                           => Snapshot.init(snapshot).some
+          case None if floored.exists(o => offsetOf.exists(f => f(snapshot) < o)) => none
+          case None                                                               => Snapshot.init(snapshot).some
         }
       }
 

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/Snapshots.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/Snapshots.scala
@@ -65,26 +65,50 @@ object Snapshots {
     database: SnapshotDatabase[F, K, S],
     offsetOf: S => Offset,
   )(implicit log: Log[F]): F[Snapshots[F, S]] =
-    Ref.of[F, Option[Snapshot[S]]](None).map(buffer => Snapshots(key, database, buffer.stateInstance, offsetOf))
+    for {
+      buffer <- Ref.of[F, Option[Snapshot[S]]](None)
+      // the high-water offset recovered for a key that has no buffered snapshot (a deleted key recovered from an
+      // offset-carrying tombstone). A buffered snapshot carries its own high-water via `offsetOf`; this floor covers
+      // the value-less case. See `read`/`append`/`delete` and docs/cassandra-single-writer-design.md.
+      floor <- Ref.of[F, Option[Offset]](None)
+    } yield Snapshots(key, database, buffer.stateInstance, floor.stateInstance, offsetOf)
 
   private[snapshot] def apply[F[_]: Monad, K: LogPrefix, S](
     key: K,
     database: SnapshotDatabase[F, K, S],
     buffer: Stateful[F, Option[Snapshot[S]]],
+    floor: Stateful[F, Option[Offset]],
     offsetOf: S => Offset,
   )(implicit log: Log[F]): Snapshots[F, S] = new Snapshots[F, S] {
     private val prefixLog: Log[F] = log.prefixed(LogPrefix[K].extract(key))
 
-    def read = database.get(key)
+    // the replay-window high-water: the buffered snapshot's offset, else the recovered tombstone floor.
+    private def highWater(buffered: Option[Snapshot[S]], floored: Option[Offset]): Option[Offset] =
+      buffered.map(s => offsetOf(s.value)) orElse floored
+
+    def read =
+      database.recover(key).flatMap {
+        case Recovered.Present(snapshot) => snapshot.some.pure[F]
+        // a tombstone reads back absent, but its offset is the replay-window floor: hold it so a re-derived snapshot
+        // (or delete) below it is dropped rather than persisted as a stale, self-fencing write. See
+        // docs/cassandra-single-writer-design.md.
+        case Recovered.Deleted(offset) => floor.set(offset.some).as(none[S])
+        case Recovered.Absent          => none[S].pure[F]
+      }
 
     def append(snapshot: S) =
-      buffer.modify {
-        // keep the buffer monotonic in offset: a lower-offset append is replay onto a recovered snapshot (a no-op
-        // under deterministic folds), so dropping it holds the high-water offset that fences `delete`. See
-        // docs/cassandra-single-writer-design.md.
-        case Some(s) if offsetOf(snapshot) < offsetOf(s.value) => s.some
-        case Some(s)                                           => s.updateValue(snapshot).some
-        case None                                              => Snapshot.init(snapshot).some
+      floor.get.flatMap { floored =>
+        buffer.modify {
+          // keep the buffer monotonic in offset: a lower-offset append is replay onto a recovered snapshot (a no-op
+          // under deterministic folds), so dropping it holds the high-water offset that fences `delete`. See
+          // docs/cassandra-single-writer-design.md.
+          case Some(s) if offsetOf(snapshot) < offsetOf(s.value) => s.some
+          case Some(s)                                           => s.updateValue(snapshot).some
+          // a fresh buffer below the recovered tombstone floor is a replayed event onto a deleted key: drop it so the
+          // floor holds and the re-derived snapshot is not persisted below it (the self-fence).
+          case None if floored.exists(offsetOf(snapshot) < _) => none
+          case None                                           => Snapshot.init(snapshot).some
+        }
       }
 
     def initPersisted(snapshot: S) =
@@ -105,17 +129,21 @@ object Snapshots {
     }
 
     def delete(persist: Boolean, offset: Offset) = {
-      buffer.get.flatMap { buffered =>
-        // fence on the buffer's high-water offset (see `append`), not `offset`: after recovery a key's snapshot can
-        // lead the partition's processing offset, and a compare-and-set backend would reject a delete gated below it
-        // as stale though the owner is legitimate. A genuinely stale writer only reached its own lower offset.
-        val fenceOffset = buffered.fold(offset)(snapshot => offset max offsetOf(snapshot.value))
-        val delete = if (persist) {
-          database.delete(key, fenceOffset) *> prefixLog.info("deleted snapshot")
-        } else {
-          ().pure[F]
-        }
-        buffer.set(None) *> delete
+      (buffer.get, floor.get).tupled.flatMap {
+        case (buffered, floored) =>
+          // fence on the key's high-water offset (the buffered snapshot's, or the recovered tombstone floor), not
+          // `offset`: after recovery a key's snapshot can lead the partition's processing offset, and a compare-and-set
+          // backend would reject a delete gated below it as stale though the owner is legitimate. A genuinely stale
+          // writer only reached its own lower offset.
+          val fenceOffset = highWater(buffered, floored).fold(offset)(offset max _)
+          val delete = if (persist) {
+            database.delete(key, fenceOffset) *> prefixLog.info("deleted snapshot")
+          } else {
+            ().pure[F]
+          }
+          // the delete writes a tombstone at `fenceOffset`; hold it as the floor so a later replayed re-persist below it
+          // is still dropped (the buffer is cleared and no longer carries the high-water).
+          buffer.set(None) *> floor.set(fenceOffset.some) *> delete
       }
     }
 

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/Snapshots.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/Snapshots.scala
@@ -7,8 +7,32 @@ import cats.{Applicative, Monad}
 import com.evolutiongaming.catshelper.Log
 import com.evolutiongaming.kafka.flow.LogPrefix
 import com.evolutiongaming.kafka.flow.effect.CatsEffectMtlInstances.*
+import com.evolutiongaming.skafka.Offset
 
-trait Snapshots[F[_], S] extends SnapshotReader[F, S] with SnapshotWriter[F, S]
+trait Snapshots[F[_], S] extends SnapshotReader[F, S] with SnapshotWriter[F, S] {
+
+  /** The buffer cell's offset - the fenced store's view of the key, seeded by `read`: a live snapshot's offset or a
+    * deletion tombstone's (the replay-window floor). `None` for an empty cell or an unfenced buffer.
+    *
+    * Events-recovery uses this as its journal filter: the journal is UNFENCED - a zombie's replayed appends can land
+    * after a delete cleared it, and a journal TTL can reap rows the snapshot already carries - so journal events at or
+    * below this offset are already reflected in the store's view (folded into the live snapshot, or deleted) and must
+    * not be folded again onto the recovery base. Filtering on the store's offset rather than comparing fold results is
+    * what makes the guard hold at EVERY recovery, not only the first: stale residue rows stay permanently below the
+    * floor no matter how far legitimate appends advance the journal. See `docs/cassandra-single-writer-design.md` (the
+    * journal revive).
+    */
+  def floor: F[Option[Offset]]
+
+  /** Whether this buffer fences stale writers (its store gates writes on the snapshot offset).
+    *
+    * Only a fencing buffer keeps an offset high-water and can recover an offset-carrying tombstone, so only a fencing
+    * buffer needs its replay-window floor seeded from the snapshot store on events-recovery. An unfenced
+    * (last-write-wins) buffer never reads back a tombstone, so that read can be skipped. See
+    * `docs/cassandra-single-writer-design.md`.
+    */
+  def fenced: Boolean
+}
 
 /** Allows to read a previously saved snapshot */
 trait SnapshotReader[F[_], S] {
@@ -42,81 +66,141 @@ trait SnapshotWriter[F[_], S] {
     *
     * @param persist
     *   if `true` then also calls underlying database, flushes buffers only otherwise.
+    * @param offset
+    *   offset of the state being deleted; passed to the database so a stale-writer-protecting backend can gate the
+    *   delete on it.
     */
-  def delete(persist: Boolean): F[Unit]
+  def delete(persist: Boolean, offset: Offset): F[Unit]
 
 }
 object Snapshots {
 
-  /** Creates a buffer for a given writer */
+  /** Per-key snapshot buffer over `database`.
+    *
+    * The buffer holds one `Stored` cell - a live snapshot, an offset-carrying tombstone, or nothing yet - plus whether
+    * it is already persisted. Every write (`append`, `delete`) and recovery (`read`) flows through that one cell, kept
+    * monotonic in offset, so a persist and a delete share the same offset discipline: the cell never regresses below
+    * the key's high-water offset. See `docs/cassandra-single-writer-design.md`.
+    *
+    * @param offsetOf
+    *   how to read the offset a snapshot sits at, when this store fences stale writers. `Some(f)` makes the cell
+    *   offset-carrying: the buffer is kept monotonic and a delete is stamped at the key's high-water offset (see the
+    *   `put` below); `None` is unfenced (last-write-wins, the offset is never tracked). A `KafkaSnapshot`-backed store
+    *   passes `Some(_.offset)` (see `SnapshotDatabase.snapshotsOf`).
+    */
   private[flow] def of[F[_]: Ref.Make: Monad, K: LogPrefix, S](
     key: K,
-    database: SnapshotDatabase[F, K, S]
+    database: SnapshotDatabase[F, K, S],
+    offsetOf: Option[S => Offset],
   )(implicit log: Log[F]): F[Snapshots[F, S]] =
-    Ref.of[F, Option[Snapshot[S]]](None).map(buffer => Snapshots(key, database, buffer.stateInstance))
+    Ref.of[F, Option[Cell[S]]](none).map(state => Snapshots(key, database, state.stateInstance, offsetOf))
+
+  /** The per-key buffer cell: a `Stored` unit (live snapshot or offset-carrying tombstone floor) plus the `persisted`
+    * flag `flush` needs. An empty buffer is `None`.
+    */
+  private[snapshot] final case class Cell[S](stored: Stored[S], persisted: Boolean)
 
   private[snapshot] def apply[F[_]: Monad, K: LogPrefix, S](
     key: K,
     database: SnapshotDatabase[F, K, S],
-    buffer: Stateful[F, Option[Snapshot[S]]]
+    state: Stateful[F, Option[Cell[S]]],
+    offsetOf: Option[S => Offset],
   )(implicit log: Log[F]): Snapshots[F, S] = new Snapshots[F, S] {
     private val prefixLog: Log[F] = log.prefixed(LogPrefix[K].extract(key))
 
-    def read = database.get(key)
+    // fenced iff the store gates writes on an offset (`offsetOf` is set); this is what keeps the buffer monotonic and
+    // makes a recovered tombstone carry a floor (see `put` and `read`)
+    val fenced: Boolean = offsetOf.isDefined
 
-    def append(snapshot: S) = {
-      buffer.modify {
-        case Some(s) => s.updateValue(snapshot).some
-        case None    => Snapshot.init(snapshot).some
+    def read =
+      // seed the cell with whatever the store holds - a tombstone's offset is the replay-window high-water (kept
+      // even with no value), a live snapshot the recovery base - so a re-derived snapshot or delete below it is
+      // dropped rather than persisted as a stale, self-fencing write, and `floor` exposes the store's offset for
+      // events-recovery's journal filter. See docs/cassandra-single-writer-design.md.
+      database.read(key).flatMap {
+        case Some(Stored.Tombstone(offset)) =>
+          state.set(Cell(Stored.Tombstone(offset), persisted = true).some).as(none[S])
+        case Some(Stored.Live(snapshot, offset)) =>
+          state.set(Cell(Stored.Live(snapshot, offset), persisted = true).some).as(snapshot.some)
+        case None => none[S].pure[F]
       }
-    }
 
-    def initPersisted(snapshot: S) = {
-      buffer.set(Snapshot.initPersisted(snapshot).some)
-    }
+    // the seeded cell's offset (see the trait doc); the offset is carried only when the buffer fences
+    def floor =
+      state.get.map(_.flatMap(_.stored.offset))
 
-    def flush = {
-      for {
-        snapshot <- buffer.get
-        _ <- snapshot traverse_ { snapshot =>
-          if (!snapshot.persisted) {
-            for {
-              _ <- database.persist(key, snapshot.value)
-              _ <- buffer.set(snapshot.copy(persisted = true).some)
-            } yield ()
-          } else ().pure[F]
+    def append(snapshot: S) =
+      put(Stored.Live(snapshot, offsetOf.map(_(snapshot))))
+
+    // a delete routes the processing offset through the same monotonic `put`, which lifts the tombstone to the key's
+    // high-water when the buffer leads it (a fenced store then gates the tombstone on the high-water, not the trailing
+    // processing offset). An unfenced cell has no high-water, so the processing offset passes through unchanged - and
+    // an unfenced store ignores `stored.offset` on write anyway, so the tombstone's carried offset is inert there.
+    def delete(persist: Boolean, offset: Offset) =
+      put(Stored.Tombstone(offset)) *> {
+        // A fenced store ALWAYS writes the offset-carrying tombstone, even for a never-persisted key (`persist` =
+        // false). Skipping it there leaves the row absent while the consumer offset commits past the delete, so a
+        // paused zombie still holding the key's buffered pre-delete snapshot can flush it back onto the absent row
+        // (gated only by the snapshot compare-and-set, not the consumer generation) and durably resurrect the
+        // deleted key -- permanent, since recovery resumes past the delete. The tombstone is the fence that gates
+        // that flush, so in a fenced store it is never "unnecessary". The economy -- a buffer-only delete just
+        // marks the cell persisted so a later flush writes nothing -- applies only to the unfenced (last-write-wins)
+        // store, which has no offset gate to arm anyway. See docs/cassandra-single-writer-design.md (the delete of
+        // a never-persisted key).
+        if (persist || fenced) flushCell(_ => prefixLog.info("deleted snapshot"))
+        else markPersisted
+      }
+
+    // through the same monotonic `put` as any other write: recovery code may seed a state derived from a
+    // source that trails the buffer's floor (events-recovery folds the journal, which a delete clears or a
+    // TTL reaps below the snapshot store's tombstone), and a plain `set` here would regress the floor the
+    // read just established - reopening the replay-window self-fence. A below-floor init is dropped; the
+    // cell (already `persisted`) keeps the floor.
+    def initPersisted(snapshot: S) =
+      put(Stored.Live(snapshot, offsetOf.map(_(snapshot)))) *> markPersisted
+
+    def flush = flushCell(_ => ().pure[F])
+
+    // the single monotonic write site. A live append below the high-water is replay onto a recovered cell (a no-op
+    // under deterministic folds), so it is dropped; a tombstone is lifted to the high-water so the legitimate owner's
+    // delete still applies rather than self-fencing. See docs/cassandra-single-writer-design.md.
+    private def put(next: Stored[S]): F[Unit] =
+      state.modify { current =>
+        val highWater = current.flatMap(_.stored.offset)
+        next match {
+          case Stored.Live(snapshot, offset) =>
+            val below = (offset, highWater).mapN(_ < _).getOrElse(false)
+            current match {
+              case Some(cur) if below => cur.some
+              // an unchanged live value keeps the existing cell (and its `persisted` flag)
+              case Some(cur @ Cell(Stored.Live(existing, _), _)) if existing == snapshot => cur.some
+              case _ => Cell(next, persisted = false).some
+            }
+          case Stored.Tombstone(at) =>
+            Cell(Stored.Tombstone(highWater.fold(at)(_ max at)), persisted = false).some
         }
-      } yield ()
-    }
-
-    def delete(persist: Boolean) = {
-      val delete = if (persist) {
-        database.delete(key) *> prefixLog.info("deleted snapshot")
-      } else {
-        ().pure[F]
       }
-      buffer.set(None) *> delete
-    }
+
+    // writes any dirty cell - live snapshot OR tombstone - then marks it persisted. A tombstone only reaches here from
+    // a `delete(persist = true)`; a buffer-only delete marks the cell persisted itself so it is never written.
+    private def flushCell(onWrite: Stored[S] => F[Unit]): F[Unit] =
+      state.get.flatMap {
+        case Some(Cell(stored, false)) => database.write(key, stored) *> onWrite(stored) *> markPersisted
+        case _                         => ().pure[F]
+      }
+
+    private val markPersisted: F[Unit] = state.modify(_.map(_.copy(persisted = true)))
 
   }
 
   def empty[F[_]: Applicative, S]: Snapshots[F, S] = new Snapshots[F, S] {
-    def read                     = none[S].pure[F]
-    def append(event: S)         = ().pure[F]
-    def initPersisted(event: S)  = ().pure[F]
-    def flush                    = ().pure[F]
-    def delete(persist: Boolean) = ().pure[F]
-  }
-
-  final case class Snapshot[S](value: S, persisted: Boolean) { self =>
-    def updateValue(newValue: S): Snapshot[S] =
-      if (value == newValue) self
-      else copy(value = newValue, persisted = false)
-  }
-
-  object Snapshot {
-    def init[S](value: S): Snapshot[S]          = Snapshot(value, persisted = false)
-    def initPersisted[S](value: S): Snapshot[S] = Snapshot(value, persisted = true)
+    val fenced                                   = false
+    def read                                     = none[S].pure[F]
+    def floor                                    = none[Offset].pure[F]
+    def append(event: S)                         = ().pure[F]
+    def initPersisted(event: S)                  = ().pure[F]
+    def flush                                    = ().pure[F]
+    def delete(persist: Boolean, offset: Offset) = ().pure[F]
   }
 
 }

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/Snapshots.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/Snapshots.scala
@@ -52,99 +52,100 @@ trait SnapshotWriter[F[_], S] {
 }
 object Snapshots {
 
-  /** The per-key buffer cell: a live snapshot value (with whether it is already persisted), a value-less high-water
-    * floor recovered from or left by a delete, or nothing yet. Folding the live snapshot and the tombstone floor into
-    * one monotonic cell lets `read`/`append`/`delete` reason about a single high-water (see `highWater`), so a deleted
-    * key's offset is held even though it carries no value. Parallels [[Recovered]], but `Live` also carries the
-    * `persisted` flag `flush` needs.
-    */
-  private[flow] sealed trait Buffered[+S]
-  private[flow] object Buffered {
-    final case class Live[S](value: S, persisted: Boolean) extends Buffered[S]
-    final case class Deleted(offset: Offset) extends Buffered[Nothing]
-    case object Empty extends Buffered[Nothing]
-  }
-
   /** Per-key snapshot buffer over `database`.
     *
+    * The buffer holds one [[Stored]] cell - a live snapshot, an offset-carrying tombstone, or nothing yet - plus
+    * whether it is already persisted. Every write (`append`, `delete`) and recovery (`read`) flows through that one
+    * cell, kept monotonic in offset, so a persist and a delete share the same offset discipline: the cell never
+    * regresses below the key's high-water offset. See `docs/cassandra-single-writer-design.md`.
+    *
     * @param offsetOf
-    *   how to read the offset a snapshot sits at, when this store fences stale writers. `Some(f)` keeps the buffer
-    *   monotonic and gates a delete on the key's high-water offset (see [[apply]]'s `append`/`delete`); `None` is
-    *   unfenced (last-write-wins). A `KafkaSnapshot`-backed store passes `Some(_.offset)` (see
-    *   [[SnapshotDatabase.snapshotsOf]]).
+    *   how to read the offset a snapshot sits at, when this store fences stale writers. `Some(f)` makes the cell
+    *   offset-carrying: the buffer is kept monotonic and a delete is stamped at the key's high-water offset (see the
+    *   `put` below); `None` is unfenced (last-write-wins, the offset is never tracked). A `KafkaSnapshot`-backed store
+    *   passes `Some(_.offset)` (see [[SnapshotDatabase.snapshotsOf]]).
     */
   private[flow] def of[F[_]: Ref.Make: Monad, K: LogPrefix, S](
     key: K,
     database: SnapshotDatabase[F, K, S],
     offsetOf: Option[S => Offset],
   )(implicit log: Log[F]): F[Snapshots[F, S]] =
-    Ref.of[F, Buffered[S]](Buffered.Empty).map(state => Snapshots(key, database, state.stateInstance, offsetOf))
+    Ref.of[F, Option[Cell[S]]](none).map(state => Snapshots(key, database, state.stateInstance, offsetOf))
+
+  /** The per-key buffer cell: a [[Stored]] unit (live snapshot or offset-carrying tombstone floor) plus the `persisted`
+    * flag `flush` needs. An empty buffer is `None`.
+    */
+  private[snapshot] final case class Cell[S](stored: Stored[S], persisted: Boolean)
 
   private[snapshot] def apply[F[_]: Monad, K: LogPrefix, S](
     key: K,
     database: SnapshotDatabase[F, K, S],
-    state: Stateful[F, Buffered[S]],
+    state: Stateful[F, Option[Cell[S]]],
     offsetOf: Option[S => Offset],
   )(implicit log: Log[F]): Snapshots[F, S] = new Snapshots[F, S] {
     private val prefixLog: Log[F] = log.prefixed(LogPrefix[K].extract(key))
 
-    // the replay-window high-water: a live snapshot's offset (when fenced), or the recovered/left tombstone floor.
-    private def highWater(current: Buffered[S]): Option[Offset] = current match {
-      case Buffered.Live(value, _) => offsetOf.map(_(value))
-      case Buffered.Deleted(o)     => o.some
-      case Buffered.Empty          => none
-    }
-
     def read =
-      database.recover(key).flatMap {
-        case Recovered.Present(snapshot) => snapshot.some.pure[F] // `initPersistedState` seeds `Live` right after
-        // a tombstone reads back absent, but its offset is the replay-window floor: hold it so a re-derived snapshot
-        // (or delete) below it is dropped rather than persisted as a stale, self-fencing write. See
-        // docs/cassandra-single-writer-design.md.
-        case Recovered.Deleted(offset) => state.set(Buffered.Deleted(offset)).as(none[S])
-        case Recovered.Absent          => none[S].pure[F]
+      // only a recovered tombstone needs seeding here: its offset is the replay-window high-water (kept even with no
+      // value), so a re-derived snapshot or delete below it is dropped rather than persisted as a stale, self-fencing
+      // write. A live snapshot's cell is seeded by `initPersistedState` right after (see `Persistence.read`), so we
+      // just return its value. See docs/cassandra-single-writer-design.md.
+      database.read(key).flatMap {
+        case Some(Stored.Tombstone(offset)) =>
+          state.set(Cell(Stored.Tombstone(offset), persisted = true).some).as(none[S])
+        case Some(Stored.Live(snapshot, _)) => snapshot.some.pure[F]
+        case None                           => none[S].pure[F]
       }
 
     def append(snapshot: S) =
-      // keep the buffer monotonic in offset: a lower-offset append is replay onto a recovered snapshot (a no-op under
-      // deterministic folds), so dropping it holds the high-water offset that fences `delete` and drops a re-derived
-      // snapshot below a recovered tombstone floor. See docs/cassandra-single-writer-design.md.
-      state.modify { current =>
-        val below = (offsetOf.map(_(snapshot)), highWater(current)).mapN(_ < _).getOrElse(false)
-        if (below) current
-        else
-          current match {
-            // an unchanged value keeps the existing cell (and its `persisted` flag); anything else becomes a fresh,
-            // not-yet-persisted live snapshot
-            case Buffered.Live(existing, _) if existing == snapshot => current
-            case _                                                  => Buffered.Live(snapshot, persisted = false)
-          }
+      put(Stored.Live(snapshot, offsetOf.map(_(snapshot))))
+
+    // a delete routes the processing offset through the same monotonic `put`, which lifts the tombstone to the key's
+    // high-water when the buffer leads it (a fenced store then gates the tombstone on the high-water, not the trailing
+    // processing offset). An unfenced cell has no high-water, so the processing offset passes through unchanged - and
+    // an unfenced store ignores `stored.offset` on write anyway, so the tombstone's carried offset is inert there.
+    def delete(persist: Boolean, offset: Offset) =
+      put(Stored.Tombstone(offset)) *> {
+        // persist the (lifted) tombstone, or for a buffer-only delete just mark it persisted so a later flush does not
+        // write an unnecessary tombstone (`flushCell` writes any dirty cell, tombstone included)
+        if (persist) flushCell(_ => prefixLog.info("deleted snapshot"))
+        else markPersisted
       }
 
     def initPersisted(snapshot: S) =
-      state.set(Buffered.Live(snapshot, persisted = true))
+      state.set(Cell(Stored.Live(snapshot, offsetOf.map(_(snapshot))), persisted = true).some)
 
-    def flush =
+    def flush = flushCell(_ => ().pure[F])
+
+    // the single monotonic write site. A live append below the high-water is replay onto a recovered cell (a no-op
+    // under deterministic folds), so it is dropped; a tombstone is lifted to the high-water so the legitimate owner's
+    // delete still applies rather than self-fencing. See docs/cassandra-single-writer-design.md.
+    private def put(next: Stored[S]): F[Unit] =
+      state.modify { current =>
+        val highWater = current.flatMap(_.stored.offset)
+        next match {
+          case Stored.Live(snapshot, offset) =>
+            val below = (offset, highWater).mapN(_ < _).getOrElse(false)
+            current match {
+              case Some(cur) if below => cur.some
+              // an unchanged live value keeps the existing cell (and its `persisted` flag)
+              case Some(cur @ Cell(Stored.Live(existing, _), _)) if existing == snapshot => cur.some
+              case _ => Cell(next, persisted = false).some
+            }
+          case Stored.Tombstone(at) =>
+            Cell(Stored.Tombstone(highWater.fold(at)(_ max at)), persisted = false).some
+        }
+      }
+
+    // writes any dirty cell - live snapshot OR tombstone - then marks it persisted. A tombstone only reaches here from
+    // a `delete(persist = true)`; a buffer-only delete marks the cell persisted itself so it is never written.
+    private def flushCell(onWrite: Stored[S] => F[Unit]): F[Unit] =
       state.get.flatMap {
-        case Buffered.Live(value, false) =>
-          database.persist(key, value) *> state.set(Buffered.Live(value, persisted = true))
-        case _ => ().pure[F]
+        case Some(Cell(stored, false)) => database.write(key, stored) *> onWrite(stored) *> markPersisted
+        case _                         => ().pure[F]
       }
 
-    def delete(persist: Boolean, offset: Offset) =
-      state.get.flatMap { current =>
-        // fence on the key's high-water offset (the live snapshot's, or the recovered/left tombstone floor), not
-        // `offset`: after recovery a key's snapshot can lead the partition's processing offset, and a compare-and-set
-        // backend would reject a delete gated below it as stale though the owner is legitimate. A genuinely stale
-        // writer only reached its own lower offset.
-        val fenceOffset = highWater(current).fold(offset)(offset max _)
-        val delete =
-          if (persist) database.delete(key, fenceOffset) *> prefixLog.info("deleted snapshot")
-          else ().pure[F]
-        // leave the tombstone offset as the floor so a later replayed re-persist below it is still dropped (the cell no
-        // longer carries a live snapshot's high-water).
-        state.set(Buffered.Deleted(fenceOffset)) *> delete
-      }
+    private val markPersisted: F[Unit] = state.modify(_.map(_.copy(persisted = true)))
 
   }
 

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/Snapshots.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/Snapshots.scala
@@ -9,7 +9,17 @@ import com.evolutiongaming.kafka.flow.LogPrefix
 import com.evolutiongaming.kafka.flow.effect.CatsEffectMtlInstances.*
 import com.evolutiongaming.skafka.Offset
 
-trait Snapshots[F[_], S] extends SnapshotReader[F, S] with SnapshotWriter[F, S]
+trait Snapshots[F[_], S] extends SnapshotReader[F, S] with SnapshotWriter[F, S] {
+
+  /** Whether this buffer fences stale writers (its store gates writes on the snapshot offset).
+    *
+    * Only a fencing buffer keeps an offset high-water and can recover an offset-carrying tombstone, so only a fencing
+    * buffer needs its replay-window floor seeded from the snapshot store on events-recovery. An unfenced
+    * (last-write-wins) buffer never reads back a tombstone, so that read can be skipped. See
+    * `docs/cassandra-single-writer-design.md`.
+    */
+  def fenced: Boolean
+}
 
 /** Allows to read a previously saved snapshot */
 trait SnapshotReader[F[_], S] {
@@ -54,16 +64,16 @@ object Snapshots {
 
   /** Per-key snapshot buffer over `database`.
     *
-    * The buffer holds one [[Stored]] cell - a live snapshot, an offset-carrying tombstone, or nothing yet - plus
-    * whether it is already persisted. Every write (`append`, `delete`) and recovery (`read`) flows through that one
-    * cell, kept monotonic in offset, so a persist and a delete share the same offset discipline: the cell never
-    * regresses below the key's high-water offset. See `docs/cassandra-single-writer-design.md`.
+    * The buffer holds one `Stored` cell - a live snapshot, an offset-carrying tombstone, or nothing yet - plus whether
+    * it is already persisted. Every write (`append`, `delete`) and recovery (`read`) flows through that one cell, kept
+    * monotonic in offset, so a persist and a delete share the same offset discipline: the cell never regresses below
+    * the key's high-water offset. See `docs/cassandra-single-writer-design.md`.
     *
     * @param offsetOf
     *   how to read the offset a snapshot sits at, when this store fences stale writers. `Some(f)` makes the cell
     *   offset-carrying: the buffer is kept monotonic and a delete is stamped at the key's high-water offset (see the
     *   `put` below); `None` is unfenced (last-write-wins, the offset is never tracked). A `KafkaSnapshot`-backed store
-    *   passes `Some(_.offset)` (see [[SnapshotDatabase.snapshotsOf]]).
+    *   passes `Some(_.offset)` (see `SnapshotDatabase.snapshotsOf`).
     */
   private[flow] def of[F[_]: Ref.Make: Monad, K: LogPrefix, S](
     key: K,
@@ -72,7 +82,7 @@ object Snapshots {
   )(implicit log: Log[F]): F[Snapshots[F, S]] =
     Ref.of[F, Option[Cell[S]]](none).map(state => Snapshots(key, database, state.stateInstance, offsetOf))
 
-  /** The per-key buffer cell: a [[Stored]] unit (live snapshot or offset-carrying tombstone floor) plus the `persisted`
+  /** The per-key buffer cell: a `Stored` unit (live snapshot or offset-carrying tombstone floor) plus the `persisted`
     * flag `flush` needs. An empty buffer is `None`.
     */
   private[snapshot] final case class Cell[S](stored: Stored[S], persisted: Boolean)
@@ -84,6 +94,10 @@ object Snapshots {
     offsetOf: Option[S => Offset],
   )(implicit log: Log[F]): Snapshots[F, S] = new Snapshots[F, S] {
     private val prefixLog: Log[F] = log.prefixed(LogPrefix[K].extract(key))
+
+    // fenced iff the store gates writes on an offset (`offsetOf` is set); this is what keeps the buffer monotonic and
+    // makes a recovered tombstone carry a floor (see `put` and `read`)
+    val fenced: Boolean = offsetOf.isDefined
 
     def read =
       // only a recovered tombstone needs seeding here: its offset is the replay-window high-water (kept even with no
@@ -150,6 +164,7 @@ object Snapshots {
   }
 
   def empty[F[_]: Applicative, S]: Snapshots[F, S] = new Snapshots[F, S] {
+    val fenced                                   = false
     def read                                     = none[S].pure[F]
     def append(event: S)                         = ().pure[F]
     def initPersisted(event: S)                  = ().pure[F]

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/Snapshots.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/Snapshots.scala
@@ -7,6 +7,7 @@ import cats.{Applicative, Monad}
 import com.evolutiongaming.catshelper.Log
 import com.evolutiongaming.kafka.flow.LogPrefix
 import com.evolutiongaming.kafka.flow.effect.CatsEffectMtlInstances.*
+import com.evolutiongaming.skafka.Offset
 
 trait Snapshots[F[_], S] extends SnapshotReader[F, S] with SnapshotWriter[F, S]
 
@@ -42,38 +43,52 @@ trait SnapshotWriter[F[_], S] {
     *
     * @param persist
     *   if `true` then also calls underlying database, flushes buffers only otherwise.
+    * @param offset
+    *   offset of the state being deleted; passed to the database so a stale-writer-protecting backend can gate the
+    *   delete on it.
     */
-  def delete(persist: Boolean): F[Unit]
+  def delete(persist: Boolean, offset: Offset): F[Unit]
 
 }
 object Snapshots {
 
-  /** Creates a buffer for a given writer */
+  /** Per-key snapshot buffer over `database`.
+    *
+    * @param offsetOf
+    *   the offset a snapshot sits at, used to keep the buffer monotonic and to fence a delete on the key's high-water
+    *   offset (see [[apply]]'s `append`/`delete`). A `KafkaSnapshot`-backed store passes `_.offset` (see
+    *   [[SnapshotDatabase.snapshotsOf]]); other stores pass `_ => Offset.min`, which makes the fence inert
+    *   (last-write-wins).
+    */
   private[flow] def of[F[_]: Ref.Make: Monad, K: LogPrefix, S](
     key: K,
-    database: SnapshotDatabase[F, K, S]
+    database: SnapshotDatabase[F, K, S],
+    offsetOf: S => Offset,
   )(implicit log: Log[F]): F[Snapshots[F, S]] =
-    Ref.of[F, Option[Snapshot[S]]](None).map(buffer => Snapshots(key, database, buffer.stateInstance))
+    Ref.of[F, Option[Snapshot[S]]](None).map(buffer => Snapshots(key, database, buffer.stateInstance, offsetOf))
 
   private[snapshot] def apply[F[_]: Monad, K: LogPrefix, S](
     key: K,
     database: SnapshotDatabase[F, K, S],
-    buffer: Stateful[F, Option[Snapshot[S]]]
+    buffer: Stateful[F, Option[Snapshot[S]]],
+    offsetOf: S => Offset,
   )(implicit log: Log[F]): Snapshots[F, S] = new Snapshots[F, S] {
     private val prefixLog: Log[F] = log.prefixed(LogPrefix[K].extract(key))
 
     def read = database.get(key)
 
-    def append(snapshot: S) = {
+    def append(snapshot: S) =
       buffer.modify {
-        case Some(s) => s.updateValue(snapshot).some
-        case None    => Snapshot.init(snapshot).some
+        // keep the buffer monotonic in offset: a lower-offset append is replay onto a recovered snapshot (a no-op
+        // under deterministic folds), so dropping it holds the high-water offset that fences `delete`. See
+        // docs/cassandra-single-writer-design.md.
+        case Some(s) if offsetOf(snapshot) < offsetOf(s.value) => s.some
+        case Some(s)                                           => s.updateValue(snapshot).some
+        case None                                              => Snapshot.init(snapshot).some
       }
-    }
 
-    def initPersisted(snapshot: S) = {
+    def initPersisted(snapshot: S) =
       buffer.set(Snapshot.initPersisted(snapshot).some)
-    }
 
     def flush = {
       for {
@@ -89,23 +104,29 @@ object Snapshots {
       } yield ()
     }
 
-    def delete(persist: Boolean) = {
-      val delete = if (persist) {
-        database.delete(key) *> prefixLog.info("deleted snapshot")
-      } else {
-        ().pure[F]
+    def delete(persist: Boolean, offset: Offset) = {
+      buffer.get.flatMap { buffered =>
+        // fence on the buffer's high-water offset (see `append`), not `offset`: after recovery a key's snapshot can
+        // lead the partition's processing offset, and a compare-and-set backend would reject a delete gated below it
+        // as stale though the owner is legitimate. A genuinely stale writer only reached its own lower offset.
+        val fenceOffset = buffered.fold(offset)(snapshot => offset max offsetOf(snapshot.value))
+        val delete = if (persist) {
+          database.delete(key, fenceOffset) *> prefixLog.info("deleted snapshot")
+        } else {
+          ().pure[F]
+        }
+        buffer.set(None) *> delete
       }
-      buffer.set(None) *> delete
     }
 
   }
 
   def empty[F[_]: Applicative, S]: Snapshots[F, S] = new Snapshots[F, S] {
-    def read                     = none[S].pure[F]
-    def append(event: S)         = ().pure[F]
-    def initPersisted(event: S)  = ().pure[F]
-    def flush                    = ().pure[F]
-    def delete(persist: Boolean) = ().pure[F]
+    def read                                     = none[S].pure[F]
+    def append(event: S)                         = ().pure[F]
+    def initPersisted(event: S)                  = ().pure[F]
+    def flush                                    = ().pure[F]
+    def delete(persist: Boolean, offset: Offset) = ().pure[F]
   }
 
   final case class Snapshot[S](value: S, persisted: Boolean) { self =>

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotsOf.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotsOf.scala
@@ -5,6 +5,7 @@ import cats.effect.Ref
 import cats.syntax.all.*
 import com.evolutiongaming.catshelper.Log
 import com.evolutiongaming.kafka.flow.LogPrefix
+import com.evolutiongaming.skafka.Offset
 
 trait SnapshotsOf[F[_], K, S] {
 
@@ -16,9 +17,26 @@ object SnapshotsOf {
   def memory[F[_]: Ref.Make: Monad: Log, K: LogPrefix, S]: F[SnapshotsOf[F, K, S]] =
     SnapshotDatabase.memory[F, K, S].map(database => backedBy(database))
 
-  def backedBy[F[_]: Ref.Make: Monad: Log, K: LogPrefix, S](db: SnapshotDatabase[F, K, S]): SnapshotsOf[F, K, S] = {
-    key =>
-      Snapshots.of(key, db)
+  /** Wires a database into the per-key buffer with no offset fence (last-write-wins). A stale-writer-protecting store
+    * keyed by `KafkaSnapshot` wires through `SnapshotDatabase.snapshotsOf`; a custom offset-carrying store can opt into
+    * fencing with the `offsetOf` overload.
+    */
+  def backedBy[F[_]: Ref.Make: Monad: Log, K: LogPrefix, S](
+    db: SnapshotDatabase[F, K, S]
+  ): SnapshotsOf[F, K, S] = { key =>
+    Snapshots.of(key, db, None)
+  }
+
+  /** Wires a database into the per-key buffer fenced on the offset `offsetOf` extracts from each snapshot: the buffer
+    * is kept monotonic and a delete is gated on the key's high-water offset (see `Snapshots.of`). For a custom
+    * offset-carrying snapshot type; the store's own `persist`/`delete` must also gate on the offset to be stale-writer
+    * safe (see the persistence docs' "Custom snapshot storage").
+    */
+  def backedBy[F[_]: Ref.Make: Monad: Log, K: LogPrefix, S](
+    db: SnapshotDatabase[F, K, S],
+    offsetOf: S => Offset,
+  ): SnapshotsOf[F, K, S] = { key =>
+    Snapshots.of(key, db, Some(offsetOf))
   }
 
 }

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotsOf.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotsOf.scala
@@ -18,8 +18,8 @@ object SnapshotsOf {
     SnapshotDatabase.memory[F, K, S].map(database => backedBy(database))
 
   /** Wires a database into the per-key buffer with no offset fence (last-write-wins). A stale-writer-protecting store
-    * keyed by `KafkaSnapshot` wires through [[SnapshotDatabase.snapshotsOf]]; a custom offset-carrying store can opt
-    * into fencing with the `offsetOf` overload.
+    * keyed by `KafkaSnapshot` wires through `SnapshotDatabase.snapshotsOf`; a custom offset-carrying store can opt into
+    * fencing with the `offsetOf` overload.
     */
   def backedBy[F[_]: Ref.Make: Monad: Log, K: LogPrefix, S](
     db: SnapshotDatabase[F, K, S]
@@ -28,7 +28,7 @@ object SnapshotsOf {
   }
 
   /** Wires a database into the per-key buffer fenced on the offset `offsetOf` extracts from each snapshot: the buffer
-    * is kept monotonic and a delete is gated on the key's high-water offset (see [[Snapshots.of]]). For a custom
+    * is kept monotonic and a delete is gated on the key's high-water offset (see `Snapshots.of`). For a custom
     * offset-carrying snapshot type; the store's own `persist`/`delete` must also gate on the offset to be stale-writer
     * safe (see the persistence docs' "Custom snapshot storage").
     */

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotsOf.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotsOf.scala
@@ -5,6 +5,7 @@ import cats.effect.Ref
 import cats.syntax.all.*
 import com.evolutiongaming.catshelper.Log
 import com.evolutiongaming.kafka.flow.LogPrefix
+import com.evolutiongaming.skafka.Offset
 
 trait SnapshotsOf[F[_], K, S] {
 
@@ -16,9 +17,26 @@ object SnapshotsOf {
   def memory[F[_]: Ref.Make: Monad: Log, K: LogPrefix, S]: F[SnapshotsOf[F, K, S]] =
     SnapshotDatabase.memory[F, K, S].map(database => backedBy(database))
 
-  def backedBy[F[_]: Ref.Make: Monad: Log, K: LogPrefix, S](db: SnapshotDatabase[F, K, S]): SnapshotsOf[F, K, S] = {
-    key =>
-      Snapshots.of(key, db)
+  /** Wires a database into the per-key buffer with no offset fence (last-write-wins). A stale-writer-protecting store
+    * keyed by `KafkaSnapshot` wires through [[SnapshotDatabase.snapshotsOf]]; a custom offset-carrying store can opt
+    * into fencing with the `offsetOf` overload.
+    */
+  def backedBy[F[_]: Ref.Make: Monad: Log, K: LogPrefix, S](
+    db: SnapshotDatabase[F, K, S]
+  ): SnapshotsOf[F, K, S] = { key =>
+    Snapshots.of(key, db, _ => Offset.min)
+  }
+
+  /** Wires a database into the per-key buffer fenced on the offset `offsetOf` extracts from each snapshot: the buffer
+    * is kept monotonic and a delete is gated on the key's high-water offset (see [[Snapshots.of]]). For a custom
+    * offset-carrying snapshot type; the store's own `persist`/`delete` must also gate on the offset to be stale-writer
+    * safe (see the persistence docs' "Custom snapshot storage").
+    */
+  def backedBy[F[_]: Ref.Make: Monad: Log, K: LogPrefix, S](
+    db: SnapshotDatabase[F, K, S],
+    offsetOf: S => Offset,
+  ): SnapshotsOf[F, K, S] = { key =>
+    Snapshots.of(key, db, offsetOf)
   }
 
 }

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotsOf.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotsOf.scala
@@ -24,7 +24,7 @@ object SnapshotsOf {
   def backedBy[F[_]: Ref.Make: Monad: Log, K: LogPrefix, S](
     db: SnapshotDatabase[F, K, S]
   ): SnapshotsOf[F, K, S] = { key =>
-    Snapshots.of(key, db, _ => Offset.min)
+    Snapshots.of(key, db, None)
   }
 
   /** Wires a database into the per-key buffer fenced on the offset `offsetOf` extracts from each snapshot: the buffer
@@ -36,7 +36,7 @@ object SnapshotsOf {
     db: SnapshotDatabase[F, K, S],
     offsetOf: S => Offset,
   ): SnapshotsOf[F, K, S] = { key =>
-    Snapshots.of(key, db, offsetOf)
+    Snapshots.of(key, db, Some(offsetOf))
   }
 
 }

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/AdditionalPersistSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/AdditionalPersistSpec.scala
@@ -148,8 +148,8 @@ class AdditionalPersistSpec extends FunSuite {
 
       override def snapshotDatabase: SnapshotDatabase[IO, KafkaKey, String] =
         new SnapshotDatabase[IO, KafkaKey, String] {
-          override def delete(key: KafkaKey): IO[Unit]        = snapshots.update(_ - key)
-          override def get(key: KafkaKey): IO[Option[String]] = snapshots.get.map(_.get(key))
+          override def delete(key: KafkaKey, offset: Offset): IO[Unit] = snapshots.update(_ - key)
+          override def get(key: KafkaKey): IO[Option[String]]          = snapshots.get.map(_.get(key))
           override def persist(key: KafkaKey, snapshot: String): IO[Unit] =
             if (key.key == "key1" && snapshot == "value10") {
               IO.raiseError(new Exception("Persist error"))

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/AdditionalPersistSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/AdditionalPersistSpec.scala
@@ -3,13 +3,14 @@ package com.evolutiongaming.kafka.flow
 import cats.effect.testkit.TestControl
 import cats.effect.unsafe.IORuntime
 import cats.effect.{IO, Ref, Resource}
+import cats.syntax.all.*
 import com.evolutiongaming.catshelper.{Log, LogOf}
 import com.evolutiongaming.kafka.flow.effect.CatsEffectMtlInstances.*
 import com.evolutiongaming.kafka.flow.kafka.ScheduleCommit
 import com.evolutiongaming.kafka.flow.key.KeysOf
 import com.evolutiongaming.kafka.flow.persistence.PersistenceOf
 import com.evolutiongaming.kafka.flow.registry.EntityRegistry
-import com.evolutiongaming.kafka.flow.snapshot.{SnapshotDatabase, SnapshotsOf}
+import com.evolutiongaming.kafka.flow.snapshot.{SnapshotDatabase, SnapshotsOf, Stored}
 import com.evolutiongaming.kafka.flow.timer.{TimerFlowOf, TimersOf}
 import com.evolutiongaming.skafka.consumer.{ConsumerRecord, WithSize}
 import com.evolutiongaming.skafka.{Offset, TopicPartition}
@@ -148,12 +149,15 @@ class AdditionalPersistSpec extends FunSuite {
 
       override def snapshotDatabase: SnapshotDatabase[IO, KafkaKey, String] =
         new SnapshotDatabase[IO, KafkaKey, String] {
-          override def delete(key: KafkaKey, offset: Offset): IO[Unit] = snapshots.update(_ - key)
-          override def get(key: KafkaKey): IO[Option[String]]          = snapshots.get.map(_.get(key))
-          override def persist(key: KafkaKey, snapshot: String): IO[Unit] =
-            if (key.key == "key1" && snapshot == "value10") {
-              IO.raiseError(new Exception("Persist error"))
-            } else snapshots.update(_ + (key -> snapshot))
+          override def read(key: KafkaKey): IO[Option[Stored[String]]] =
+            snapshots.get.map(_.get(key).map(value => Stored.Live(value, none)))
+          override def write(key: KafkaKey, stored: Stored[String]): IO[Unit] =
+            stored.value match {
+              case Some(snapshot) =>
+                if (key.key == "key1" && snapshot == "value10") IO.raiseError(new Exception("Persist error"))
+                else snapshots.update(_ + (key -> snapshot))
+              case None => snapshots.update(_ - key)
+            }
         }
     }
 

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/AdditionalPersistSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/AdditionalPersistSpec.scala
@@ -3,13 +3,14 @@ package com.evolutiongaming.kafka.flow
 import cats.effect.testkit.TestControl
 import cats.effect.unsafe.IORuntime
 import cats.effect.{IO, Ref, Resource}
+import cats.syntax.all.*
 import com.evolutiongaming.catshelper.{Log, LogOf}
 import com.evolutiongaming.kafka.flow.effect.CatsEffectMtlInstances.*
 import com.evolutiongaming.kafka.flow.kafka.ScheduleCommit
 import com.evolutiongaming.kafka.flow.key.KeysOf
 import com.evolutiongaming.kafka.flow.persistence.PersistenceOf
 import com.evolutiongaming.kafka.flow.registry.EntityRegistry
-import com.evolutiongaming.kafka.flow.snapshot.{SnapshotDatabase, SnapshotsOf}
+import com.evolutiongaming.kafka.flow.snapshot.{SnapshotDatabase, SnapshotsOf, Stored}
 import com.evolutiongaming.kafka.flow.timer.{TimerFlowOf, TimersOf}
 import com.evolutiongaming.skafka.consumer.{ConsumerRecord, WithSize}
 import com.evolutiongaming.skafka.{Offset, TopicPartition}
@@ -148,12 +149,15 @@ class AdditionalPersistSpec extends FunSuite {
 
       override def snapshotDatabase: SnapshotDatabase[IO, KafkaKey, String] =
         new SnapshotDatabase[IO, KafkaKey, String] {
-          override def delete(key: KafkaKey): IO[Unit]        = snapshots.update(_ - key)
-          override def get(key: KafkaKey): IO[Option[String]] = snapshots.get.map(_.get(key))
-          override def persist(key: KafkaKey, snapshot: String): IO[Unit] =
-            if (key.key == "key1" && snapshot == "value10") {
-              IO.raiseError(new Exception("Persist error"))
-            } else snapshots.update(_ + (key -> snapshot))
+          override def read(key: KafkaKey): IO[Option[Stored[String]]] =
+            snapshots.get.map(_.get(key).map(value => Stored.Live(value, none)))
+          override def write(key: KafkaKey, stored: Stored[String]): IO[Unit] =
+            stored.value match {
+              case Some(snapshot) =>
+                if (key.key == "key1" && snapshot == "value10") IO.raiseError(new Exception("Persist error"))
+                else snapshots.update(_ + (key -> snapshot))
+              case None => snapshots.update(_ - key)
+            }
         }
     }
 

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/PartitionFlowSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/PartitionFlowSpec.scala
@@ -13,7 +13,7 @@ import com.evolutiongaming.kafka.flow.kafka.ScheduleCommit
 import com.evolutiongaming.kafka.flow.key.{KeyDatabase, KeysOf}
 import com.evolutiongaming.kafka.flow.persistence.PersistenceOf
 import com.evolutiongaming.kafka.flow.registry.EntityRegistry
-import com.evolutiongaming.kafka.flow.snapshot.{SnapshotDatabase, SnapshotsOf}
+import com.evolutiongaming.kafka.flow.snapshot.{SnapshotDatabase, SnapshotsOf, Stored}
 import com.evolutiongaming.kafka.flow.timer.{TimerContext, TimerFlowOf, TimersOf, Timestamp}
 import com.evolutiongaming.skafka.consumer.{ConsumerRecord, WithSize}
 import com.evolutiongaming.skafka.{Offset, Partition, TopicPartition}
@@ -172,12 +172,12 @@ class PartitionFlowSpec extends FunSuite {
     class LocalFixture(waitForN: Int) extends ConstFixture(waitForN) {
       // It fails persisting for key = 'key2' on the 3rd event only
       private val snapshotDatabase = new SnapshotDatabase[IO, String, State] {
-        def get(key: String): IO[Option[(Offset, Int)]] = IO.pure(none)
-        def persist(key: String, snapshot: (Offset, Int)): IO[Unit] = {
-          val (_, sent) = snapshot
-          IO.whenA(key == "key2" && sent == 3)(IO.raiseError(new Exception("Test error")))
-        }
-        def delete(key: String, offset: Offset): IO[Unit] = IO.unit
+        def read(key: String): IO[Option[Stored[State]]] = IO.pure(none)
+        def write(key: String, stored: Stored[State]): IO[Unit] =
+          stored.value.traverse_ {
+            case (_, sent) =>
+              IO.whenA(key == "key2" && sent == 3)(IO.raiseError(new Exception("Test error")))
+          }
       }
 
       override def flow: Resource[IO, PartitionFlow[IO]] = makeFlow(
@@ -359,11 +359,10 @@ class PartitionFlowSpec extends FunSuite {
     // Waiting for 100 events to represents a long-living flow that doesn't unload the state during its lifetime
     class LocalFixture extends ConstFixture(100) {
       private val snapshotDatabase = new SnapshotDatabase[IO, String, State] {
-        def get(key: String): IO[Option[(Offset, Int)]] = IO.pure(none)
+        def read(key: String): IO[Option[Stored[State]]] = IO.pure(none)
         // Fail snapshot persistence for the second key
-        def persist(key: String, snapshot: (Offset, Int)): IO[Unit] =
-          IO.raiseError(new Exception("Test error")).whenA(key == key2)
-        def delete(key: String, offset: Offset): IO[Unit] = IO.unit
+        def write(key: String, stored: Stored[State]): IO[Unit] =
+          IO.raiseError(new Exception("Test error")).whenA(stored.value.isDefined && key == key2)
       }
 
       override def flow: Resource[IO, PartitionFlow[IO]] = makeFlow(

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/PartitionFlowSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/PartitionFlowSpec.scala
@@ -9,7 +9,7 @@ import com.evolutiongaming.kafka.flow.PartitionFlow.{FilterRecord, PartitionKey}
 import com.evolutiongaming.kafka.flow.PartitionFlowSpec.*
 import com.evolutiongaming.kafka.flow.effect.CatsEffectMtlInstances.*
 import com.evolutiongaming.kafka.flow.journal.JournalsOf
-import com.evolutiongaming.kafka.flow.kafka.{ScheduleCommit, ToOffset}
+import com.evolutiongaming.kafka.flow.kafka.ScheduleCommit
 import com.evolutiongaming.kafka.flow.key.{KeyDatabase, KeysOf}
 import com.evolutiongaming.kafka.flow.persistence.PersistenceOf
 import com.evolutiongaming.kafka.flow.registry.EntityRegistry
@@ -177,7 +177,7 @@ class PartitionFlowSpec extends FunSuite {
           val (_, sent) = snapshot
           IO.whenA(key == "key2" && sent == 3)(IO.raiseError(new Exception("Test error")))
         }
-        def delete(key: String): IO[Unit] = IO.unit
+        def delete(key: String, offset: Offset): IO[Unit] = IO.unit
       }
 
       override def flow: Resource[IO, PartitionFlow[IO]] = makeFlow(
@@ -363,7 +363,7 @@ class PartitionFlowSpec extends FunSuite {
         // Fail snapshot persistence for the second key
         def persist(key: String, snapshot: (Offset, Int)): IO[Unit] =
           IO.raiseError(new Exception("Test error")).whenA(key == key2)
-        def delete(key: String): IO[Unit] = IO.unit
+        def delete(key: String, offset: Offset): IO[Unit] = IO.unit
       }
 
       override def flow: Resource[IO, PartitionFlow[IO]] = makeFlow(
@@ -484,13 +484,6 @@ object PartitionFlowSpec {
   class ConstFixture(waitForN: Int) {
     implicit val logOf: LogOf[IO] = LogOf.empty
     implicit val log: Log[IO]     = Log.empty
-
-    implicit val stateToOffset: ToOffset[State] = new ToOffset[State] {
-      def offset(state: State): Offset = {
-        val (offset, _) = state
-        offset
-      }
-    }
 
     type State = (Offset, Int)
 

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/PartitionFlowSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/PartitionFlowSpec.scala
@@ -9,11 +9,11 @@ import com.evolutiongaming.kafka.flow.PartitionFlow.{FilterRecord, PartitionKey}
 import com.evolutiongaming.kafka.flow.PartitionFlowSpec.*
 import com.evolutiongaming.kafka.flow.effect.CatsEffectMtlInstances.*
 import com.evolutiongaming.kafka.flow.journal.JournalsOf
-import com.evolutiongaming.kafka.flow.kafka.{ScheduleCommit, ToOffset}
+import com.evolutiongaming.kafka.flow.kafka.ScheduleCommit
 import com.evolutiongaming.kafka.flow.key.{KeyDatabase, KeysOf}
 import com.evolutiongaming.kafka.flow.persistence.PersistenceOf
 import com.evolutiongaming.kafka.flow.registry.EntityRegistry
-import com.evolutiongaming.kafka.flow.snapshot.{SnapshotDatabase, SnapshotsOf}
+import com.evolutiongaming.kafka.flow.snapshot.{SnapshotDatabase, SnapshotsOf, Stored}
 import com.evolutiongaming.kafka.flow.timer.{TimerContext, TimerFlowOf, TimersOf, Timestamp}
 import com.evolutiongaming.skafka.consumer.{ConsumerRecord, WithSize}
 import com.evolutiongaming.skafka.{Offset, Partition, TopicPartition}
@@ -172,12 +172,12 @@ class PartitionFlowSpec extends FunSuite {
     class LocalFixture(waitForN: Int) extends ConstFixture(waitForN) {
       // It fails persisting for key = 'key2' on the 3rd event only
       private val snapshotDatabase = new SnapshotDatabase[IO, String, State] {
-        def get(key: String): IO[Option[(Offset, Int)]] = IO.pure(none)
-        def persist(key: String, snapshot: (Offset, Int)): IO[Unit] = {
-          val (_, sent) = snapshot
-          IO.whenA(key == "key2" && sent == 3)(IO.raiseError(new Exception("Test error")))
-        }
-        def delete(key: String): IO[Unit] = IO.unit
+        def read(key: String): IO[Option[Stored[State]]] = IO.pure(none)
+        def write(key: String, stored: Stored[State]): IO[Unit] =
+          stored.value.traverse_ {
+            case (_, sent) =>
+              IO.whenA(key == "key2" && sent == 3)(IO.raiseError(new Exception("Test error")))
+          }
       }
 
       override def flow: Resource[IO, PartitionFlow[IO]] = makeFlow(
@@ -359,11 +359,10 @@ class PartitionFlowSpec extends FunSuite {
     // Waiting for 100 events to represents a long-living flow that doesn't unload the state during its lifetime
     class LocalFixture extends ConstFixture(100) {
       private val snapshotDatabase = new SnapshotDatabase[IO, String, State] {
-        def get(key: String): IO[Option[(Offset, Int)]] = IO.pure(none)
+        def read(key: String): IO[Option[Stored[State]]] = IO.pure(none)
         // Fail snapshot persistence for the second key
-        def persist(key: String, snapshot: (Offset, Int)): IO[Unit] =
-          IO.raiseError(new Exception("Test error")).whenA(key == key2)
-        def delete(key: String): IO[Unit] = IO.unit
+        def write(key: String, stored: Stored[State]): IO[Unit] =
+          IO.raiseError(new Exception("Test error")).whenA(stored.value.isDefined && key == key2)
       }
 
       override def flow: Resource[IO, PartitionFlow[IO]] = makeFlow(
@@ -485,20 +484,16 @@ object PartitionFlowSpec {
     implicit val logOf: LogOf[IO] = LogOf.empty
     implicit val log: Log[IO]     = Log.empty
 
-    implicit val stateToOffset: ToOffset[State] = new ToOffset[State] {
-      def offset(state: State): Offset = {
-        val (offset, _) = state
-        offset
-      }
-    }
-
     type State = (Offset, Int)
 
     val keysOf     = KeysOf.memory1[IO, String].unsafeRunSync()(IORuntime.global)
     val journalsOf = JournalsOf.memory[IO, String, ConsumerRecord[String, ByteVector]].unsafeRunSync()(IORuntime.global)
     val snapshotsOf = SnapshotsOf.memory[IO, String, State].unsafeRunSync()(IORuntime.global)
     val (persistenceOf, _) =
-      PersistenceOf.restoreEvents(keysOf, journalsOf, snapshotsOf).allocated.unsafeRunSync()(IORuntime.global)
+      PersistenceOf
+        .restoreEvents(keysOf, journalsOf, snapshotsOf, (record: ConsumerRecord[String, ByteVector]) => record.offset)
+        .allocated
+        .unsafeRunSync()(IORuntime.global)
 
     def fold: FoldOption[IO, State, ConsumerRecord[String, ByteVector]] =
       FoldOption.of { (state, record) =>

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/persistence/PersistenceSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/persistence/PersistenceSpec.scala
@@ -51,6 +51,30 @@ class PersistenceSpec extends FunSuite {
     assert(context.deleteCalled)
   }
 
+  test("delete forwards the current processing offset to the database") {
+    val f = new ConstFixture
+
+    // Given("a flushed state and a known current processing offset")
+    val offset = Offset.unsafe(42)
+    val context0 = Context(timestamps =
+      TimestampState(Timestamp(clock = Instant.parse("2020-01-01T01:02:03.004Z"), watermark = None, offset = offset))
+    )
+
+    // And("delete is requested")
+    val program =
+      f.persistence.appendEvent("event1") *>
+        f.persistence.replaceState(0) *>
+        f.persistence.flush *>
+        f.persistence.delete
+
+    // When("program is run")
+    val context = program.runS(context0).value
+
+    // Then("the database delete receives that offset")
+    assert(context.deleteCalled)
+    assertEquals(context.deleteOffset, offset.some)
+  }
+
   test("delete is not called if the new state was never persisted") {
     val f = new ConstFixture
 
@@ -109,6 +133,7 @@ object PersistenceSpec {
       )
     ),
     deleteCalled: Boolean         = false,
+    deleteOffset: Option[Offset]  = None,
     initializedState: Option[Int] = None
   )
 
@@ -120,8 +145,8 @@ object PersistenceSpec {
       def initPersistedState(state: Int) = State.modify { context =>
         context.copy(initializedState = state.some)
       }
-      def delete(persist: Boolean) = State.modify { context =>
-        context.copy(deleteCalled = persist)
+      def delete(persist: Boolean, offset: Offset) = State.modify { context =>
+        context.copy(deleteCalled = persist, deleteOffset = offset.some)
       }
       def flushKeys  = ().pure[F]
       def flushState = ().pure[F]

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/persistence/ReadStateFloorGateSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/persistence/ReadStateFloorGateSpec.scala
@@ -1,0 +1,164 @@
+package com.evolutiongaming.kafka.flow.persistence
+
+import cats.effect.unsafe.IORuntime
+import cats.effect.{IO, Ref}
+import cats.syntax.all.*
+import com.evolutiongaming.catshelper.Log
+import com.evolutiongaming.kafka.flow.FoldOption
+import com.evolutiongaming.kafka.flow.journal.{JournalReader, Journals}
+import com.evolutiongaming.kafka.flow.snapshot.{KafkaSnapshot, SnapshotDatabase, Snapshots, Stored}
+import com.evolutiongaming.skafka.Offset
+import com.evolutiongaming.sstream.Stream
+import munit.FunSuite
+
+/** The events-recovery seam (`ReadState` over journal + fenced snapshot store).
+  *
+  * The floor read is gated on the buffer being fenced: only a fencing buffer can recover a tombstone floor, so an
+  * unfenced (last-write-wins) buffer must not pay a per-key store round-trip on every recovery.
+  *
+  * The journal-revive guard: the journal is unfenced, so a stale owner's replayed appends can land after a delete
+  * cleared it, and a journal TTL can reap rows the snapshot already carries. Recovery folds the journal ONTO the
+  * store's view (a live snapshot as the base, a tombstone's offset as the floor) and skips events at or below the
+  * store's offset. The filter is structural, so it holds at EVERY recovery: after legitimate post-guard events advance
+  * the journal and the snapshot together, stale residue below the floor still never re-enters the fold (the revive
+  * re-entry). See `Persistence.ReadState` and `docs/cassandra-single-writer-design.md`.
+  */
+class ReadStateFloorGateSpec extends FunSuite {
+  implicit val ioRuntime: IORuntime = IORuntime.global
+  implicit val log: Log[IO]         = Log.empty[IO]
+
+  private val fold = FoldOption.empty[IO, KafkaSnapshot[String], String]
+
+  private def countingDb(reads: Ref[IO, Int]): SnapshotDatabase[IO, String, KafkaSnapshot[String]] =
+    new SnapshotDatabase[IO, String, KafkaSnapshot[String]] {
+      def read(key: String) =
+        reads.update(_ + 1).as((Stored.Tombstone(Offset.unsafe(5)): Stored[KafkaSnapshot[String]]).some)
+      def write(key: String, stored: Stored[KafkaSnapshot[String]]) = IO.unit
+    }
+
+  test("a fenced buffer reads the store for the tombstone floor before folding the journal") {
+    val test = for {
+      reads     <- Ref.of[IO, Int](0)
+      snapshots <- Snapshots.of[IO, String, KafkaSnapshot[String]]("key1", countingDb(reads), Some(_.offset))
+      state     <- ReadState(Journals.empty[IO, String], fold, snapshots, (_: String) => Offset.min).read
+      count     <- reads.get
+    } yield {
+      assertEquals(state, None) // the journal is empty; the floor read's value is a side-effect only
+      assertEquals(count, 1)
+    }
+    test.unsafeRunSync()
+  }
+
+  test("an unfenced buffer skips the floor read (it can never recover a tombstone)") {
+    val test = for {
+      reads     <- Ref.of[IO, Int](0)
+      snapshots <- Snapshots.of[IO, String, KafkaSnapshot[String]]("key1", countingDb(reads), None)
+      state     <- ReadState(Journals.empty[IO, String], fold, snapshots, (_: String) => Offset.min).read
+      count     <- reads.get
+    } yield {
+      assertEquals(state, None)
+      assertEquals(count, 0)
+    }
+    test.unsafeRunSync()
+  }
+
+  // events are (offset, payload); the fold concatenates payloads so a stale row folded in is visible in the value,
+  // not only in the offset - the revive corrupts CONTENTS at correct-looking offsets
+  private type Event = (Long, String)
+
+  private def journalOf(events: Event*): JournalReader[IO, Event] =
+    new JournalReader[IO, Event] {
+      def read = Stream.from[IO, List, Event](events.toList)
+    }
+
+  private val eventOffset: Event => Offset = event => Offset.unsafe(event._1)
+
+  private val foldEvents: FoldOption[IO, KafkaSnapshot[String], Event] =
+    FoldOption.of { (state, event) =>
+      KafkaSnapshot(offset = Offset.unsafe(event._1), value = state.fold("")(_.value) + event._2).some.pure[IO]
+    }
+
+  private def storeOf(stored: Stored[KafkaSnapshot[String]]): SnapshotDatabase[IO, String, KafkaSnapshot[String]] =
+    new SnapshotDatabase[IO, String, KafkaSnapshot[String]] {
+      def read(key: String)                                         = stored.some.pure[IO]
+      def write(key: String, stored: Stored[KafkaSnapshot[String]]) = IO.unit
+    }
+
+  private def readState(
+    store: SnapshotDatabase[IO, String, KafkaSnapshot[String]],
+    journal: JournalReader[IO, Event],
+  ): IO[Option[KafkaSnapshot[String]]] =
+    for {
+      snapshots <- Snapshots.of[IO, String, KafkaSnapshot[String]]("key1", store, Some(_.offset))
+      state     <- ReadState(journal, foldEvents, snapshots, eventOffset).read
+    } yield state
+
+  test("a fenced buffer never folds journal residue a stored tombstone leads (the journal revive)") {
+    // the key was deleted at offset 5; the journal holds a stale owner's replayed pre-delete appends only
+    val store = storeOf(Stored.Tombstone(Offset.unsafe(5)))
+    val state = readState(store, journalOf((2, "a"), (3, "b"))).unsafeRunSync()
+    assertEquals(state, None)
+  }
+
+  test("a fenced buffer folds only post-delete journal events onto the tombstone floor") {
+    // legitimate post-delete events fold from scratch; the pre-delete residue at 2 is skipped, not folded
+    val store = storeOf(Stored.Tombstone(Offset.unsafe(5)))
+    val state = readState(store, journalOf((2, "a"), (7, "x"))).unsafeRunSync()
+    assertEquals(state.map(_.offset), Offset.unsafe(7).some)
+    assertEquals(state.map(_.value), "x".some) // "a" must not be in the fold
+  }
+
+  test("the revive cannot re-enter after post-delete events advance the journal past the tombstone (second recovery)") {
+    // the revive re-entry: residue (2,3) + post-delete events (7,8) put the journal's high-water at 8, at/above any
+    // snapshot the store can hold - a fold-result comparison would pass the polluted fold through; the offset
+    // filter must still skip the residue
+    val store = storeOf(Stored.Tombstone(Offset.unsafe(5)))
+    val state = readState(store, journalOf((2, "a"), (3, "b"), (7, "x"), (8, "y"))).unsafeRunSync()
+    assertEquals(state.map(_.offset), Offset.unsafe(8).some)
+    assertEquals(state.map(_.value), "xy".some) // pre-delete "ab" resurrected nowhere
+  }
+
+  test("a fenced buffer recovers the stored live snapshot as the base when the journal trails it") {
+    // the journal head was TTL-reaped (or polluted below the snapshot): the store's snapshot is the recovery base
+    val store =
+      storeOf(Stored.Live(KafkaSnapshot(offset = Offset.unsafe(10), value = "base"), Offset.unsafe(10).some))
+    val state = readState(store, journalOf((2, "a"), (3, "b"))).unsafeRunSync()
+    assertEquals(state.map(_.value), "base".some)
+    assertEquals(state.map(_.offset), Offset.unsafe(10).some)
+  }
+
+  test("a live key's post-snapshot journal suffix folds onto the store base, never from scratch (second recovery)") {
+    // the live arm: after the reaped-head recovery, new events (11,12) advance journal and snapshot together;
+    // a fold from scratch would rebuild from the suffix alone and silently lose the base
+    val store =
+      storeOf(Stored.Live(KafkaSnapshot(offset = Offset.unsafe(10), value = "base"), Offset.unsafe(10).some))
+    val state = readState(store, journalOf((2, "a"), (11, "x"), (12, "y"))).unsafeRunSync()
+    assertEquals(state.map(_.offset), Offset.unsafe(12).some)
+    assertEquals(state.map(_.value), "basexy".some) // the base is under the suffix; the reaped "a" is not
+  }
+
+  test("an intact journal folds only its above-snapshot suffix onto the base (no double-fold)") {
+    // the ordinary case: the journal holds everything; events at or below the snapshot offset are already folded
+    // into the base and must be skipped even for a fold with no filter of its own
+    val store =
+      storeOf(Stored.Live(KafkaSnapshot(offset = Offset.unsafe(2), value = "ab"), Offset.unsafe(2).some))
+    val state = readState(store, journalOf((1, "a"), (2, "b"), (3, "c"))).unsafeRunSync()
+    assertEquals(state.map(_.offset), Offset.unsafe(3).some)
+    assertEquals(state.map(_.value), "abc".some) // not "ababc"
+  }
+
+  test("an unfenced buffer folds the whole journal from scratch (pre-existing exposure, unchanged)") {
+    val test = for {
+      snapshots <- Snapshots.of[IO, String, KafkaSnapshot[String]](
+        "key1",
+        SnapshotDatabase.empty[IO, String, KafkaSnapshot[String]],
+        None,
+      )
+      state <- ReadState(journalOf((2, "a"), (3, "b")), foldEvents, snapshots, eventOffset).read
+    } yield {
+      assertEquals(state.map(_.offset), Offset.unsafe(3).some)
+      assertEquals(state.map(_.value), "ab".some)
+    }
+    test.unsafeRunSync()
+  }
+}

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/FlushCellConcurrencySpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/FlushCellConcurrencySpec.scala
@@ -1,0 +1,171 @@
+package com.evolutiongaming.kafka.flow.snapshot
+
+import cats.effect.std.Semaphore
+import cats.effect.unsafe.implicits.global
+import cats.effect.{Deferred, IO, Ref}
+import cats.syntax.all.*
+import com.evolutiongaming.catshelper.Log
+import com.evolutiongaming.kafka.flow.effect.CatsEffectMtlInstances.*
+import com.evolutiongaming.kafka.flow.snapshot.Snapshots.Cell
+import munit.FunSuite
+
+/** Shows that per-key serialization (one poll thread per partition) is what keeps `Snapshots.flushCell` from losing a
+  * write.
+  *
+  * `flushCell` is a two-step compound over the buffer cell:
+  * {{{
+  *   state.get                       // observe Cell(stored = v1, persisted = false)
+  *   database.write(key, v1)         // make v1 durable
+  *   markPersisted                   // state.modify(_.copy(persisted = true))  -- a SEPARATE state transaction
+  * }}}
+  * `state.get` .. `markPersisted` is NOT atomic. A concurrent `append(v2)` (routed through `put`, another
+  * `state.modify`) landing between `database.write` and `markPersisted` rebinds the cell to unpersisted v2;
+  * `markPersisted` then flips THAT cell to `persisted = true`. The buffer claims v2 is durable while the database only
+  * received v1 -- a lost write, permanent because v2 is marked persisted and never re-flushed.
+  *
+  * Lost-write predicate on the final state: `cell.persisted && cell.value != durableValue`.
+  *
+  *   - UNSERIALIZED (hazard is real): `flush` and a racing `append` may interleave, pinned deterministically by a
+  *     `Deferred` handshake -- the fake database parks inside `write` (after the row is durable, before
+  *     `markPersisted`) until the append has run -- so the lost write reproduces on EVERY iteration with no reliance on
+  *     scheduler timing.
+  *   - SERIALIZED (hazard is forbidden): the same `flush` and `append`, guarded by a `Semaphore(1)` mirroring
+  *     `TopicFlow.safeguard`'s single per-cycle permit, cannot interleave, so no lost write even though the fake
+  *     database yields (`IO.cede`) to widen the write -> markPersisted window as far as the runtime allows.
+  *
+  * Test-only: production code is unchanged. Exercises `Snapshots.apply` over a `Ref`-backed cell so the test can
+  * inspect `Cell.persisted` / `Cell.value` after the race.
+  */
+class FlushCellConcurrencySpec extends FunSuite {
+
+  import FlushCellConcurrencySpec.*
+
+  private implicit val log: Log[IO] = Log.empty[IO]
+
+  // Bounded so CI stays fast; both cases are deterministic, so more iterations only add confidence, not flakiness.
+  private val iterations = 200
+
+  test("UNSERIALIZED: an append interleaving between database.write and markPersisted causes a lost write") {
+    // A database that, on a live write, makes the row durable then PARKS inside `write` (before `markPersisted`)
+    // until the test releases it -- turning the timing race into a deterministic handshake so the racing append is
+    // guaranteed to land in the window.
+    def raceOnce: IO[Boolean] =
+      for {
+        db          <- Ref.of[IO, Map[K, S]](Map.empty)
+        writeParked <- Deferred[IO, Unit] // completed once the row is durable and flush is parked pre-markPersisted
+        release     <- Deferred[IO, Unit] // completed by the test to let flush proceed to markPersisted
+        gatingDb = new SnapshotDatabase[IO, K, S] {
+          def read(key: K): IO[Option[Stored[S]]] = db.get.map(_.get(key).map(v => Stored.Live(v, none)))
+          def write(key: K, stored: Stored[S]) =
+            (stored match {
+              case Stored.Live(v, _)   => db.update(_ + (key -> v))
+              case Stored.Tombstone(_) => db.update(_ - key)
+            }) *> writeParked.complete(()) *> release.get
+        }
+        state    <- Ref.of[IO, Option[Cell[S]]](none)
+        snapshots = Snapshots(key, gatingDb, state.stateInstance, noFence)
+
+        _     <- snapshots.append(1) // buffer cell = Cell(Live(1), persisted = false)
+        fiber <- snapshots.flush.start // reads the cell, writes 1 to the db, parks inside write()
+        _     <- writeParked.get // db now holds 1; flush is suspended just before markPersisted
+        _     <- snapshots.append(2) // INTERLEAVE: cell = Cell(Live(2), persisted = false)
+        _     <- release.complete(()) // resume flush -> markPersisted flips the v2 cell to persisted = true
+        _     <- fiber.join
+
+        durable <- db.get.map(_.get(key))
+        cell    <- state.get
+      } yield isLostWrite(cell, durable)
+
+    val lostWrites = List.fill(iterations)(raceOnce).sequence.map(_.count(identity)).unsafeRunSync()
+
+    // Every iteration reproduces the lost write, since the handshake forces the hazardous interleaving.
+    assertEquals(
+      lostWrites,
+      iterations,
+      s"expected the lost write on every unserialized iteration, saw it $lostWrites/$iterations times"
+    )
+  }
+
+  test("SERIALIZED: a Semaphore(1) around flush and append (as TopicFlow.safeguard does) forbids the lost write") {
+    // A database whose `write` yields around the durable update, opening the write -> markPersisted window as wide as
+    // the runtime allows. Serialization -- not a narrow window -- is what must keep this safe.
+    def serializedOnce: IO[Boolean] =
+      for {
+        db <- Ref.of[IO, Map[K, S]](Map.empty)
+        yieldingDb = new SnapshotDatabase[IO, K, S] {
+          def read(key: K): IO[Option[Stored[S]]] = db.get.map(_.get(key).map(v => Stored.Live(v, none)))
+          def write(key: K, stored: Stored[S]) =
+            IO.cede *> (stored match {
+              case Stored.Live(v, _)   => db.update(_ + (key -> v))
+              case Stored.Tombstone(_) => db.update(_ - key)
+            }) *> IO.cede
+        }
+        state    <- Ref.of[IO, Option[Cell[S]]](none)
+        snapshots = Snapshots(key, yieldingDb, state.stateInstance, noFence)
+        sem      <- Semaphore[IO](1)
+        guard     = (op: IO[Unit]) => sem.permit.use(_ => op)
+
+        _ <- snapshots.append(1) // buffer cell = Cell(Live(1), persisted = false)
+        // Started concurrently, but the single permit serializes them: neither can observe a half-finished flush,
+        // so the append can never slip between database.write and markPersisted.
+        _ <- (guard(snapshots.flush), guard(snapshots.append(2))).parTupled
+
+        durable <- db.get.map(_.get(key))
+        cell    <- state.get
+      } yield isLostWrite(cell, durable)
+
+    val lostWrites = List.fill(iterations)(serializedOnce).sequence.map(_.count(identity)).unsafeRunSync()
+
+    assertEquals(lostWrites, 0, s"serialized flush/append must never lose a write, but did $lostWrites times")
+  }
+
+  test("SERIALIZED (sequential poll thread): flush *> append never marks a value persisted the db never received") {
+    // The plainest model of the single poll thread: flush and append run one after another, never overlapping. Even
+    // with the yielding database, the invariant `persisted ==> durable == value` holds throughout.
+    def sequentialOnce: IO[Boolean] =
+      for {
+        db <- Ref.of[IO, Map[K, S]](Map.empty)
+        yieldingDb = new SnapshotDatabase[IO, K, S] {
+          def read(key: K): IO[Option[Stored[S]]] = db.get.map(_.get(key).map(v => Stored.Live(v, none)))
+          def write(key: K, stored: Stored[S]) =
+            IO.cede *> (stored match {
+              case Stored.Live(v, _)   => db.update(_ + (key -> v))
+              case Stored.Tombstone(_) => db.update(_ - key)
+            }) *> IO.cede
+        }
+        state    <- Ref.of[IO, Option[Cell[S]]](none)
+        snapshots = Snapshots(key, yieldingDb, state.stateInstance, noFence)
+
+        _        <- snapshots.append(1)
+        _        <- snapshots.flush // v1 becomes durable AND is marked persisted, atomically w.r.t. the append
+        durable1 <- db.get.map(_.get(key))
+        cell1    <- state.get
+        _        <- snapshots.append(2)
+        _        <- snapshots.flush
+        durable2 <- db.get.map(_.get(key))
+        cell2    <- state.get
+      } yield isLostWrite(cell1, durable1) || isLostWrite(cell2, durable2)
+
+    val lostWrites = List.fill(iterations)(sequentialOnce).sequence.map(_.count(identity)).unsafeRunSync()
+
+    assertEquals(lostWrites, 0, s"sequential flush/append must never lose a write, but did $lostWrites times")
+  }
+
+}
+
+object FlushCellConcurrencySpec {
+
+  type K = String
+  type S = Int
+
+  private val key = "key1"
+
+  // last-write-wins (no offset fence): an append always rebinds the cell, isolating the flushCell race from the
+  // separate offset-monotonicity concern.
+  private val noFence: Option[S => com.evolutiongaming.skafka.Offset] = None
+
+  /** Lost-write predicate: the cell claims durability (`persisted`) while the database holds a different value. */
+  private def isLostWrite(cell: Option[Cell[S]], durable: Option[S]): Boolean =
+    cell.exists(c => c.persisted && c.stored.value != durable)
+
+}

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotReplayFencingSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotReplayFencingSpec.scala
@@ -1,0 +1,169 @@
+package com.evolutiongaming.kafka.flow.snapshot
+
+import cats.effect.testkit.TestControl
+import cats.effect.unsafe.implicits.global
+import cats.effect.{IO, Ref}
+import cats.syntax.all.*
+import com.evolutiongaming.catshelper.{Log, LogOf}
+import com.evolutiongaming.kafka.flow.effect.CatsEffectMtlInstances.*
+import com.evolutiongaming.kafka.flow.kafka.ScheduleCommit
+import com.evolutiongaming.kafka.flow.key.{KeyDatabase, KeysOf}
+import com.evolutiongaming.kafka.flow.persistence.PersistenceOf
+import com.evolutiongaming.kafka.flow.registry.EntityRegistry
+import com.evolutiongaming.kafka.flow.timer.{TimerFlowOf, TimersOf}
+import com.evolutiongaming.kafka.flow.{FoldOption, KafkaKey, KeyStateOf, PartitionFlow, PartitionFlowConfig, TickOption}
+import com.evolutiongaming.skafka.consumer.{ConsumerRecord, WithSize}
+import com.evolutiongaming.skafka.{Offset, Partition, TopicPartition}
+import munit.FunSuite
+import scodec.bits.ByteVector
+
+import scala.concurrent.duration.*
+import scala.util.control.NoStackTrace
+
+/** `TestControl`-driven flow-level regressions for the compare-and-set replay-window fix (simulated time).
+  *
+  * A key is recovered with a snapshot whose offset (5) leads the committed offset the partition resumes from (0). While
+  * replaying events below it (`current.offset` < 5) the buffer must stay at the high-water offset, so a delete is
+  * fenced on 5 (not the processing offset) and a re-derived snapshot is not re-persisted below 5 - otherwise the
+  * offset-gated store below rejects the legitimate owner as stale.
+  */
+class SnapshotReplayFencingSpec extends FunSuite {
+
+  private implicit val logOf: LogOf[IO] = LogOf.empty[IO]
+  private implicit val log: Log[IO]     = Log.empty[IO]
+
+  private val tp            = TopicPartition("topic", Partition.min)
+  private val key           = KafkaKey("app", "group", tp, "key1")
+  private val recoveredAt   = Offset.unsafe(5)
+  private val recoveredSnap = KafkaSnapshot(offset = recoveredAt, value = "recovered")
+
+  import SnapshotReplayFencingSpec.StaleWrite
+
+  /** In-memory snapshot store mimicking the Cassandra compare-and-set guard `IF offset <= :offset`: a write or delete
+    * whose offset is below the stored one is rejected.
+    */
+  private def offsetGatedDb(
+    storage: Ref[IO, Map[KafkaKey, KafkaSnapshot[String]]]
+  ): SnapshotDatabase[IO, KafkaKey, KafkaSnapshot[String]] =
+    new SnapshotDatabase[IO, KafkaKey, KafkaSnapshot[String]] {
+      def get(key: KafkaKey): IO[Option[KafkaSnapshot[String]]] = storage.get.map(_.get(key))
+
+      def persist(key: KafkaKey, snapshot: KafkaSnapshot[String]): IO[Unit] =
+        storage.modify { snapshots =>
+          snapshots.get(key) match {
+            case Some(stored) if stored.offset > snapshot.offset =>
+              (snapshots, StaleWrite(stored.offset, snapshot.offset).raiseError[IO, Unit])
+            case _ => (snapshots.updated(key, snapshot), ().pure[IO])
+          }
+        }.flatten
+
+      def delete(key: KafkaKey, offset: Offset): IO[Unit] =
+        storage.modify { snapshots =>
+          snapshots.get(key) match {
+            case Some(stored) if stored.offset > offset =>
+              (snapshots, StaleWrite(stored.offset, offset).raiseError[IO, Unit])
+            case _ => (snapshots.removed(key), ().pure[IO])
+          }
+        }.flatten
+    }
+
+  private val fold: FoldOption[IO, KafkaSnapshot[String], ConsumerRecord[String, ByteVector]] =
+    FoldOption.of { (state, record) =>
+      IO {
+        val event = record.value.flatMap(_.value.decodeUtf8.toOption).getOrElse(sys.error("event payload missing"))
+        KafkaSnapshot(offset = record.offset, value = state.fold(event)(s => s"${s.value},$event")).some
+      }
+    }
+
+  private val deletingTick: TickOption[IO, KafkaSnapshot[String]] =
+    TickOption.of[IO, KafkaSnapshot[String]](_ => none[KafkaSnapshot[String]].pure[IO])
+
+  private def replayedRecord(offset: Long, event: String): ConsumerRecord[String, ByteVector] =
+    ConsumerRecord[String, ByteVector](
+      topicPartition   = tp,
+      offset           = Offset.unsafe(offset),
+      timestampAndType = None,
+      key              = WithSize(key.key).some,
+      value            = WithSize(ByteVector.encodeUtf8(event).toOption.get).some,
+    )
+
+  /** Recovers `key` at offset 5 while the partition is (re)assigned at offset 0 (a slower key held the commit back),
+    * then feeds `records` and fires the timers once, all in `TestControl`'s simulated time. Returns the stored snapshot
+    * afterwards. `executeEmbed` raises if the flow fails (e.g. a stale-write conflict from the offset-gated store) -
+    * the bug.
+    */
+  private def runRecoveredAheadOfCommit(
+    tick: TickOption[IO, KafkaSnapshot[String]],
+    timerFlowOf: TimerFlowOf[IO],
+    records: List[ConsumerRecord[String, ByteVector]],
+  ): Option[KafkaSnapshot[String]] = {
+    val program = for {
+      keyStorage      <- Ref.of[IO, Set[KafkaKey]](Set(key))
+      snapshotStorage <- Ref.of[IO, Map[KafkaKey, KafkaSnapshot[String]]](Map(key -> recoveredSnap))
+      keysOf           = KeysOf.of[IO, KafkaKey](KeyDatabase.memory[IO, KafkaKey](keyStorage.stateInstance))
+      snapshotsOf     <- offsetGatedDb(snapshotStorage).snapshotsOf
+      persistenceOf = PersistenceOf
+        .snapshotsOnly[IO, KafkaKey, KafkaSnapshot[String], ConsumerRecord[String, ByteVector]](keysOf, snapshotsOf)
+      timersOf <- TimersOf.memory[IO, KafkaKey]
+      keyStateOf = KeyStateOf.eagerRecovery[IO, KafkaSnapshot[String]](
+        applicationId = "app",
+        groupId       = "group",
+        keysOf        = keysOf,
+        timersOf      = timersOf,
+        persistenceOf = persistenceOf,
+        timerFlowOf   = timerFlowOf,
+        fold          = fold,
+        tick          = tick,
+        registry      = EntityRegistry.empty[IO, KafkaKey, KafkaSnapshot[String]],
+      )
+      _ <- PartitionFlow
+        .resource[IO](
+          topicPartition = tp,
+          assignedAt     = Offset.min,
+          keyStateOf     = keyStateOf,
+          config         = PartitionFlowConfig(triggerTimersInterval = 0.seconds),
+          scheduleCommit = ScheduleCommit.empty[IO],
+        )
+        .use { flow =>
+          // advance simulated time so the registered timer expires, then a poll fires it
+          IO.sleep(1.minute) *> flow(records)
+        }
+      stored <- snapshotStorage.get.map(_.get(key))
+    } yield stored
+
+    TestControl.executeEmbed(program).unsafeRunSync()
+  }
+
+  // flushes only on the timer, never periodically, so the tick is what acts
+  private val deleteOnTimer = TimerFlowOf.persistPeriodically[IO](fireEvery = 0.seconds, persistEvery = 1.hour)
+  // flushes on every timer tick, so a re-derived snapshot would be (re)persisted
+  private val flushOnTimer = TimerFlowOf.persistPeriodically[IO](fireEvery = 0.seconds, persistEvery = 0.seconds)
+
+  test("tick-delete of a recovered key (unprocessed) is fenced on the high-water offset") {
+    // an empty poll fires the tick while current.offset is still 0; the delete must be fenced on 5
+    val stored = runRecoveredAheadOfCommit(deletingTick, deleteOnTimer, records = List.empty)
+    assert(stored.isEmpty)
+  }
+
+  test("tick-delete after a replayed record (buffer offset would regress) is fenced on the high-water offset") {
+    // a replayed record at offset 2 (< 5) is folded first; the buffer must stay at 5 so the tick's delete applies
+    val stored = runRecoveredAheadOfCommit(deletingTick, deleteOnTimer, records = List(replayedRecord(2, "e3")))
+    assert(stored.isEmpty)
+  }
+
+  test("a periodic flush during replay below a recovered snapshot does not conflict") {
+    // a replayed record at offset 2 (< 5) with an identity tick and a flushing timer: the re-derived snapshot must not
+    // be persisted at offset 2; the recovered snapshot (offset 5) survives
+    val stored =
+      runRecoveredAheadOfCommit(TickOption.id[IO, KafkaSnapshot[String]], flushOnTimer, List(replayedRecord(2, "e3")))
+    assertEquals(stored.map(_.offset), recoveredAt.some)
+    assertEquals(stored.map(_.value), "recovered".some)
+  }
+
+}
+
+object SnapshotReplayFencingSpec {
+  final case class StaleWrite(stored: Offset, attempted: Offset)
+      extends RuntimeException(s"stale write: attempted $attempted, stored $stored")
+      with NoStackTrace
+}

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotReplayFencingSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotReplayFencingSpec.scala
@@ -84,6 +84,17 @@ class SnapshotReplayFencingSpec extends FunSuite {
       def get(key: KafkaKey): IO[Option[KafkaSnapshot[String]]] =
         storage.get.map(_.get(key).collect { case Stored.Live(snapshot) => snapshot })
 
+      // recovery surfaces the tombstone's offset as the replay-window floor (mirrors CassandraSnapshots.recover); a
+      // present row recovers as Present, a tombstone as Deleted(offset), no row as Absent
+      override def recover(key: KafkaKey)(implicit F: cats.Functor[IO]): IO[Recovered[KafkaSnapshot[String]]] =
+        storage
+          .get
+          .map(_.get(key) match {
+            case Some(Stored.Live(snapshot)) => Recovered.Present(snapshot)
+            case Some(Stored.Tombstone(o))   => Recovered.Deleted(o)
+            case None                        => Recovered.Absent
+          })
+
       def persist(key: KafkaKey, snapshot: KafkaSnapshot[String]): IO[Unit] =
         storage.modify { snapshots =>
           snapshots.get(key) match {
@@ -247,25 +258,27 @@ class SnapshotReplayFencingSpec extends FunSuite {
     assertEquals(stored.map(_.value), "recovered".some)
   }
 
-  // --- Tombstone replay-window finding -------------------------------------------------------------------------------
+  // --- Tombstone replay-window: the fix ------------------------------------------------------------------------------
   //
   // The three tests above show the replay-window fix (monotonic buffer + delete fenced on the high-water offset) for a
-  // *live* recovered snapshot. The fix needs that high-water offset X to be in the buffer after recovery. A tombstone
-  // is recovered as `None` (Cassandra's null `value`), so the buffer starts empty with no high-water: `SnapshotFold`'s
-  // `record.offset > snapshot.offset` filter is bypassed for a `None` state and the monotonic buffer climbs from the
-  // re-folded replayed offsets (all < X) instead of holding X. The store's offset guard still rejects a write/delete
-  // below X, so the *legitimate* owner fences itself. Each test below is the tombstone counterpart of a passing live
-  // test above; the only changed variable is live-snapshot vs tombstone. Safety is unaffected (the durable offset X
-  // never regresses); this is a liveness defect.
+  // *live* recovered snapshot, where the high-water offset X seeds the buffer. A tombstone reads back as `None`
+  // (Cassandra's null `value`), so before the fix the buffer started empty with no high-water and the monotonic buffer
+  // climbed from the re-folded replayed offsets (all < X); a flush mid-replay then persisted below X, which the
+  // offset-X tombstone rejected, fencing the *legitimate* owner (a livelock; safety was never at risk).
+  //
+  // The fix: recovery surfaces the tombstone's offset as the buffer floor (`SnapshotDatabase.recover` ->
+  // `Recovered.Deleted`, held by `Snapshots`), so a re-derived snapshot below X is dropped and the owner makes
+  // progress. Each test below is the tombstone counterpart of a passing live test above; the only changed variable is
+  // live-snapshot vs tombstone.
 
-  test("FINDING (persist path): a periodic flush during replay below a tombstoned key fences the legitimate owner") {
-    // counterpart of "a periodic flush during replay below a recovered snapshot does not conflict" (which passes):
-    // with a live snapshot the re-derived snapshot is dropped and the flush is a no-op; with a tombstone the re-derived
-    // snapshot is persisted at the replayed offset 2, which the offset-5 tombstone rejects
+  test("FIXED (persist path): a periodic flush during replay below a tombstoned key no longer fences the owner") {
+    // counterpart of "a periodic flush during replay below a recovered snapshot does not conflict": the re-derived
+    // snapshot at the replayed offset 2 is dropped at the recovered floor (5), so the flush is a no-op and the owner
+    // makes progress instead of self-fencing on the offset-5 tombstone
     val (outcome, stored) =
       runRecoveredFromTombstone(TickOption.id[IO, KafkaSnapshot[String]], flushOnTimer, List(replayedRecord(2, "e3")))
-    assert(clue(outcome).isLeft, "expected the legitimate owner to self-fence, but the flow completed")
-    assert(outcome.swap.exists(_.isInstanceOf[StaleWrite]), s"expected a StaleWrite conflict, got ${clue(outcome)}")
+    assert(clue(outcome).isRight, s"expected the legitimate owner to make progress, got ${clue(outcome)}")
+    // the floor held: nothing was persisted below the tombstone's offset, so the row is unchanged
     assertEquals(stored, Stored.Tombstone(recoveredAt).some)
   }
 
@@ -283,14 +296,12 @@ class SnapshotReplayFencingSpec extends FunSuite {
     assertEquals(stored, Stored.Live(KafkaSnapshot(offset = Offset.unsafe(2), value = "e3")).some)
   }
 
-  test("OBSERVATION (delete path is shadowed): a tick-delete during replay on a tombstone is a buffer-only delete") {
-    // The design doc calls the tick-delete the irreducible replay-window case for a *live* snapshot (`SnapshotFold`
-    // drops a re-derived snapshot, so only a delete reaches the store). For a tombstone that does not hold: after a
-    // `None` recovery nothing is marked persisted (`Persistence.read` calls `onPersisted` only for a `Some` state), so
-    // a tick-delete during replay is dispatched with persist=false - a buffer-only delete that never reaches the
-    // offset-gated store, hence no conflict. The persist path above reaches the store first and is the manifesting
-    // defect; the delete path is shadowed by it. Contrast the live counterpart, where the same tick issues a real
-    // store delete fenced on the high-water offset.
+  test("REGRESSION (delete path): a tick-delete during replay on a tombstone stays a buffer-only no-op") {
+    // The persist path was the only one that ever reached the store for a tombstone: after a `None` recovery nothing is
+    // marked persisted (`Persistence.read` calls `onPersisted` only for a `Some` state), so a tick-delete during replay
+    // is dispatched with persist=false - a buffer-only delete that never touches the offset-gated store. This holds
+    // before and after the fix; the test pins it so a future change to the recovered floor cannot turn it into a
+    // store delete fenced below the tombstone's offset.
     val (outcome, stored) =
       runRecoveredFromTombstone(deletingTick, deleteOnTimer, records = List(replayedRecord(2, "e3")))
     assert(clue(outcome).isRight, "a buffer-only delete must not reach the store")

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotReplayFencingSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotReplayFencingSpec.scala
@@ -67,6 +67,43 @@ class SnapshotReplayFencingSpec extends FunSuite {
         }.flatten
     }
 
+  import SnapshotReplayFencingSpec.Stored
+
+  /** Like [[offsetGatedDb]], but faithful to the Cassandra compare-and-set *delete*: a delete does not remove the row,
+    * it leaves an offset-carrying logical tombstone (mirrors `CassandraSnapshots.deleteCompareAndSet`'s `SET value =
+    * null, offset = :offset` and `decode` reading a null `value` back as `None`). So a deleted key reads back absent
+    * (`get` -> `None`) yet its stored `offset` still gates a later lower-offset write or delete - the guard that
+    * survives the delete. The store is seeded already holding such a tombstone (the key was deleted at its high-water
+    * offset and the tombstone has not been TTL-reaped).
+    */
+  private def tombstoneGatedDb(
+    storage: Ref[IO, Map[KafkaKey, Stored]]
+  ): SnapshotDatabase[IO, KafkaKey, KafkaSnapshot[String]] =
+    new SnapshotDatabase[IO, KafkaKey, KafkaSnapshot[String]] {
+      // a tombstone reads back as absent, exactly like Cassandra's null `value`
+      def get(key: KafkaKey): IO[Option[KafkaSnapshot[String]]] =
+        storage.get.map(_.get(key).collect { case Stored.Live(snapshot) => snapshot })
+
+      def persist(key: KafkaKey, snapshot: KafkaSnapshot[String]): IO[Unit] =
+        storage.modify { snapshots =>
+          snapshots.get(key) match {
+            case Some(stored) if stored.offset > snapshot.offset =>
+              (snapshots, StaleWrite(stored.offset, snapshot.offset).raiseError[IO, Unit])
+            case _ => (snapshots.updated(key, Stored.Live(snapshot)), ().pure[IO])
+          }
+        }.flatten
+
+      def delete(key: KafkaKey, offset: Offset): IO[Unit] =
+        storage.modify { snapshots =>
+          snapshots.get(key) match {
+            case Some(stored) if stored.offset > offset =>
+              (snapshots, StaleWrite(stored.offset, offset).raiseError[IO, Unit])
+            // keep the row as an offset-carrying tombstone (do not remove it): the offset guard survives the delete
+            case _ => (snapshots.updated(key, Stored.Tombstone(offset)), ().pure[IO])
+          }
+        }.flatten
+    }
+
   private val fold: FoldOption[IO, KafkaSnapshot[String], ConsumerRecord[String, ByteVector]] =
     FoldOption.of { (state, record) =>
       IO {
@@ -134,6 +171,56 @@ class SnapshotReplayFencingSpec extends FunSuite {
     TestControl.executeEmbed(program).unsafeRunSync()
   }
 
+  /** Same scenario as [[runRecoveredAheadOfCommit]] - a key whose stored offset (5) leads the committed offset the
+    * partition resumes from (0) - but the stored row is a `tombstoneGatedDb` *tombstone* rather than a live snapshot,
+    * and the store starts already holding it. The only changed variable versus the live tests above is therefore
+    * live-snapshot vs tombstone. Returns the flow's outcome (`Left` if it self-fenced) and the stored entry after.
+    */
+  private def runRecoveredFromTombstone(
+    tick: TickOption[IO, KafkaSnapshot[String]],
+    timerFlowOf: TimerFlowOf[IO],
+    records: List[ConsumerRecord[String, ByteVector]],
+    initial: Option[Stored] = Stored.Tombstone(recoveredAt).some,
+  ): (Either[Throwable, Unit], Option[Stored]) = {
+    val program = for {
+      keyStorage <- Ref.of[IO, Set[KafkaKey]](Set(key))
+      snapshotStorage <- Ref.of[IO, Map[KafkaKey, Stored]](
+        initial.fold(Map.empty[KafkaKey, Stored])(s => Map(key -> s))
+      )
+      keysOf       = KeysOf.of[IO, KafkaKey](KeyDatabase.memory[IO, KafkaKey](keyStorage.stateInstance))
+      snapshotsOf <- tombstoneGatedDb(snapshotStorage).snapshotsOf
+      persistenceOf = PersistenceOf
+        .snapshotsOnly[IO, KafkaKey, KafkaSnapshot[String], ConsumerRecord[String, ByteVector]](keysOf, snapshotsOf)
+      timersOf <- TimersOf.memory[IO, KafkaKey]
+      keyStateOf = KeyStateOf.eagerRecovery[IO, KafkaSnapshot[String]](
+        applicationId = "app",
+        groupId       = "group",
+        keysOf        = keysOf,
+        timersOf      = timersOf,
+        persistenceOf = persistenceOf,
+        timerFlowOf   = timerFlowOf,
+        fold          = fold,
+        tick          = tick,
+        registry      = EntityRegistry.empty[IO, KafkaKey, KafkaSnapshot[String]],
+      )
+      outcome <- PartitionFlow
+        .resource[IO](
+          topicPartition = tp,
+          assignedAt     = Offset.min,
+          keyStateOf     = keyStateOf,
+          config         = PartitionFlowConfig(triggerTimersInterval = 0.seconds),
+          scheduleCommit = ScheduleCommit.empty[IO],
+        )
+        .use { flow =>
+          IO.sleep(1.minute) *> flow(records)
+        }
+        .attempt
+      stored <- snapshotStorage.get.map(_.get(key))
+    } yield (outcome, stored)
+
+    TestControl.executeEmbed(program).unsafeRunSync()
+  }
+
   // flushes only on the timer, never periodically, so the tick is what acts
   private val deleteOnTimer = TimerFlowOf.persistPeriodically[IO](fireEvery = 0.seconds, persistEvery = 1.hour)
   // flushes on every timer tick, so a re-derived snapshot would be (re)persisted
@@ -160,10 +247,69 @@ class SnapshotReplayFencingSpec extends FunSuite {
     assertEquals(stored.map(_.value), "recovered".some)
   }
 
+  // --- Tombstone replay-window finding -------------------------------------------------------------------------------
+  //
+  // The three tests above show the replay-window fix (monotonic buffer + delete fenced on the high-water offset) for a
+  // *live* recovered snapshot. The fix needs that high-water offset X to be in the buffer after recovery. A tombstone
+  // is recovered as `None` (Cassandra's null `value`), so the buffer starts empty with no high-water: `SnapshotFold`'s
+  // `record.offset > snapshot.offset` filter is bypassed for a `None` state and the monotonic buffer climbs from the
+  // re-folded replayed offsets (all < X) instead of holding X. The store's offset guard still rejects a write/delete
+  // below X, so the *legitimate* owner fences itself. Each test below is the tombstone counterpart of a passing live
+  // test above; the only changed variable is live-snapshot vs tombstone. Safety is unaffected (the durable offset X
+  // never regresses); this is a liveness defect.
+
+  test("FINDING (persist path): a periodic flush during replay below a tombstoned key fences the legitimate owner") {
+    // counterpart of "a periodic flush during replay below a recovered snapshot does not conflict" (which passes):
+    // with a live snapshot the re-derived snapshot is dropped and the flush is a no-op; with a tombstone the re-derived
+    // snapshot is persisted at the replayed offset 2, which the offset-5 tombstone rejects
+    val (outcome, stored) =
+      runRecoveredFromTombstone(TickOption.id[IO, KafkaSnapshot[String]], flushOnTimer, List(replayedRecord(2, "e3")))
+    assert(clue(outcome).isLeft, "expected the legitimate owner to self-fence, but the flow completed")
+    assert(outcome.swap.exists(_.isInstanceOf[StaleWrite]), s"expected a StaleWrite conflict, got ${clue(outcome)}")
+    assertEquals(stored, Stored.Tombstone(recoveredAt).some)
+  }
+
+  test("CONTROL: once the tombstone is reaped (no offset guard), the same replay makes progress") {
+    // isolates the cause to the lingering tombstone offset, not the `None` recovery itself: with no row at all (the
+    // tombstone has been TTL-reaped), recovery is still `None` and the replayed record is still re-folded, but the
+    // flush now succeeds because there is no offset guard to reject it
+    val (outcome, stored) = runRecoveredFromTombstone(
+      TickOption.id[IO, KafkaSnapshot[String]],
+      flushOnTimer,
+      records = List(replayedRecord(2, "e3")),
+      initial = none,
+    )
+    assert(clue(outcome).isRight, "expected the owner to make progress once the offset guard is gone")
+    assertEquals(stored, Stored.Live(KafkaSnapshot(offset = Offset.unsafe(2), value = "e3")).some)
+  }
+
+  test("OBSERVATION (delete path is shadowed): a tick-delete during replay on a tombstone is a buffer-only delete") {
+    // The design doc calls the tick-delete the irreducible replay-window case for a *live* snapshot (`SnapshotFold`
+    // drops a re-derived snapshot, so only a delete reaches the store). For a tombstone that does not hold: after a
+    // `None` recovery nothing is marked persisted (`Persistence.read` calls `onPersisted` only for a `Some` state), so
+    // a tick-delete during replay is dispatched with persist=false - a buffer-only delete that never reaches the
+    // offset-gated store, hence no conflict. The persist path above reaches the store first and is the manifesting
+    // defect; the delete path is shadowed by it. Contrast the live counterpart, where the same tick issues a real
+    // store delete fenced on the high-water offset.
+    val (outcome, stored) =
+      runRecoveredFromTombstone(deletingTick, deleteOnTimer, records = List(replayedRecord(2, "e3")))
+    assert(clue(outcome).isRight, "a buffer-only delete must not reach the store")
+    assertEquals(stored, Stored.Tombstone(recoveredAt).some)
+  }
+
 }
 
 object SnapshotReplayFencingSpec {
   final case class StaleWrite(stored: Offset, attempted: Offset)
       extends RuntimeException(s"stale write: attempted $attempted, stored $stored")
       with NoStackTrace
+
+  /** A row in [[SnapshotReplayFencingSpec.tombstoneGatedDb]]: either a live snapshot or an offset-carrying logical
+    * tombstone (a deleted key whose `offset` guard is kept). Both expose the `offset` the compare-and-set guard checks.
+    */
+  sealed trait Stored { def offset: Offset }
+  object Stored {
+    final case class Live(snapshot: KafkaSnapshot[String]) extends Stored { def offset: Offset = snapshot.offset }
+    final case class Tombstone(offset: Offset) extends Stored
+  }
 }

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotReplayFencingSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotReplayFencingSpec.scala
@@ -7,6 +7,7 @@ import cats.syntax.all.*
 import com.evolutiongaming.catshelper.{Log, LogOf}
 import com.evolutiongaming.kafka.flow.effect.CatsEffectMtlInstances.*
 import com.evolutiongaming.kafka.flow.kafka.ScheduleCommit
+import com.evolutiongaming.kafka.flow.journal.JournalsOf
 import com.evolutiongaming.kafka.flow.key.{KeyDatabase, KeysOf}
 import com.evolutiongaming.kafka.flow.persistence.PersistenceOf
 import com.evolutiongaming.kafka.flow.registry.EntityRegistry
@@ -232,6 +233,60 @@ class SnapshotReplayFencingSpec extends FunSuite {
     TestControl.executeEmbed(program).unsafeRunSync()
   }
 
+  /** The events-recovery counterpart of [[runRecoveredFromTombstone]]: state is restored by folding the journal
+    * (`restoreEvents`), not from the snapshot. A deleted key's journal is empty, so the fold yields `None` and only the
+    * snapshot store still carries the deletion's high-water offset. `restoreEvents` must seed the buffer floor from
+    * that tombstone, or a replayed flush self-fences on the offset-gated tombstone exactly as the snapshot path did
+    * before its fix. The journal starts empty (the delete cleared it); the snapshot store starts holding the tombstone.
+    */
+  private def runRecoveredFromTombstoneViaEvents(
+    timerFlowOf: TimerFlowOf[IO],
+    records: List[ConsumerRecord[String, ByteVector]],
+  ): (Either[Throwable, Unit], Option[Stored]) = {
+    val program = for {
+      keyStorage      <- Ref.of[IO, Set[KafkaKey]](Set(key))
+      snapshotStorage <- Ref.of[IO, Map[KafkaKey, Stored]](Map(key -> Stored.Tombstone(recoveredAt)))
+      keysOf           = KeysOf.of[IO, KafkaKey](KeyDatabase.memory[IO, KafkaKey](keyStorage.stateInstance))
+      snapshotsOf     <- tombstoneGatedDb(snapshotStorage).snapshotsOf
+      journalsOf      <- JournalsOf.memory[IO, KafkaKey, ConsumerRecord[String, ByteVector]]
+      persistenceOf <- PersistenceOf
+        .restoreEvents[IO, KafkaKey, KafkaSnapshot[String], ConsumerRecord[String, ByteVector]](
+          keysOf,
+          journalsOf,
+          snapshotsOf,
+        )
+        .allocated
+        .map(_._1)
+      timersOf <- TimersOf.memory[IO, KafkaKey]
+      keyStateOf = KeyStateOf.eagerRecovery[IO, KafkaSnapshot[String]](
+        applicationId = "app",
+        groupId       = "group",
+        keysOf        = keysOf,
+        timersOf      = timersOf,
+        persistenceOf = persistenceOf,
+        timerFlowOf   = timerFlowOf,
+        fold          = fold,
+        tick          = TickOption.id[IO, KafkaSnapshot[String]],
+        registry      = EntityRegistry.empty[IO, KafkaKey, KafkaSnapshot[String]],
+      )
+      outcome <- PartitionFlow
+        .resource[IO](
+          topicPartition = tp,
+          assignedAt     = Offset.min,
+          keyStateOf     = keyStateOf,
+          config         = PartitionFlowConfig(triggerTimersInterval = 0.seconds),
+          scheduleCommit = ScheduleCommit.empty[IO],
+        )
+        .use { flow =>
+          IO.sleep(1.minute) *> flow(records)
+        }
+        .attempt
+      stored <- snapshotStorage.get.map(_.get(key))
+    } yield (outcome, stored)
+
+    TestControl.executeEmbed(program).unsafeRunSync()
+  }
+
   // flushes only on the timer, never periodically, so the tick is what acts
   private val deleteOnTimer = TimerFlowOf.persistPeriodically[IO](fireEvery = 0.seconds, persistEvery = 1.hour)
   // flushes on every timer tick, so a re-derived snapshot would be (re)persisted
@@ -305,6 +360,17 @@ class SnapshotReplayFencingSpec extends FunSuite {
     val (outcome, stored) =
       runRecoveredFromTombstone(deletingTick, deleteOnTimer, records = List(replayedRecord(2, "e3")))
     assert(clue(outcome).isRight, "a buffer-only delete must not reach the store")
+    assertEquals(stored, Stored.Tombstone(recoveredAt).some)
+  }
+
+  test("FIXED (events recovery): a deleted key replayed below its tombstone offset no longer fences the owner") {
+    // The `restoreEvents` counterpart of the persist-path tombstone test: the delete cleared the key's journal, so
+    // events recovery yields `None` and the high-water offset survives only on the snapshot tombstone. restoreEvents
+    // seeds the buffer floor from it, so the re-derived snapshot at the replayed offset 2 is dropped at the floor (5)
+    // and the flush is a no-op; without the seed the flush would persist below 5 and the offset-5 tombstone would
+    // reject the legitimate owner (the deleted-key journal-recovery replay window).
+    val (outcome, stored) = runRecoveredFromTombstoneViaEvents(flushOnTimer, List(replayedRecord(2, "e3")))
+    assert(clue(outcome).isRight, s"expected the legitimate owner to make progress, got ${clue(outcome)}")
     assertEquals(stored, Stored.Tombstone(recoveredAt).some)
   }
 

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotReplayFencingSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotReplayFencingSpec.scala
@@ -47,28 +47,33 @@ class SnapshotReplayFencingSpec extends FunSuite {
     storage: Ref[IO, Map[KafkaKey, KafkaSnapshot[String]]]
   ): SnapshotDatabase[IO, KafkaKey, KafkaSnapshot[String]] =
     new SnapshotDatabase[IO, KafkaKey, KafkaSnapshot[String]] {
-      def get(key: KafkaKey): IO[Option[KafkaSnapshot[String]]] = storage.get.map(_.get(key))
+      def read(key: KafkaKey): IO[Option[Stored[KafkaSnapshot[String]]]] =
+        storage.get.map(_.get(key).map(s => Stored.Live(s, s.offset.some)))
 
-      def persist(key: KafkaKey, snapshot: KafkaSnapshot[String]): IO[Unit] =
-        storage.modify { snapshots =>
-          snapshots.get(key) match {
-            case Some(stored) if stored.offset > snapshot.offset =>
-              (snapshots, StaleWrite(stored.offset, snapshot.offset).raiseError[IO, Unit])
-            case _ => (snapshots.updated(key, snapshot), ().pure[IO])
-          }
-        }.flatten
-
-      def delete(key: KafkaKey, offset: Offset): IO[Unit] =
-        storage.modify { snapshots =>
-          snapshots.get(key) match {
-            case Some(stored) if stored.offset > offset =>
-              (snapshots, StaleWrite(stored.offset, offset).raiseError[IO, Unit])
-            case _ => (snapshots.removed(key), ().pure[IO])
-          }
-        }.flatten
+      // a present value persists (gated on the snapshot's offset), an absent value deletes (gated on stored.offset)
+      def write(key: KafkaKey, stored: Stored[KafkaSnapshot[String]]): IO[Unit] =
+        stored.value match {
+          case Some(snapshot) =>
+            storage.modify { snapshots =>
+              snapshots.get(key) match {
+                case Some(existing) if existing.offset > snapshot.offset =>
+                  (snapshots, StaleWrite(existing.offset, snapshot.offset).raiseError[IO, Unit])
+                case _ => (snapshots.updated(key, snapshot), ().pure[IO])
+              }
+            }.flatten
+          case None =>
+            val offset = stored.offset.getOrElse(Offset.min)
+            storage.modify { snapshots =>
+              snapshots.get(key) match {
+                case Some(existing) if existing.offset > offset =>
+                  (snapshots, StaleWrite(existing.offset, offset).raiseError[IO, Unit])
+                case _ => (snapshots.removed(key), ().pure[IO])
+              }
+            }.flatten
+        }
     }
 
-  import SnapshotReplayFencingSpec.Stored
+  import SnapshotReplayFencingSpec.Row
 
   /** Like [[offsetGatedDb]], but faithful to the Cassandra compare-and-set *delete*: a delete does not remove the row,
     * it leaves an offset-carrying logical tombstone (mirrors `CassandraSnapshots.deleteCompareAndSet`'s `SET value =
@@ -78,42 +83,41 @@ class SnapshotReplayFencingSpec extends FunSuite {
     * offset and the tombstone has not been TTL-reaped).
     */
   private def tombstoneGatedDb(
-    storage: Ref[IO, Map[KafkaKey, Stored]]
+    storage: Ref[IO, Map[KafkaKey, Row]]
   ): SnapshotDatabase[IO, KafkaKey, KafkaSnapshot[String]] =
     new SnapshotDatabase[IO, KafkaKey, KafkaSnapshot[String]] {
-      // a tombstone reads back as absent, exactly like Cassandra's null `value`
-      def get(key: KafkaKey): IO[Option[KafkaSnapshot[String]]] =
-        storage.get.map(_.get(key).collect { case Stored.Live(snapshot) => snapshot })
-
-      // recovery surfaces the tombstone's offset as the replay-window floor (mirrors CassandraSnapshots.recover); a
-      // present row recovers as Present, a tombstone as Deleted(offset), no row as Absent
-      override def recover(key: KafkaKey)(implicit F: cats.Functor[IO]): IO[Recovered[KafkaSnapshot[String]]] =
+      // recovery surfaces the row as a Stored: a present row carries its value, a tombstone reads back value-less but
+      // keeps its offset as the replay-window floor (mirrors CassandraSnapshots.read), no row is None
+      def read(key: KafkaKey): IO[Option[Stored[KafkaSnapshot[String]]]] =
         storage
           .get
-          .map(_.get(key) match {
-            case Some(Stored.Live(snapshot)) => Recovered.Present(snapshot)
-            case Some(Stored.Tombstone(o))   => Recovered.Deleted(o)
-            case None                        => Recovered.Absent
+          .map(_.get(key).map {
+            case Row.Live(snapshot) => Stored.Live(snapshot, snapshot.offset.some)
+            case Row.Tombstone(o)   => Stored.Tombstone(o)
           })
 
-      def persist(key: KafkaKey, snapshot: KafkaSnapshot[String]): IO[Unit] =
-        storage.modify { snapshots =>
-          snapshots.get(key) match {
-            case Some(stored) if stored.offset > snapshot.offset =>
-              (snapshots, StaleWrite(stored.offset, snapshot.offset).raiseError[IO, Unit])
-            case _ => (snapshots.updated(key, Stored.Live(snapshot)), ().pure[IO])
-          }
-        }.flatten
-
-      def delete(key: KafkaKey, offset: Offset): IO[Unit] =
-        storage.modify { snapshots =>
-          snapshots.get(key) match {
-            case Some(stored) if stored.offset > offset =>
-              (snapshots, StaleWrite(stored.offset, offset).raiseError[IO, Unit])
-            // keep the row as an offset-carrying tombstone (do not remove it): the offset guard survives the delete
-            case _ => (snapshots.updated(key, Stored.Tombstone(offset)), ().pure[IO])
-          }
-        }.flatten
+      // a present value persists (gated on the snapshot's offset); an absent value leaves an offset-carrying tombstone
+      // (gated on stored.offset) rather than removing the row, so the offset guard survives the delete
+      def write(key: KafkaKey, stored: Stored[KafkaSnapshot[String]]): IO[Unit] =
+        stored.value match {
+          case Some(snapshot) =>
+            storage.modify { snapshots =>
+              snapshots.get(key) match {
+                case Some(existing) if existing.offset > snapshot.offset =>
+                  (snapshots, StaleWrite(existing.offset, snapshot.offset).raiseError[IO, Unit])
+                case _ => (snapshots.updated(key, Row.Live(snapshot)), ().pure[IO])
+              }
+            }.flatten
+          case None =>
+            val offset = stored.offset.getOrElse(Offset.min)
+            storage.modify { snapshots =>
+              snapshots.get(key) match {
+                case Some(existing) if existing.offset > offset =>
+                  (snapshots, StaleWrite(existing.offset, offset).raiseError[IO, Unit])
+                case _ => (snapshots.updated(key, Row.Tombstone(offset)), ().pure[IO])
+              }
+            }.flatten
+        }
     }
 
   private val fold: FoldOption[IO, KafkaSnapshot[String], ConsumerRecord[String, ByteVector]] =
@@ -192,12 +196,12 @@ class SnapshotReplayFencingSpec extends FunSuite {
     tick: TickOption[IO, KafkaSnapshot[String]],
     timerFlowOf: TimerFlowOf[IO],
     records: List[ConsumerRecord[String, ByteVector]],
-    initial: Option[Stored] = Stored.Tombstone(recoveredAt).some,
-  ): (Either[Throwable, Unit], Option[Stored]) = {
+    initial: Option[Row] = Row.Tombstone(recoveredAt).some,
+  ): (Either[Throwable, Unit], Option[Row]) = {
     val program = for {
       keyStorage <- Ref.of[IO, Set[KafkaKey]](Set(key))
-      snapshotStorage <- Ref.of[IO, Map[KafkaKey, Stored]](
-        initial.fold(Map.empty[KafkaKey, Stored])(s => Map(key -> s))
+      snapshotStorage <- Ref.of[IO, Map[KafkaKey, Row]](
+        initial.fold(Map.empty[KafkaKey, Row])(s => Map(key -> s))
       )
       keysOf       = KeysOf.of[IO, KafkaKey](KeyDatabase.memory[IO, KafkaKey](keyStorage.stateInstance))
       snapshotsOf <- tombstoneGatedDb(snapshotStorage).snapshotsOf
@@ -242,10 +246,10 @@ class SnapshotReplayFencingSpec extends FunSuite {
   private def runRecoveredFromTombstoneViaEvents(
     timerFlowOf: TimerFlowOf[IO],
     records: List[ConsumerRecord[String, ByteVector]],
-  ): (Either[Throwable, Unit], Option[Stored]) = {
+  ): (Either[Throwable, Unit], Option[Row]) = {
     val program = for {
       keyStorage      <- Ref.of[IO, Set[KafkaKey]](Set(key))
-      snapshotStorage <- Ref.of[IO, Map[KafkaKey, Stored]](Map(key -> Stored.Tombstone(recoveredAt)))
+      snapshotStorage <- Ref.of[IO, Map[KafkaKey, Row]](Map(key -> Row.Tombstone(recoveredAt)))
       keysOf           = KeysOf.of[IO, KafkaKey](KeyDatabase.memory[IO, KafkaKey](keyStorage.stateInstance))
       snapshotsOf     <- tombstoneGatedDb(snapshotStorage).snapshotsOf
       journalsOf      <- JournalsOf.memory[IO, KafkaKey, ConsumerRecord[String, ByteVector]]
@@ -334,7 +338,7 @@ class SnapshotReplayFencingSpec extends FunSuite {
       runRecoveredFromTombstone(TickOption.id[IO, KafkaSnapshot[String]], flushOnTimer, List(replayedRecord(2, "e3")))
     assert(clue(outcome).isRight, s"expected the legitimate owner to make progress, got ${clue(outcome)}")
     // the floor held: nothing was persisted below the tombstone's offset, so the row is unchanged
-    assertEquals(stored, Stored.Tombstone(recoveredAt).some)
+    assertEquals(stored, Row.Tombstone(recoveredAt).some)
   }
 
   test("CONTROL: once the tombstone is reaped (no offset guard), the same replay makes progress") {
@@ -348,7 +352,7 @@ class SnapshotReplayFencingSpec extends FunSuite {
       initial = none,
     )
     assert(clue(outcome).isRight, "expected the owner to make progress once the offset guard is gone")
-    assertEquals(stored, Stored.Live(KafkaSnapshot(offset = Offset.unsafe(2), value = "e3")).some)
+    assertEquals(stored, Row.Live(KafkaSnapshot(offset = Offset.unsafe(2), value = "e3")).some)
   }
 
   test("REGRESSION (delete path): a tick-delete during replay on a tombstone stays a buffer-only no-op") {
@@ -360,7 +364,7 @@ class SnapshotReplayFencingSpec extends FunSuite {
     val (outcome, stored) =
       runRecoveredFromTombstone(deletingTick, deleteOnTimer, records = List(replayedRecord(2, "e3")))
     assert(clue(outcome).isRight, "a buffer-only delete must not reach the store")
-    assertEquals(stored, Stored.Tombstone(recoveredAt).some)
+    assertEquals(stored, Row.Tombstone(recoveredAt).some)
   }
 
   test("FIXED (events recovery): a deleted key replayed below its tombstone offset no longer fences the owner") {
@@ -371,7 +375,7 @@ class SnapshotReplayFencingSpec extends FunSuite {
     // reject the legitimate owner (the deleted-key journal-recovery replay window).
     val (outcome, stored) = runRecoveredFromTombstoneViaEvents(flushOnTimer, List(replayedRecord(2, "e3")))
     assert(clue(outcome).isRight, s"expected the legitimate owner to make progress, got ${clue(outcome)}")
-    assertEquals(stored, Stored.Tombstone(recoveredAt).some)
+    assertEquals(stored, Row.Tombstone(recoveredAt).some)
   }
 
 }
@@ -384,9 +388,9 @@ object SnapshotReplayFencingSpec {
   /** A row in [[SnapshotReplayFencingSpec.tombstoneGatedDb]]: either a live snapshot or an offset-carrying logical
     * tombstone (a deleted key whose `offset` guard is kept). Both expose the `offset` the compare-and-set guard checks.
     */
-  sealed trait Stored { def offset: Offset }
-  object Stored {
-    final case class Live(snapshot: KafkaSnapshot[String]) extends Stored { def offset: Offset = snapshot.offset }
-    final case class Tombstone(offset: Offset) extends Stored
+  sealed trait Row { def offset: Offset }
+  object Row {
+    final case class Live(snapshot: KafkaSnapshot[String]) extends Row { def offset: Offset = snapshot.offset }
+    final case class Tombstone(offset: Offset) extends Row
   }
 }

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotReplayFencingSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotReplayFencingSpec.scala
@@ -325,8 +325,8 @@ class SnapshotReplayFencingSpec extends FunSuite {
   // climbed from the re-folded replayed offsets (all < X); a flush mid-replay then persisted below X, which the
   // offset-X tombstone rejected, fencing the *legitimate* owner (a livelock; safety was never at risk).
   //
-  // The fix: recovery surfaces the tombstone's offset as the buffer floor (`SnapshotDatabase.recover` ->
-  // `Recovered.Deleted`, held by `Snapshots`), so a re-derived snapshot below X is dropped and the owner makes
+  // The fix: recovery surfaces the tombstone's offset as the buffer floor (`SnapshotDatabase.read` ->
+  // `Stored.Tombstone`, held by `Snapshots`), so a re-derived snapshot below X is dropped and the owner makes
   // progress. Each test below is the tombstone counterpart of a passing live test above; the only changed variable is
   // live-snapshot vs tombstone.
 
@@ -376,6 +376,17 @@ class SnapshotReplayFencingSpec extends FunSuite {
     val (outcome, stored) = runRecoveredFromTombstoneViaEvents(flushOnTimer, List(replayedRecord(2, "e3")))
     assert(clue(outcome).isRight, s"expected the legitimate owner to make progress, got ${clue(outcome)}")
     assertEquals(stored, Row.Tombstone(recoveredAt).some)
+  }
+
+  test(
+    "events recovery: a replayed event at/above the recovered tombstone offset is persisted (floor does not over-fence)"
+  ) {
+    // counterpart of the below-floor events-recovery test: an event at offset 7 (>= the tombstone floor 5) is a
+    // legitimate post-deletion re-creation; the floor must not drop it. It is folded, buffered and flushed, replacing
+    // the tombstone with a live snapshot at offset 7 - confirming the floor fences only below-floor replays.
+    val (outcome, stored) = runRecoveredFromTombstoneViaEvents(flushOnTimer, List(replayedRecord(7, "e7")))
+    assert(clue(outcome).isRight, s"expected the >= floor event to be persisted, got ${clue(outcome)}")
+    assertEquals(stored, Row.Live(KafkaSnapshot(offset = Offset.unsafe(7), value = "e7")).some)
   }
 
 }

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotReplayFencingSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotReplayFencingSpec.scala
@@ -1,0 +1,408 @@
+package com.evolutiongaming.kafka.flow.snapshot
+
+import cats.effect.testkit.TestControl
+import cats.effect.unsafe.implicits.global
+import cats.effect.{IO, Ref}
+import cats.syntax.all.*
+import com.evolutiongaming.catshelper.{Log, LogOf}
+import com.evolutiongaming.kafka.flow.effect.CatsEffectMtlInstances.*
+import com.evolutiongaming.kafka.flow.kafka.ScheduleCommit
+import com.evolutiongaming.kafka.flow.journal.JournalsOf
+import com.evolutiongaming.kafka.flow.key.{KeyDatabase, KeysOf}
+import com.evolutiongaming.kafka.flow.persistence.PersistenceOf
+import com.evolutiongaming.kafka.flow.registry.EntityRegistry
+import com.evolutiongaming.kafka.flow.timer.{TimerFlowOf, TimersOf}
+import com.evolutiongaming.kafka.flow.{FoldOption, KafkaKey, KeyStateOf, PartitionFlow, PartitionFlowConfig, TickOption}
+import com.evolutiongaming.skafka.consumer.{ConsumerRecord, WithSize}
+import com.evolutiongaming.skafka.{Offset, Partition, TopicPartition}
+import munit.FunSuite
+import scodec.bits.ByteVector
+
+import scala.concurrent.duration.*
+import scala.util.control.NoStackTrace
+
+/** `TestControl`-driven flow-level regressions for the compare-and-set replay-window fix (simulated time).
+  *
+  * A key is recovered with a snapshot whose offset (5) leads the committed offset the partition resumes from (0). While
+  * replaying events below it (`current.offset` < 5) the buffer must stay at the high-water offset, so a delete is
+  * fenced on 5 (not the processing offset) and a re-derived snapshot is not re-persisted below 5 - otherwise the
+  * offset-gated store below rejects the legitimate owner as stale.
+  */
+class SnapshotReplayFencingSpec extends FunSuite {
+
+  private implicit val logOf: LogOf[IO] = LogOf.empty[IO]
+  private implicit val log: Log[IO]     = Log.empty[IO]
+
+  private val tp            = TopicPartition("topic", Partition.min)
+  private val key           = KafkaKey("app", "group", tp, "key1")
+  private val recoveredAt   = Offset.unsafe(5)
+  private val recoveredSnap = KafkaSnapshot(offset = recoveredAt, value = "recovered")
+
+  import SnapshotReplayFencingSpec.StaleWrite
+
+  /** In-memory snapshot store mimicking the Cassandra compare-and-set guard `IF offset <= :offset`: a write or delete
+    * whose offset is below the stored one is rejected.
+    */
+  private def offsetGatedDb(
+    storage: Ref[IO, Map[KafkaKey, KafkaSnapshot[String]]]
+  ): SnapshotDatabase[IO, KafkaKey, KafkaSnapshot[String]] =
+    new SnapshotDatabase[IO, KafkaKey, KafkaSnapshot[String]] {
+      def read(key: KafkaKey): IO[Option[Stored[KafkaSnapshot[String]]]] =
+        storage.get.map(_.get(key).map(s => Stored.Live(s, s.offset.some)))
+
+      // a present value persists (gated on the snapshot's offset), an absent value deletes (gated on stored.offset)
+      def write(key: KafkaKey, stored: Stored[KafkaSnapshot[String]]): IO[Unit] =
+        stored.value match {
+          case Some(snapshot) =>
+            storage.modify { snapshots =>
+              snapshots.get(key) match {
+                case Some(existing) if existing.offset > snapshot.offset =>
+                  (snapshots, StaleWrite(existing.offset, snapshot.offset).raiseError[IO, Unit])
+                case _ => (snapshots.updated(key, snapshot), ().pure[IO])
+              }
+            }.flatten
+          case None =>
+            val offset = stored.offset.getOrElse(Offset.min)
+            storage.modify { snapshots =>
+              snapshots.get(key) match {
+                case Some(existing) if existing.offset > offset =>
+                  (snapshots, StaleWrite(existing.offset, offset).raiseError[IO, Unit])
+                case _ => (snapshots.removed(key), ().pure[IO])
+              }
+            }.flatten
+        }
+    }
+
+  import SnapshotReplayFencingSpec.Row
+
+  /** Like [[offsetGatedDb]], but faithful to the Cassandra compare-and-set *delete*: a delete does not remove the row,
+    * it leaves an offset-carrying logical tombstone (mirrors `CassandraSnapshots.deleteCompareAndSet`'s `SET value =
+    * null, offset = :offset` and `decode` reading a null `value` back as `None`). So a deleted key reads back absent
+    * (`get` -> `None`) yet its stored `offset` still gates a later lower-offset write or delete - the guard that
+    * survives the delete. The store is seeded already holding such a tombstone (the key was deleted at its high-water
+    * offset and the tombstone has not been TTL-reaped).
+    */
+  private def tombstoneGatedDb(
+    storage: Ref[IO, Map[KafkaKey, Row]]
+  ): SnapshotDatabase[IO, KafkaKey, KafkaSnapshot[String]] =
+    new SnapshotDatabase[IO, KafkaKey, KafkaSnapshot[String]] {
+      // recovery surfaces the row as a Stored: a present row carries its value, a tombstone reads back value-less but
+      // keeps its offset as the replay-window floor (mirrors CassandraSnapshots.read), no row is None
+      def read(key: KafkaKey): IO[Option[Stored[KafkaSnapshot[String]]]] =
+        storage
+          .get
+          .map(_.get(key).map {
+            case Row.Live(snapshot) => Stored.Live(snapshot, snapshot.offset.some)
+            case Row.Tombstone(o)   => Stored.Tombstone(o)
+          })
+
+      // a present value persists (gated on the snapshot's offset); an absent value leaves an offset-carrying tombstone
+      // (gated on stored.offset) rather than removing the row, so the offset guard survives the delete
+      def write(key: KafkaKey, stored: Stored[KafkaSnapshot[String]]): IO[Unit] =
+        stored.value match {
+          case Some(snapshot) =>
+            storage.modify { snapshots =>
+              snapshots.get(key) match {
+                case Some(existing) if existing.offset > snapshot.offset =>
+                  (snapshots, StaleWrite(existing.offset, snapshot.offset).raiseError[IO, Unit])
+                case _ => (snapshots.updated(key, Row.Live(snapshot)), ().pure[IO])
+              }
+            }.flatten
+          case None =>
+            val offset = stored.offset.getOrElse(Offset.min)
+            storage.modify { snapshots =>
+              snapshots.get(key) match {
+                case Some(existing) if existing.offset > offset =>
+                  (snapshots, StaleWrite(existing.offset, offset).raiseError[IO, Unit])
+                case _ => (snapshots.updated(key, Row.Tombstone(offset)), ().pure[IO])
+              }
+            }.flatten
+        }
+    }
+
+  private val fold: FoldOption[IO, KafkaSnapshot[String], ConsumerRecord[String, ByteVector]] =
+    FoldOption.of { (state, record) =>
+      IO {
+        val event = record.value.flatMap(_.value.decodeUtf8.toOption).getOrElse(sys.error("event payload missing"))
+        KafkaSnapshot(offset = record.offset, value = state.fold(event)(s => s"${s.value},$event")).some
+      }
+    }
+
+  private val deletingTick: TickOption[IO, KafkaSnapshot[String]] =
+    TickOption.of[IO, KafkaSnapshot[String]](_ => none[KafkaSnapshot[String]].pure[IO])
+
+  private def replayedRecord(offset: Long, event: String): ConsumerRecord[String, ByteVector] =
+    ConsumerRecord[String, ByteVector](
+      topicPartition   = tp,
+      offset           = Offset.unsafe(offset),
+      timestampAndType = None,
+      key              = WithSize(key.key).some,
+      value            = WithSize(ByteVector.encodeUtf8(event).toOption.get).some,
+    )
+
+  /** Recovers `key` at offset 5 while the partition is (re)assigned at offset 0 (a slower key held the commit back),
+    * then feeds `records` and fires the timers once, all in `TestControl`'s simulated time. Returns the stored snapshot
+    * afterwards. `executeEmbed` raises if the flow fails (e.g. a stale-write conflict from the offset-gated store) -
+    * the bug.
+    */
+  private def runRecoveredAheadOfCommit(
+    tick: TickOption[IO, KafkaSnapshot[String]],
+    timerFlowOf: TimerFlowOf[IO],
+    records: List[ConsumerRecord[String, ByteVector]],
+  ): Option[KafkaSnapshot[String]] = {
+    val program = for {
+      keyStorage      <- Ref.of[IO, Set[KafkaKey]](Set(key))
+      snapshotStorage <- Ref.of[IO, Map[KafkaKey, KafkaSnapshot[String]]](Map(key -> recoveredSnap))
+      keysOf           = KeysOf.of[IO, KafkaKey](KeyDatabase.memory[IO, KafkaKey](keyStorage.stateInstance))
+      snapshotsOf     <- offsetGatedDb(snapshotStorage).snapshotsOf
+      persistenceOf = PersistenceOf
+        .snapshotsOnly[IO, KafkaKey, KafkaSnapshot[String], ConsumerRecord[String, ByteVector]](keysOf, snapshotsOf)
+      timersOf <- TimersOf.memory[IO, KafkaKey]
+      keyStateOf = KeyStateOf.eagerRecovery[IO, KafkaSnapshot[String]](
+        applicationId = "app",
+        groupId       = "group",
+        keysOf        = keysOf,
+        timersOf      = timersOf,
+        persistenceOf = persistenceOf,
+        timerFlowOf   = timerFlowOf,
+        fold          = fold,
+        tick          = tick,
+        registry      = EntityRegistry.empty[IO, KafkaKey, KafkaSnapshot[String]],
+      )
+      _ <- PartitionFlow
+        .resource[IO](
+          topicPartition = tp,
+          assignedAt     = Offset.min,
+          keyStateOf     = keyStateOf,
+          config         = PartitionFlowConfig(triggerTimersInterval = 0.seconds),
+          scheduleCommit = ScheduleCommit.empty[IO],
+        )
+        .use { flow =>
+          // advance simulated time so the registered timer expires, then a poll fires it
+          IO.sleep(1.minute) *> flow(records)
+        }
+      stored <- snapshotStorage.get.map(_.get(key))
+    } yield stored
+
+    TestControl.executeEmbed(program).unsafeRunSync()
+  }
+
+  /** Same scenario as [[runRecoveredAheadOfCommit]] - a key whose stored offset (5) leads the committed offset the
+    * partition resumes from (0) - but the stored row is a `tombstoneGatedDb` *tombstone* rather than a live snapshot,
+    * and the store starts already holding it. The only changed variable versus the live tests above is therefore
+    * live-snapshot vs tombstone. Returns the flow's outcome (`Left` if it self-fenced) and the stored entry after.
+    */
+  private def runRecoveredFromTombstone(
+    tick: TickOption[IO, KafkaSnapshot[String]],
+    timerFlowOf: TimerFlowOf[IO],
+    records: List[ConsumerRecord[String, ByteVector]],
+    initial: Option[Row] = Row.Tombstone(recoveredAt).some,
+  ): (Either[Throwable, Unit], Option[Row]) = {
+    val program = for {
+      keyStorage <- Ref.of[IO, Set[KafkaKey]](Set(key))
+      snapshotStorage <- Ref.of[IO, Map[KafkaKey, Row]](
+        initial.fold(Map.empty[KafkaKey, Row])(s => Map(key -> s))
+      )
+      keysOf       = KeysOf.of[IO, KafkaKey](KeyDatabase.memory[IO, KafkaKey](keyStorage.stateInstance))
+      snapshotsOf <- tombstoneGatedDb(snapshotStorage).snapshotsOf
+      persistenceOf = PersistenceOf
+        .snapshotsOnly[IO, KafkaKey, KafkaSnapshot[String], ConsumerRecord[String, ByteVector]](keysOf, snapshotsOf)
+      timersOf <- TimersOf.memory[IO, KafkaKey]
+      keyStateOf = KeyStateOf.eagerRecovery[IO, KafkaSnapshot[String]](
+        applicationId = "app",
+        groupId       = "group",
+        keysOf        = keysOf,
+        timersOf      = timersOf,
+        persistenceOf = persistenceOf,
+        timerFlowOf   = timerFlowOf,
+        fold          = fold,
+        tick          = tick,
+        registry      = EntityRegistry.empty[IO, KafkaKey, KafkaSnapshot[String]],
+      )
+      outcome <- PartitionFlow
+        .resource[IO](
+          topicPartition = tp,
+          assignedAt     = Offset.min,
+          keyStateOf     = keyStateOf,
+          config         = PartitionFlowConfig(triggerTimersInterval = 0.seconds),
+          scheduleCommit = ScheduleCommit.empty[IO],
+        )
+        .use { flow =>
+          IO.sleep(1.minute) *> flow(records)
+        }
+        .attempt
+      stored <- snapshotStorage.get.map(_.get(key))
+    } yield (outcome, stored)
+
+    TestControl.executeEmbed(program).unsafeRunSync()
+  }
+
+  /** The events-recovery counterpart of [[runRecoveredFromTombstone]]: state is restored by folding the journal
+    * (`restoreEvents`), not from the snapshot. A deleted key's journal is empty, so the fold yields `None` and only the
+    * snapshot store still carries the deletion's high-water offset. `restoreEvents` must seed the buffer floor from
+    * that tombstone, or a replayed flush self-fences on the offset-gated tombstone exactly as the snapshot path did
+    * before its fix. The journal starts empty (the delete cleared it); the snapshot store starts holding the tombstone.
+    */
+  private def runRecoveredFromTombstoneViaEvents(
+    timerFlowOf: TimerFlowOf[IO],
+    records: List[ConsumerRecord[String, ByteVector]],
+  ): (Either[Throwable, Unit], Option[Row]) = {
+    val program = for {
+      keyStorage      <- Ref.of[IO, Set[KafkaKey]](Set(key))
+      snapshotStorage <- Ref.of[IO, Map[KafkaKey, Row]](Map(key -> Row.Tombstone(recoveredAt)))
+      keysOf           = KeysOf.of[IO, KafkaKey](KeyDatabase.memory[IO, KafkaKey](keyStorage.stateInstance))
+      snapshotsOf     <- tombstoneGatedDb(snapshotStorage).snapshotsOf
+      journalsOf      <- JournalsOf.memory[IO, KafkaKey, ConsumerRecord[String, ByteVector]]
+      persistenceOf <- PersistenceOf
+        .restoreEvents[IO, KafkaKey, KafkaSnapshot[String], ConsumerRecord[String, ByteVector]](
+          keysOf,
+          journalsOf,
+          snapshotsOf,
+          _.offset,
+        )
+        .allocated
+        .map(_._1)
+      timersOf <- TimersOf.memory[IO, KafkaKey]
+      keyStateOf = KeyStateOf.eagerRecovery[IO, KafkaSnapshot[String]](
+        applicationId = "app",
+        groupId       = "group",
+        keysOf        = keysOf,
+        timersOf      = timersOf,
+        persistenceOf = persistenceOf,
+        timerFlowOf   = timerFlowOf,
+        fold          = fold,
+        tick          = TickOption.id[IO, KafkaSnapshot[String]],
+        registry      = EntityRegistry.empty[IO, KafkaKey, KafkaSnapshot[String]],
+      )
+      outcome <- PartitionFlow
+        .resource[IO](
+          topicPartition = tp,
+          assignedAt     = Offset.min,
+          keyStateOf     = keyStateOf,
+          config         = PartitionFlowConfig(triggerTimersInterval = 0.seconds),
+          scheduleCommit = ScheduleCommit.empty[IO],
+        )
+        .use { flow =>
+          IO.sleep(1.minute) *> flow(records)
+        }
+        .attempt
+      stored <- snapshotStorage.get.map(_.get(key))
+    } yield (outcome, stored)
+
+    TestControl.executeEmbed(program).unsafeRunSync()
+  }
+
+  // flushes only on the timer, never periodically, so the tick is what acts
+  private val deleteOnTimer = TimerFlowOf.persistPeriodically[IO](fireEvery = 0.seconds, persistEvery = 1.hour)
+  // flushes on every timer tick, so a re-derived snapshot would be (re)persisted
+  private val flushOnTimer = TimerFlowOf.persistPeriodically[IO](fireEvery = 0.seconds, persistEvery = 0.seconds)
+
+  test("tick-delete of a recovered key (unprocessed) is fenced on the high-water offset") {
+    // an empty poll fires the tick while current.offset is still 0; the delete must be fenced on 5
+    val stored = runRecoveredAheadOfCommit(deletingTick, deleteOnTimer, records = List.empty)
+    assert(stored.isEmpty)
+  }
+
+  test("tick-delete after a replayed record (buffer offset would regress) is fenced on the high-water offset") {
+    // a replayed record at offset 2 (< 5) is folded first; the buffer must stay at 5 so the tick's delete applies
+    val stored = runRecoveredAheadOfCommit(deletingTick, deleteOnTimer, records = List(replayedRecord(2, "e3")))
+    assert(stored.isEmpty)
+  }
+
+  test("a periodic flush during replay below a recovered snapshot does not conflict") {
+    // a replayed record at offset 2 (< 5) with an identity tick and a flushing timer: the re-derived snapshot must not
+    // be persisted at offset 2; the recovered snapshot (offset 5) survives
+    val stored =
+      runRecoveredAheadOfCommit(TickOption.id[IO, KafkaSnapshot[String]], flushOnTimer, List(replayedRecord(2, "e3")))
+    assertEquals(stored.map(_.offset), recoveredAt.some)
+    assertEquals(stored.map(_.value), "recovered".some)
+  }
+
+  // --- Tombstone replay-window: the fix ------------------------------------------------------------------------------
+  //
+  // The three tests above show the replay-window fix (monotonic buffer + delete fenced on the high-water offset) for a
+  // *live* recovered snapshot, where the high-water offset X seeds the buffer. A tombstone reads back as `None`
+  // (Cassandra's null `value`), so before the fix the buffer started empty with no high-water and the monotonic buffer
+  // climbed from the re-folded replayed offsets (all < X); a flush mid-replay then persisted below X, which the
+  // offset-X tombstone rejected, fencing the *legitimate* owner (a livelock; safety was never at risk).
+  //
+  // The fix: recovery surfaces the tombstone's offset as the buffer floor (`SnapshotDatabase.read` ->
+  // `Stored.Tombstone`, held by `Snapshots`), so a re-derived snapshot below X is dropped and the owner makes
+  // progress. Each test below is the tombstone counterpart of a passing live test above; the only changed variable is
+  // live-snapshot vs tombstone.
+
+  test("FIXED (persist path): a periodic flush during replay below a tombstoned key no longer fences the owner") {
+    // counterpart of "a periodic flush during replay below a recovered snapshot does not conflict": the re-derived
+    // snapshot at the replayed offset 2 is dropped at the recovered floor (5), so the flush is a no-op and the owner
+    // makes progress instead of self-fencing on the offset-5 tombstone
+    val (outcome, stored) =
+      runRecoveredFromTombstone(TickOption.id[IO, KafkaSnapshot[String]], flushOnTimer, List(replayedRecord(2, "e3")))
+    assert(clue(outcome).isRight, s"expected the legitimate owner to make progress, got ${clue(outcome)}")
+    // the floor held: nothing was persisted below the tombstone's offset, so the row is unchanged
+    assertEquals(stored, Row.Tombstone(recoveredAt).some)
+  }
+
+  test("CONTROL: once the tombstone is reaped (no offset guard), the same replay makes progress") {
+    // isolates the cause to the lingering tombstone offset, not the `None` recovery itself: with no row at all (the
+    // tombstone has been TTL-reaped), recovery is still `None` and the replayed record is still re-folded, but the
+    // flush now succeeds because there is no offset guard to reject it
+    val (outcome, stored) = runRecoveredFromTombstone(
+      TickOption.id[IO, KafkaSnapshot[String]],
+      flushOnTimer,
+      records = List(replayedRecord(2, "e3")),
+      initial = none,
+    )
+    assert(clue(outcome).isRight, "expected the owner to make progress once the offset guard is gone")
+    assertEquals(stored, Row.Live(KafkaSnapshot(offset = Offset.unsafe(2), value = "e3")).some)
+  }
+
+  test("REGRESSION (delete path): a tick-delete during replay on a tombstone stays a buffer-only no-op") {
+    // The persist path was the only one that ever reached the store for a tombstone: after a `None` recovery nothing is
+    // marked persisted (`Persistence.read` calls `onPersisted` only for a `Some` state), so a tick-delete during replay
+    // is dispatched with persist=false - a buffer-only delete that never touches the offset-gated store. This holds
+    // before and after the fix; the test pins it so a future change to the recovered floor cannot turn it into a
+    // store delete fenced below the tombstone's offset.
+    val (outcome, stored) =
+      runRecoveredFromTombstone(deletingTick, deleteOnTimer, records = List(replayedRecord(2, "e3")))
+    assert(clue(outcome).isRight, "a buffer-only delete must not reach the store")
+    assertEquals(stored, Row.Tombstone(recoveredAt).some)
+  }
+
+  test("FIXED (events recovery): a deleted key replayed below its tombstone offset no longer fences the owner") {
+    // The `restoreEvents` counterpart of the persist-path tombstone test: the delete cleared the key's journal, so
+    // events recovery yields `None` and the high-water offset survives only on the snapshot tombstone. restoreEvents
+    // seeds the buffer floor from it, so the re-derived snapshot at the replayed offset 2 is dropped at the floor (5)
+    // and the flush is a no-op; without the seed the flush would persist below 5 and the offset-5 tombstone would
+    // reject the legitimate owner (the deleted-key journal-recovery replay window).
+    val (outcome, stored) = runRecoveredFromTombstoneViaEvents(flushOnTimer, List(replayedRecord(2, "e3")))
+    assert(clue(outcome).isRight, s"expected the legitimate owner to make progress, got ${clue(outcome)}")
+    assertEquals(stored, Row.Tombstone(recoveredAt).some)
+  }
+
+  test(
+    "events recovery: a replayed event at/above the recovered tombstone offset is persisted (floor does not over-fence)"
+  ) {
+    // counterpart of the below-floor events-recovery test: an event at offset 7 (>= the tombstone floor 5) is a
+    // legitimate post-deletion re-creation; the floor must not drop it. It is folded, buffered and flushed, replacing
+    // the tombstone with a live snapshot at offset 7 - confirming the floor fences only below-floor replays.
+    val (outcome, stored) = runRecoveredFromTombstoneViaEvents(flushOnTimer, List(replayedRecord(7, "e7")))
+    assert(clue(outcome).isRight, s"expected the >= floor event to be persisted, got ${clue(outcome)}")
+    assertEquals(stored, Row.Live(KafkaSnapshot(offset = Offset.unsafe(7), value = "e7")).some)
+  }
+
+}
+
+object SnapshotReplayFencingSpec {
+  final case class StaleWrite(stored: Offset, attempted: Offset)
+      extends RuntimeException(s"stale write: attempted $attempted, stored $stored")
+      with NoStackTrace
+
+  /** A row in [[SnapshotReplayFencingSpec.tombstoneGatedDb]]: either a live snapshot or an offset-carrying logical
+    * tombstone (a deleted key whose `offset` guard is kept). Both expose the `offset` the compare-and-set guard checks.
+    */
+  sealed trait Row { def offset: Offset }
+  object Row {
+    final case class Live(snapshot: KafkaSnapshot[String]) extends Row { def offset: Offset = snapshot.offset }
+    final case class Tombstone(offset: Offset) extends Row
+  }
+}

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotsOfSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotsOfSpec.scala
@@ -1,0 +1,70 @@
+package com.evolutiongaming.kafka.flow.snapshot
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import cats.syntax.all.*
+import com.evolutiongaming.catshelper.{Log, LogOf}
+import com.evolutiongaming.kafka.flow.KafkaKey
+import com.evolutiongaming.skafka.{Offset, Partition, TopicPartition}
+import munit.FunSuite
+
+/** The offset fence lives in the `KafkaSnapshot` path (`SnapshotDatabase.snapshotsOf`), not the generic `backedBy`:
+  *
+  *   - `snapshotsOf` fences on `KafkaSnapshot.offset` - a lower-offset (replayed) append is dropped, the high-water
+  *     snapshot survives;
+  *   - `backedBy` is plain last-write-wins - the later append wins regardless of offset.
+  *
+  * Pins both behaviours so neither silently flips.
+  */
+class SnapshotsOfSpec extends FunSuite {
+
+  private implicit val logOf: LogOf[IO] = LogOf.empty[IO]
+  private implicit val log: Log[IO]     = Log.empty[IO]
+
+  private val key = KafkaKey("app", "group", TopicPartition("topic", Partition.min), "key1")
+
+  private def snap(offset: Long, value: Int): KafkaSnapshot[Int] =
+    KafkaSnapshot(offset = Offset.unsafe(offset), value = value)
+
+  test("snapshotsOf fences on KafkaSnapshot.offset: a lower-offset replayed append is dropped") {
+    val stored = (for {
+      db          <- SnapshotDatabase.memory[IO, KafkaKey, KafkaSnapshot[Int]]
+      snapshotsOf <- db.snapshotsOf
+      snapshots   <- snapshotsOf(key)
+      _           <- snapshots.append(snap(offset = 5, value = 50))
+      _           <- snapshots.append(snap(offset = 3, value = 30)) // replayed, lower offset: must be dropped
+      _           <- snapshots.flush
+      stored      <- db.read(key).map(_.flatMap(_.value))
+    } yield stored).unsafeRunSync()
+
+    assertEquals(stored, snap(offset = 5, value = 50).some)
+  }
+
+  test("backedBy is last-write-wins: a lower-offset append overwrites (no fence)") {
+    val stored = (for {
+      db        <- SnapshotDatabase.memory[IO, KafkaKey, KafkaSnapshot[Int]]
+      snapshots <- SnapshotsOf.backedBy(db).apply(key)
+      _         <- snapshots.append(snap(offset = 5, value = 50))
+      _         <- snapshots.append(snap(offset = 3, value = 30)) // later append wins regardless of offset
+      _         <- snapshots.flush
+      stored    <- db.read(key).map(_.flatMap(_.value))
+    } yield stored).unsafeRunSync()
+
+    assertEquals(stored, snap(offset = 3, value = 30).some)
+  }
+
+  test("backedBy with an explicit offsetOf fences a custom (non-KafkaSnapshot) offset-carrying snapshot") {
+    type S = (Offset, Int) // a BYO offset-carrying snapshot type, not KafkaSnapshot
+    val stored = (for {
+      db        <- SnapshotDatabase.memory[IO, KafkaKey, S]
+      snapshots <- SnapshotsOf.backedBy[IO, KafkaKey, S](db, (s: S) => s._1).apply(key)
+      _         <- snapshots.append((Offset.unsafe(5), 50))
+      _         <- snapshots.append((Offset.unsafe(3), 30)) // lower offset: must be dropped
+      _         <- snapshots.flush
+      stored    <- db.read(key).map(_.flatMap(_.value))
+    } yield stored).unsafeRunSync()
+
+    assertEquals(stored, (Offset.unsafe(5), 50).some)
+  }
+
+}

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotsOfSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotsOfSpec.scala
@@ -8,7 +8,7 @@ import com.evolutiongaming.kafka.flow.KafkaKey
 import com.evolutiongaming.skafka.{Offset, Partition, TopicPartition}
 import munit.FunSuite
 
-/** The offset fence lives in the `KafkaSnapshot` path ([[SnapshotDatabase.snapshotsOf]]), not the generic `backedBy`:
+/** The offset fence lives in the `KafkaSnapshot` path (`SnapshotDatabase.snapshotsOf`), not the generic `backedBy`:
   *
   *   - `snapshotsOf` fences on `KafkaSnapshot.offset` - a lower-offset (replayed) append is dropped, the high-water
   *     snapshot survives;

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotsOfSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotsOfSpec.scala
@@ -1,0 +1,70 @@
+package com.evolutiongaming.kafka.flow.snapshot
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import cats.syntax.all.*
+import com.evolutiongaming.catshelper.{Log, LogOf}
+import com.evolutiongaming.kafka.flow.KafkaKey
+import com.evolutiongaming.skafka.{Offset, Partition, TopicPartition}
+import munit.FunSuite
+
+/** The offset fence lives in the `KafkaSnapshot` path ([[SnapshotDatabase.snapshotsOf]]), not the generic `backedBy`:
+  *
+  *   - `snapshotsOf` fences on `KafkaSnapshot.offset` - a lower-offset (replayed) append is dropped, the high-water
+  *     snapshot survives;
+  *   - `backedBy` is plain last-write-wins - the later append wins regardless of offset.
+  *
+  * Pins both behaviours so neither silently flips.
+  */
+class SnapshotsOfSpec extends FunSuite {
+
+  private implicit val logOf: LogOf[IO] = LogOf.empty[IO]
+  private implicit val log: Log[IO]     = Log.empty[IO]
+
+  private val key = KafkaKey("app", "group", TopicPartition("topic", Partition.min), "key1")
+
+  private def snap(offset: Long, value: Int): KafkaSnapshot[Int] =
+    KafkaSnapshot(offset = Offset.unsafe(offset), value = value)
+
+  test("snapshotsOf fences on KafkaSnapshot.offset: a lower-offset replayed append is dropped") {
+    val stored = (for {
+      db          <- SnapshotDatabase.memory[IO, KafkaKey, KafkaSnapshot[Int]]
+      snapshotsOf <- db.snapshotsOf
+      snapshots   <- snapshotsOf(key)
+      _           <- snapshots.append(snap(offset = 5, value = 50))
+      _           <- snapshots.append(snap(offset = 3, value = 30)) // replayed, lower offset: must be dropped
+      _           <- snapshots.flush
+      stored      <- db.get(key)
+    } yield stored).unsafeRunSync()
+
+    assertEquals(stored, snap(offset = 5, value = 50).some)
+  }
+
+  test("backedBy is last-write-wins: a lower-offset append overwrites (no fence)") {
+    val stored = (for {
+      db        <- SnapshotDatabase.memory[IO, KafkaKey, KafkaSnapshot[Int]]
+      snapshots <- SnapshotsOf.backedBy(db).apply(key)
+      _         <- snapshots.append(snap(offset = 5, value = 50))
+      _         <- snapshots.append(snap(offset = 3, value = 30)) // later append wins regardless of offset
+      _         <- snapshots.flush
+      stored    <- db.get(key)
+    } yield stored).unsafeRunSync()
+
+    assertEquals(stored, snap(offset = 3, value = 30).some)
+  }
+
+  test("backedBy with an explicit offsetOf fences a custom (non-KafkaSnapshot) offset-carrying snapshot") {
+    type S = (Offset, Int) // a BYO offset-carrying snapshot type, not KafkaSnapshot
+    val stored = (for {
+      db        <- SnapshotDatabase.memory[IO, KafkaKey, S]
+      snapshots <- SnapshotsOf.backedBy[IO, KafkaKey, S](db, (s: S) => s._1).apply(key)
+      _         <- snapshots.append((Offset.unsafe(5), 50))
+      _         <- snapshots.append((Offset.unsafe(3), 30)) // lower offset: must be dropped
+      _         <- snapshots.flush
+      stored    <- db.get(key)
+    } yield stored).unsafeRunSync()
+
+    assertEquals(stored, (Offset.unsafe(5), 50).some)
+  }
+
+}

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotsOfSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotsOfSpec.scala
@@ -34,7 +34,7 @@ class SnapshotsOfSpec extends FunSuite {
       _           <- snapshots.append(snap(offset = 5, value = 50))
       _           <- snapshots.append(snap(offset = 3, value = 30)) // replayed, lower offset: must be dropped
       _           <- snapshots.flush
-      stored      <- db.get(key)
+      stored      <- db.read(key).map(_.flatMap(_.value))
     } yield stored).unsafeRunSync()
 
     assertEquals(stored, snap(offset = 5, value = 50).some)
@@ -47,7 +47,7 @@ class SnapshotsOfSpec extends FunSuite {
       _         <- snapshots.append(snap(offset = 5, value = 50))
       _         <- snapshots.append(snap(offset = 3, value = 30)) // later append wins regardless of offset
       _         <- snapshots.flush
-      stored    <- db.get(key)
+      stored    <- db.read(key).map(_.flatMap(_.value))
     } yield stored).unsafeRunSync()
 
     assertEquals(stored, snap(offset = 3, value = 30).some)
@@ -61,7 +61,7 @@ class SnapshotsOfSpec extends FunSuite {
       _         <- snapshots.append((Offset.unsafe(5), 50))
       _         <- snapshots.append((Offset.unsafe(3), 30)) // lower offset: must be dropped
       _         <- snapshots.flush
-      stored    <- db.get(key)
+      stored    <- db.read(key).map(_.flatMap(_.value))
     } yield stored).unsafeRunSync()
 
     assertEquals(stored, (Offset.unsafe(5), 50).some)

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotsSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotsSpec.scala
@@ -158,6 +158,46 @@ class SnapshotsSpec extends FunSuite {
     assertEquals(result.database.get("key1"), Some(10))
   }
 
+  test("Snapshots does not re-persist a same-offset, unchanged-value append onto a persisted snapshot") {
+    val f = new ConstFixture
+
+    val database  = countingSnapshotDb(f.database)
+    val snapshots = Snapshots("key1", database, f.state, intOffset)
+    // recovered/persisted at offset 10
+    val context = Context(
+      database = Map("key1" -> 10),
+      state    = live(10, persisted = true, offset = Offset.unsafe(10).some)
+    )
+
+    // re-deriving the same snapshot at the same offset (an idempotent replay) must not re-persist
+    val program = snapshots.append(10) *> snapshots.flush
+    val result  = program.runS(context).value
+
+    assert(database.persistsCounted == 0)
+    assertEquals(result.database.get("key1"), Some(10))
+  }
+
+  test("Snapshots re-persists a same-offset append whose value changed (e.g. a timer-driven state change)") {
+    val f = new ConstFixture
+
+    // offset fixed at 10 regardless of value, so a changed value can share the stored offset (a timer tick that
+    // changes state without consuming a record); the compare-and-set guard admits an equal offset
+    val fixedAt10: Option[S => Offset] = Some(_ => Offset.unsafe(10))
+    val database                       = countingSnapshotDb(f.database)
+    val snapshots                      = Snapshots("key1", database, f.state, fixedAt10)
+    val context = Context(
+      database = Map("key1" -> 100),
+      state    = live(100, persisted = true, offset = Offset.unsafe(10).some)
+    )
+
+    // the timer changes the state (100 -> 101) without advancing the offset; the same-offset write must persist
+    val program = snapshots.append(101) *> snapshots.flush
+    val result  = program.runS(context).value
+
+    assert(database.persistsCounted == 1)
+    assertEquals(result.database.get("key1"), Some(101))
+  }
+
   test("Snapshots fences a delete on the buffered snapshot's offset when it leads the requested offset") {
     val f = new ConstFixture
 

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotsSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotsSpec.scala
@@ -5,7 +5,6 @@ import cats.mtl.Stateful
 import cats.syntax.all.*
 import com.evolutiongaming.catshelper.Log
 import com.evolutiongaming.kafka.flow.MonadStateHelper.*
-import com.evolutiongaming.kafka.flow.kafka.ToOffset
 import com.evolutiongaming.kafka.flow.snapshot.SnapshotsSpec.*
 import com.evolutiongaming.skafka.Offset
 import monocle.macros.GenLens
@@ -19,7 +18,7 @@ class SnapshotsSpec extends FunSuite {
 
     // Given("empty database")
     val database  = SnapshotDatabase.memory(f.database)
-    val snapshots = Snapshots("key1", database, f.buffer)
+    val snapshots = Snapshots("key1", database, f.buffer, noFence)
 
     // When("buffer is filled with state")
     val program =
@@ -40,7 +39,7 @@ class SnapshotsSpec extends FunSuite {
 
     // Given("empty database")
     val database  = SnapshotDatabase.memory(f.database)
-    val snapshots = Snapshots("key1", database, f.buffer)
+    val snapshots = Snapshots("key1", database, f.buffer, noFence)
 
     // When("buffer is filled with state")
     // And("Snapshots is flushed")
@@ -63,14 +62,14 @@ class SnapshotsSpec extends FunSuite {
 
     // Given("database with contents")
     val database  = SnapshotDatabase.memory(f.database)
-    val snapshots = Snapshots("key1", database, f.buffer)
+    val snapshots = Snapshots("key1", database, f.buffer, noFence)
     val context = Context(
       database = Map("key1" -> 102),
       buffer   = Some(Snapshots.Snapshot(103, persisted = false))
     )
 
     // When("delete is requested")
-    val program = snapshots.delete(true)
+    val program = snapshots.delete(true, Offset.min)
     val result  = program.runS(context).value
 
     // Then("buffer is cleared")
@@ -86,14 +85,14 @@ class SnapshotsSpec extends FunSuite {
 
     // Given("database with contents")
     val database  = SnapshotDatabase.memory(f.database)
-    val snapshots = Snapshots("key1", database, f.buffer)
+    val snapshots = Snapshots("key1", database, f.buffer, noFence)
     val context = Context(
       database = Map("key1" -> 102),
       buffer   = Some(Snapshots.Snapshot(103, persisted = false))
     )
 
     // When("delete is requested")
-    val program = snapshots.delete(false)
+    val program = snapshots.delete(false, Offset.min)
     val result  = program.runS(context).value
 
     // Then("buffer is cleared")
@@ -103,13 +102,92 @@ class SnapshotsSpec extends FunSuite {
 
   }
 
+  test("Snapshots forwards the delete offset to the database") {
+
+    val f = new ConstFixture
+
+    // Given("a database capturing the offset passed to delete")
+    val database = new SnapshotDatabase[F, K, S] {
+      def persist(key: K, snapshot: S)   = ().pure[F]
+      def get(key: K)                    = none[S].pure[F]
+      def delete(key: K, offset: Offset) = State.modify[Context](_.copy(deletedOffset = offset.some))
+    }
+    val snapshots = Snapshots("key1", database, f.buffer, noFence)
+
+    // When("delete is requested with a specific offset")
+    val offset  = Offset.unsafe(77)
+    val program = snapshots.delete(true, offset)
+    val result  = program.runS(Context()).value
+
+    // Then("the database delete receives that offset")
+    assertEquals(result.deletedOffset, offset.some)
+  }
+
+  // Fix: a recovered key's snapshot offset can lead the committed offset the partition resumes from; while replaying
+  // events below it the buffer must stay at the high-water offset so a compare-and-set backend does not reject a
+  // legitimate delete or a re-persist as stale. `intOffset` makes the Int state its own offset.
+
+  test("Snapshots keeps the higher-offset snapshot and drops a lower-offset (replayed) append") {
+    val f = new ConstFixture
+
+    val database  = SnapshotDatabase.memory(f.database)
+    val snapshots = Snapshots("key1", database, f.buffer, intOffset)
+
+    // append at offset 5, then a replayed append at offset 3 (lower) which must be dropped, then flush
+    val program = snapshots.append(5) *> snapshots.append(3) *> snapshots.flush
+    val result  = program.runS(Context()).value
+
+    // the higher-offset snapshot survives; the lower-offset append did not regress the buffer
+    assertEquals(result.database.get("key1"), Some(5))
+    assertEquals(result.buffer.map(_.value), Some(5))
+  }
+
+  test("Snapshots does not re-persist after a lower-offset (replayed) append onto a persisted snapshot") {
+    val f = new ConstFixture
+
+    val database  = countingSnapshotDb(f.database)
+    val snapshots = Snapshots("key1", database, f.buffer, intOffset)
+    // the key was recovered/persisted at offset 10
+    val context = Context(
+      database = Map("key1" -> 10),
+      buffer   = Some(Snapshots.Snapshot(10, persisted = true))
+    )
+
+    // a replayed event at offset 3 followed by a flush must not re-persist at the lower offset
+    val program = snapshots.append(3) *> snapshots.flush
+    val result  = program.runS(context).value
+
+    assert(database.persistsCounted == 0)
+    assertEquals(result.database.get("key1"), Some(10))
+  }
+
+  test("Snapshots fences a delete on the buffered snapshot's offset when it leads the requested offset") {
+    val f = new ConstFixture
+
+    val database = new SnapshotDatabase[F, K, S] {
+      def persist(key: K, snapshot: S)   = ().pure[F]
+      def get(key: K)                    = none[S].pure[F]
+      def delete(key: K, offset: Offset) = State.modify[Context](_.copy(deletedOffset = offset.some))
+    }
+    val snapshots = Snapshots("key1", database, f.buffer, intOffset)
+    // buffer holds the recovered snapshot at offset 7
+    val context = Context(buffer = Some(Snapshots.Snapshot(7, persisted = true)))
+
+    // a delete requested at the (lower) processing offset 2 must be fenced on the buffered offset 7
+    val program = snapshots.delete(true, Offset.unsafe(2))
+    val result  = program.runS(context).value
+
+    assertEquals(result.deletedOffset, Offset.unsafe(7).some)
+    assert(result.buffer.isEmpty)
+  }
+
   test("Snapshots does not persist the same snapshot more than once") {
 
     val f = new ConstFixture
 
     // Given("database with contents")
     val database  = countingSnapshotDb(f.database)
-    val snapshots = Snapshots("key1", database, f.buffer)
+    val snapshots = Snapshots("key1", database, f.buffer, noFence)
     val context = Context(
       database = Map("key1" -> 102),
       buffer   = Some(Snapshots.Snapshot(103, persisted = false))
@@ -132,7 +210,7 @@ class SnapshotsSpec extends FunSuite {
 
     // Given("database without contents")
     val database  = countingSnapshotDb(f.database)
-    val snapshots = Snapshots("key1", database, f.buffer)
+    val snapshots = Snapshots("key1", database, f.buffer, noFence)
     val context = Context(
       database = Map.empty,
       buffer   = None
@@ -155,9 +233,14 @@ object SnapshotsSpec {
   type K = String
   type S = Int
 
+  // no offset fence (last-write-wins); and the Int state as its own offset (fence active)
+  val noFence: S => Offset   = _ => Offset.min
+  val intOffset: S => Offset = i => Offset.unsafe(i.toLong)
+
   case class Context(
     database: Map[K, S]                   = Map.empty,
-    buffer: Option[Snapshots.Snapshot[S]] = None
+    buffer: Option[Snapshots.Snapshot[S]] = None,
+    deletedOffset: Option[Offset]         = None
   )
 
   class ConstFixture {
@@ -166,8 +249,6 @@ object SnapshotsSpec {
   }
 
   implicit val log: Log[F] = Log.empty[F]
-
-  implicit val withOffset: ToOffset[S] = Offset.unsafe(_)
 
   trait SnapshotDatabaseWithPersistCount extends SnapshotDatabase[F, K, S] {
     def persistsCounted: Int
@@ -185,10 +266,10 @@ object SnapshotsSpec {
       def get(key: K) =
         db.get(key)
 
-      def delete(key: K) =
-        db.delete(key)
+      def delete(key: K, offset: Offset) =
+        db.delete(key, offset)
 
-      def persistsCounted: SnapshotsSpec.S = persistCounter
+      def persistsCounted: Int = persistCounter
     }
   }
 

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotsSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotsSpec.scala
@@ -5,7 +5,7 @@ import cats.mtl.Stateful
 import cats.syntax.all.*
 import com.evolutiongaming.catshelper.Log
 import com.evolutiongaming.kafka.flow.MonadStateHelper.*
-import com.evolutiongaming.kafka.flow.snapshot.Snapshots.Buffered
+import com.evolutiongaming.kafka.flow.snapshot.Snapshots.Cell
 import com.evolutiongaming.kafka.flow.snapshot.SnapshotsSpec.*
 import com.evolutiongaming.skafka.Offset
 import monocle.macros.GenLens
@@ -66,7 +66,7 @@ class SnapshotsSpec extends FunSuite {
     val snapshots = Snapshots("key1", database, f.state, noFence)
     val context = Context(
       database = Map("key1" -> 102),
-      state    = Buffered.Live(103, persisted = false)
+      state    = live(103, persisted = false, offset = none)
     )
 
     // When("delete is requested")
@@ -89,7 +89,7 @@ class SnapshotsSpec extends FunSuite {
     val snapshots = Snapshots("key1", database, f.state, noFence)
     val context = Context(
       database = Map("key1" -> 102),
-      state    = Buffered.Live(103, persisted = false)
+      state    = live(103, persisted = false, offset = none)
     )
 
     // When("delete is requested")
@@ -107,12 +107,8 @@ class SnapshotsSpec extends FunSuite {
 
     val f = new ConstFixture
 
-    // Given("a database capturing the offset passed to delete")
-    val database = new SnapshotDatabase[F, K, S] {
-      def persist(key: K, snapshot: S)   = ().pure[F]
-      def get(key: K)                    = none[S].pure[F]
-      def delete(key: K, offset: Offset) = State.modify[Context](_.copy(deletedOffset = offset.some))
-    }
+    // Given("a database capturing the offset passed to the (value-less) write")
+    val database  = offsetCapturingDb
     val snapshots = Snapshots("key1", database, f.state, noFence)
 
     // When("delete is requested with a specific offset")
@@ -120,7 +116,7 @@ class SnapshotsSpec extends FunSuite {
     val program = snapshots.delete(true, offset)
     val result  = program.runS(Context()).value
 
-    // Then("the database delete receives that offset")
+    // Then("the database write receives that offset")
     assertEquals(result.deletedOffset, offset.some)
   }
 
@@ -151,7 +147,7 @@ class SnapshotsSpec extends FunSuite {
     // the key was recovered/persisted at offset 10
     val context = Context(
       database = Map("key1" -> 10),
-      state    = Buffered.Live(10, persisted = true)
+      state    = live(10, persisted = true, offset = Offset.unsafe(10).some)
     )
 
     // a replayed event at offset 3 followed by a flush must not re-persist at the lower offset
@@ -165,14 +161,10 @@ class SnapshotsSpec extends FunSuite {
   test("Snapshots fences a delete on the buffered snapshot's offset when it leads the requested offset") {
     val f = new ConstFixture
 
-    val database = new SnapshotDatabase[F, K, S] {
-      def persist(key: K, snapshot: S)   = ().pure[F]
-      def get(key: K)                    = none[S].pure[F]
-      def delete(key: K, offset: Offset) = State.modify[Context](_.copy(deletedOffset = offset.some))
-    }
+    val database  = offsetCapturingDb
     val snapshots = Snapshots("key1", database, f.state, intOffset)
     // buffer holds the recovered snapshot at offset 7
-    val context = Context(state = Buffered.Live(7, persisted = true))
+    val context = Context(state = live(7, persisted = true, offset = Offset.unsafe(7).some))
 
     // a delete requested at the (lower) processing offset 2 must be fenced on the buffered offset 7
     val program = snapshots.delete(true, Offset.unsafe(2))
@@ -185,19 +177,16 @@ class SnapshotsSpec extends FunSuite {
   test("Snapshots recovers an offset-carrying tombstone as the high-water floor (reads back absent)") {
     val f = new ConstFixture
 
-    // a store whose `recover` reports a deleted key with a tombstone at offset 5 (and `get` reads it back absent)
+    // a store whose `read` reports a deleted key as a value-less Stored carrying the tombstone offset 5
     val database = new SnapshotDatabase[F, K, S] {
-      def persist(key: K, snapshot: S)   = ().pure[F]
-      def get(key: K)                    = none[S].pure[F]
-      def delete(key: K, offset: Offset) = ().pure[F]
-      override def recover(key: K)(implicit F0: cats.Functor[F]) =
-        (Recovered.Deleted(Offset.unsafe(5)): Recovered[S]).pure[F]
+      def write(key: K, stored: Stored[S]) = ().pure[F]
+      def read(key: K)                     = (Stored.Tombstone(Offset.unsafe(5)): Stored[S]).some.pure[F]
     }
     val snapshots = Snapshots("key1", database, f.state, intOffset)
 
     // read returns no state (the key is deleted) but seeds the floor at 5
     val result = snapshots.read.runS(Context()).value
-    assertEquals(result.state, Buffered.Deleted(Offset.unsafe(5)): Buffered[S])
+    assertEquals(result.state, tombstone(Offset.unsafe(5)))
   }
 
   test("Snapshots drops a replayed append below the recovered tombstone floor, keeps one at/above it") {
@@ -206,7 +195,7 @@ class SnapshotsSpec extends FunSuite {
     val database  = SnapshotDatabase.memory(f.database)
     val snapshots = Snapshots("key1", database, f.state, intOffset)
     // recovered from a tombstone at offset 5 (no buffered snapshot, floor = 5)
-    val context = Context(state = Buffered.Deleted(Offset.unsafe(5)))
+    val context = Context(state = tombstone(Offset.unsafe(5)))
 
     // a replayed event at offset 3 (< 5) must be dropped; a later event at offset 7 (>= 5) is buffered and persisted
     val program = snapshots.append(3) *> snapshots.flush *> snapshots.append(7) *> snapshots.flush
@@ -225,7 +214,7 @@ class SnapshotsSpec extends FunSuite {
     val snapshots = Snapshots("key1", database, f.state, noFence)
     val context = Context(
       database = Map("key1" -> 102),
-      state    = Buffered.Live(103, persisted = false)
+      state    = live(103, persisted = false, offset = none)
     )
 
     // When("flush is requested multiple times")
@@ -248,7 +237,7 @@ class SnapshotsSpec extends FunSuite {
     val snapshots = Snapshots("key1", database, f.state, noFence)
     val context = Context(
       database = Map.empty,
-      state    = Buffered.Empty
+      state    = none
     )
 
     // When("snapshot is initialized and flush is requested")
@@ -272,15 +261,20 @@ object SnapshotsSpec {
   val noFence: Option[S => Offset]   = None
   val intOffset: Option[S => Offset] = Some(i => Offset.unsafe(i.toLong))
 
+  // a live buffer cell at `offset` (the fence path supplies one, the last-write-wins path passes none)
+  def live(value: S, persisted: Boolean, offset: Option[Offset]): Option[Cell[S]] =
+    Cell(Stored.Live(value, offset), persisted).some
+
+  // a recovered/left tombstone floor: value-less but carrying its offset, already persisted
+  def tombstone(offset: Offset): Option[Cell[S]] =
+    Cell(Stored.Tombstone(offset), persisted = true).some
+
   // the live snapshot's value if the buffer holds one, else None (a tombstone floor or an empty cell holds no value)
-  def liveValue(state: Buffered[S]): Option[S] = state match {
-    case Buffered.Live(value, _) => value.some
-    case _                       => none[S]
-  }
+  def liveValue(state: Option[Cell[S]]): Option[S] = state.flatMap(_.stored.value)
 
   case class Context(
     database: Map[K, S]           = Map.empty,
-    state: Buffered[S]            = Buffered.Empty,
+    state: Option[Cell[S]]        = None,
     deletedOffset: Option[Offset] = None
   )
 
@@ -291,6 +285,16 @@ object SnapshotsSpec {
 
   implicit val log: Log[F] = Log.empty[F]
 
+  // captures the offset of a value-less (delete) write, so a test can assert the offset forwarded to the store
+  val offsetCapturingDb: SnapshotDatabase[F, K, S] = new SnapshotDatabase[F, K, S] {
+    def read(key: K) = none[Stored[S]].pure[F]
+    def write(key: K, stored: Stored[S]) =
+      stored.value match {
+        case Some(_) => ().pure[F]
+        case None    => State.modify[Context](_.copy(deletedOffset = stored.offset))
+      }
+  }
+
   trait SnapshotDatabaseWithPersistCount extends SnapshotDatabase[F, K, S] {
     def persistsCounted: Int
   }
@@ -299,16 +303,13 @@ object SnapshotsSpec {
     new SnapshotDatabaseWithPersistCount {
       val db             = SnapshotDatabase.memory(storage)
       var persistCounter = 0
-      def persist(key: K, snapshot: S) = {
-        persistCounter += 1
-        db.persist(key, snapshot)
+      def write(key: K, stored: Stored[S]) = {
+        if (stored.value.isDefined) persistCounter += 1 // count persists, not tombstone deletes
+        db.write(key, stored)
       }
 
-      def get(key: K) =
-        db.get(key)
-
-      def delete(key: K, offset: Offset) =
-        db.delete(key, offset)
+      def read(key: K) =
+        db.read(key)
 
       def persistsCounted: Int = persistCounter
     }

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotsSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotsSpec.scala
@@ -18,7 +18,7 @@ class SnapshotsSpec extends FunSuite {
 
     // Given("empty database")
     val database  = SnapshotDatabase.memory(f.database)
-    val snapshots = Snapshots("key1", database, f.buffer, noFence)
+    val snapshots = Snapshots("key1", database, f.buffer, f.floor, noFence)
 
     // When("buffer is filled with state")
     val program =
@@ -39,7 +39,7 @@ class SnapshotsSpec extends FunSuite {
 
     // Given("empty database")
     val database  = SnapshotDatabase.memory(f.database)
-    val snapshots = Snapshots("key1", database, f.buffer, noFence)
+    val snapshots = Snapshots("key1", database, f.buffer, f.floor, noFence)
 
     // When("buffer is filled with state")
     // And("Snapshots is flushed")
@@ -62,7 +62,7 @@ class SnapshotsSpec extends FunSuite {
 
     // Given("database with contents")
     val database  = SnapshotDatabase.memory(f.database)
-    val snapshots = Snapshots("key1", database, f.buffer, noFence)
+    val snapshots = Snapshots("key1", database, f.buffer, f.floor, noFence)
     val context = Context(
       database = Map("key1" -> 102),
       buffer   = Some(Snapshots.Snapshot(103, persisted = false))
@@ -85,7 +85,7 @@ class SnapshotsSpec extends FunSuite {
 
     // Given("database with contents")
     val database  = SnapshotDatabase.memory(f.database)
-    val snapshots = Snapshots("key1", database, f.buffer, noFence)
+    val snapshots = Snapshots("key1", database, f.buffer, f.floor, noFence)
     val context = Context(
       database = Map("key1" -> 102),
       buffer   = Some(Snapshots.Snapshot(103, persisted = false))
@@ -112,7 +112,7 @@ class SnapshotsSpec extends FunSuite {
       def get(key: K)                    = none[S].pure[F]
       def delete(key: K, offset: Offset) = State.modify[Context](_.copy(deletedOffset = offset.some))
     }
-    val snapshots = Snapshots("key1", database, f.buffer, noFence)
+    val snapshots = Snapshots("key1", database, f.buffer, f.floor, noFence)
 
     // When("delete is requested with a specific offset")
     val offset  = Offset.unsafe(77)
@@ -131,7 +131,7 @@ class SnapshotsSpec extends FunSuite {
     val f = new ConstFixture
 
     val database  = SnapshotDatabase.memory(f.database)
-    val snapshots = Snapshots("key1", database, f.buffer, intOffset)
+    val snapshots = Snapshots("key1", database, f.buffer, f.floor, intOffset)
 
     // append at offset 5, then a replayed append at offset 3 (lower) which must be dropped, then flush
     val program = snapshots.append(5) *> snapshots.append(3) *> snapshots.flush
@@ -146,7 +146,7 @@ class SnapshotsSpec extends FunSuite {
     val f = new ConstFixture
 
     val database  = countingSnapshotDb(f.database)
-    val snapshots = Snapshots("key1", database, f.buffer, intOffset)
+    val snapshots = Snapshots("key1", database, f.buffer, f.floor, intOffset)
     // the key was recovered/persisted at offset 10
     val context = Context(
       database = Map("key1" -> 10),
@@ -169,7 +169,7 @@ class SnapshotsSpec extends FunSuite {
       def get(key: K)                    = none[S].pure[F]
       def delete(key: K, offset: Offset) = State.modify[Context](_.copy(deletedOffset = offset.some))
     }
-    val snapshots = Snapshots("key1", database, f.buffer, intOffset)
+    val snapshots = Snapshots("key1", database, f.buffer, f.floor, intOffset)
     // buffer holds the recovered snapshot at offset 7
     val context = Context(buffer = Some(Snapshots.Snapshot(7, persisted = true)))
 
@@ -181,13 +181,47 @@ class SnapshotsSpec extends FunSuite {
     assert(result.buffer.isEmpty)
   }
 
+  test("Snapshots recovers an offset-carrying tombstone as the high-water floor (reads back absent)") {
+    val f = new ConstFixture
+
+    // a store whose `recover` reports a deleted key with a tombstone at offset 5 (and `get` reads it back absent)
+    val database = new SnapshotDatabase[F, K, S] {
+      def persist(key: K, snapshot: S)   = ().pure[F]
+      def get(key: K)                    = none[S].pure[F]
+      def delete(key: K, offset: Offset) = ().pure[F]
+      override def recover(key: K)(implicit F0: cats.Functor[F]) =
+        (Recovered.Deleted(Offset.unsafe(5)): Recovered[S]).pure[F]
+    }
+    val snapshots = Snapshots("key1", database, f.buffer, f.floor, intOffset)
+
+    // read returns no state (the key is deleted) but seeds the floor at 5
+    val result = snapshots.read.runS(Context()).value
+    assertEquals(result.floor, Offset.unsafe(5).some)
+  }
+
+  test("Snapshots drops a replayed append below the recovered tombstone floor, keeps one at/above it") {
+    val f = new ConstFixture
+
+    val database  = SnapshotDatabase.memory(f.database)
+    val snapshots = Snapshots("key1", database, f.buffer, f.floor, intOffset)
+    // recovered from a tombstone at offset 5 (no buffered snapshot, floor = 5)
+    val context = Context(floor = Offset.unsafe(5).some)
+
+    // a replayed event at offset 3 (< 5) must be dropped; a later event at offset 7 (>= 5) is buffered and persisted
+    val program = snapshots.append(3) *> snapshots.flush *> snapshots.append(7) *> snapshots.flush
+    val result  = program.runS(context).value
+
+    assertEquals(result.database.get("key1"), Some(7))
+    assertEquals(result.buffer.map(_.value), Some(7))
+  }
+
   test("Snapshots does not persist the same snapshot more than once") {
 
     val f = new ConstFixture
 
     // Given("database with contents")
     val database  = countingSnapshotDb(f.database)
-    val snapshots = Snapshots("key1", database, f.buffer, noFence)
+    val snapshots = Snapshots("key1", database, f.buffer, f.floor, noFence)
     val context = Context(
       database = Map("key1" -> 102),
       buffer   = Some(Snapshots.Snapshot(103, persisted = false))
@@ -210,7 +244,7 @@ class SnapshotsSpec extends FunSuite {
 
     // Given("database without contents")
     val database  = countingSnapshotDb(f.database)
-    val snapshots = Snapshots("key1", database, f.buffer, noFence)
+    val snapshots = Snapshots("key1", database, f.buffer, f.floor, noFence)
     val context = Context(
       database = Map.empty,
       buffer   = None
@@ -240,12 +274,14 @@ object SnapshotsSpec {
   case class Context(
     database: Map[K, S]                   = Map.empty,
     buffer: Option[Snapshots.Snapshot[S]] = None,
+    floor: Option[Offset]                 = None,
     deletedOffset: Option[Offset]         = None
   )
 
   class ConstFixture {
     val database = Stateful[F, Context] focus GenLens[Context](_.database)
     val buffer   = Stateful[F, Context] focus GenLens[Context](_.buffer)
+    val floor    = Stateful[F, Context] focus GenLens[Context](_.floor)
   }
 
   implicit val log: Log[F] = Log.empty[F]

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotsSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotsSpec.scala
@@ -5,7 +5,7 @@ import cats.mtl.Stateful
 import cats.syntax.all.*
 import com.evolutiongaming.catshelper.Log
 import com.evolutiongaming.kafka.flow.MonadStateHelper.*
-import com.evolutiongaming.kafka.flow.kafka.ToOffset
+import com.evolutiongaming.kafka.flow.snapshot.Snapshots.Cell
 import com.evolutiongaming.kafka.flow.snapshot.SnapshotsSpec.*
 import com.evolutiongaming.skafka.Offset
 import monocle.macros.GenLens
@@ -19,7 +19,7 @@ class SnapshotsSpec extends FunSuite {
 
     // Given("empty database")
     val database  = SnapshotDatabase.memory(f.database)
-    val snapshots = Snapshots("key1", database, f.buffer)
+    val snapshots = Snapshots("key1", database, f.state, noFence)
 
     // When("buffer is filled with state")
     val program =
@@ -40,7 +40,7 @@ class SnapshotsSpec extends FunSuite {
 
     // Given("empty database")
     val database  = SnapshotDatabase.memory(f.database)
-    val snapshots = Snapshots("key1", database, f.buffer)
+    val snapshots = Snapshots("key1", database, f.state, noFence)
 
     // When("buffer is filled with state")
     // And("Snapshots is flushed")
@@ -63,18 +63,18 @@ class SnapshotsSpec extends FunSuite {
 
     // Given("database with contents")
     val database  = SnapshotDatabase.memory(f.database)
-    val snapshots = Snapshots("key1", database, f.buffer)
+    val snapshots = Snapshots("key1", database, f.state, noFence)
     val context = Context(
       database = Map("key1" -> 102),
-      buffer   = Some(Snapshots.Snapshot(103, persisted = false))
+      state    = live(103, persisted = false, offset = none)
     )
 
     // When("delete is requested")
-    val program = snapshots.delete(true)
+    val program = snapshots.delete(true, Offset.min)
     val result  = program.runS(context).value
 
-    // Then("buffer is cleared")
-    assert(result.buffer.isEmpty)
+    // Then("buffer no longer holds a live snapshot")
+    assert(liveValue(result.state).isEmpty)
     // And("key is deleted")
     assert(!result.database.contains("key1"))
 
@@ -86,21 +86,277 @@ class SnapshotsSpec extends FunSuite {
 
     // Given("database with contents")
     val database  = SnapshotDatabase.memory(f.database)
-    val snapshots = Snapshots("key1", database, f.buffer)
+    val snapshots = Snapshots("key1", database, f.state, noFence)
     val context = Context(
       database = Map("key1" -> 102),
-      buffer   = Some(Snapshots.Snapshot(103, persisted = false))
+      state    = live(103, persisted = false, offset = none)
     )
 
     // When("delete is requested")
-    val program = snapshots.delete(false)
+    val program = snapshots.delete(false, Offset.min)
     val result  = program.runS(context).value
 
-    // Then("buffer is cleared")
-    assert(result.buffer.isEmpty)
+    // Then("buffer no longer holds a live snapshot")
+    assert(liveValue(result.state).isEmpty)
     // And("key is not deleted")
     assert(result.database.contains("key1"))
 
+  }
+
+  test("Snapshots (fenced) writes the tombstone for a buffer-only delete of a never-persisted key") {
+
+    val f = new ConstFixture
+
+    // Given("a fenced store capturing the offset of a value-less (tombstone) write")
+    val database  = offsetCapturingDb
+    val snapshots = Snapshots("key1", database, f.state, intOffset)
+    // And("a never-persisted key: a buffered, not-yet-flushed live snapshot at offset 3")
+    val context = Context(state = live(3, persisted = false, offset = Offset.unsafe(3).some))
+
+    // When("a buffer-only delete is requested (persist = false)")
+    val program = snapshots.delete(false, Offset.unsafe(3))
+    val result  = program.runS(context).value
+
+    // Then("the fenced store STILL writes the offset-carrying tombstone (the fence a zombie's resurrecting
+    // flush is gated on), unlike the unfenced store which honors persist = false")
+    assertEquals(result.deletedOffset, Offset.unsafe(3).some)
+    assert(liveValue(result.state).isEmpty)
+  }
+
+  test("Snapshots forwards the delete offset to the database") {
+
+    val f = new ConstFixture
+
+    // Given("a database capturing the offset passed to the (value-less) write")
+    val database  = offsetCapturingDb
+    val snapshots = Snapshots("key1", database, f.state, noFence)
+
+    // When("delete is requested with a specific offset")
+    val offset  = Offset.unsafe(77)
+    val program = snapshots.delete(true, offset)
+    val result  = program.runS(Context()).value
+
+    // Then("the database write receives that offset")
+    assertEquals(result.deletedOffset, offset.some)
+  }
+
+  // Fix: a recovered key's snapshot offset can lead the committed offset the partition resumes from; while replaying
+  // events below it the buffer must stay at the high-water offset so a compare-and-set backend does not reject a
+  // legitimate delete or a re-persist as stale. `intOffset` makes the Int state its own offset.
+
+  test("Snapshots keeps the higher-offset snapshot and drops a lower-offset (replayed) append") {
+    val f = new ConstFixture
+
+    val database  = SnapshotDatabase.memory(f.database)
+    val snapshots = Snapshots("key1", database, f.state, intOffset)
+
+    // append at offset 5, then a replayed append at offset 3 (lower) which must be dropped, then flush
+    val program = snapshots.append(5) *> snapshots.append(3) *> snapshots.flush
+    val result  = program.runS(Context()).value
+
+    // the higher-offset snapshot survives; the lower-offset append did not regress the buffer
+    assertEquals(result.database.get("key1"), Some(5))
+    assertEquals(liveValue(result.state), Some(5))
+  }
+
+  test("Snapshots does not re-persist after a lower-offset (replayed) append onto a persisted snapshot") {
+    val f = new ConstFixture
+
+    val database  = countingSnapshotDb(f.database)
+    val snapshots = Snapshots("key1", database, f.state, intOffset)
+    // the key was recovered/persisted at offset 10
+    val context = Context(
+      database = Map("key1" -> 10),
+      state    = live(10, persisted = true, offset = Offset.unsafe(10).some)
+    )
+
+    // a replayed event at offset 3 followed by a flush must not re-persist at the lower offset
+    val program = snapshots.append(3) *> snapshots.flush
+    val result  = program.runS(context).value
+
+    assert(database.persistsCounted == 0)
+    assertEquals(result.database.get("key1"), Some(10))
+  }
+
+  test("Snapshots does not re-persist a same-offset, unchanged-value append onto a persisted snapshot") {
+    val f = new ConstFixture
+
+    val database  = countingSnapshotDb(f.database)
+    val snapshots = Snapshots("key1", database, f.state, intOffset)
+    // recovered/persisted at offset 10
+    val context = Context(
+      database = Map("key1" -> 10),
+      state    = live(10, persisted = true, offset = Offset.unsafe(10).some)
+    )
+
+    // re-deriving the same snapshot at the same offset (an idempotent replay) must not re-persist
+    val program = snapshots.append(10) *> snapshots.flush
+    val result  = program.runS(context).value
+
+    assert(database.persistsCounted == 0)
+    assertEquals(result.database.get("key1"), Some(10))
+  }
+
+  test("Snapshots re-persists a same-offset append whose value changed (e.g. a timer-driven state change)") {
+    val f = new ConstFixture
+
+    // offset fixed at 10 regardless of value, so a changed value can share the stored offset (a timer tick that
+    // changes state without consuming a record); the compare-and-set guard admits an equal offset
+    val fixedAt10: Option[S => Offset] = Some(_ => Offset.unsafe(10))
+    val database                       = countingSnapshotDb(f.database)
+    val snapshots                      = Snapshots("key1", database, f.state, fixedAt10)
+    val context = Context(
+      database = Map("key1" -> 100),
+      state    = live(100, persisted = true, offset = Offset.unsafe(10).some)
+    )
+
+    // the timer changes the state (100 -> 101) without advancing the offset; the same-offset write must persist
+    val program = snapshots.append(101) *> snapshots.flush
+    val result  = program.runS(context).value
+
+    assert(database.persistsCounted == 1)
+    assertEquals(result.database.get("key1"), Some(101))
+  }
+
+  test("Snapshots fences a delete on the buffered snapshot's offset when it leads the requested offset") {
+    val f = new ConstFixture
+
+    val database  = offsetCapturingDb
+    val snapshots = Snapshots("key1", database, f.state, intOffset)
+    // buffer holds the recovered snapshot at offset 7
+    val context = Context(state = live(7, persisted = true, offset = Offset.unsafe(7).some))
+
+    // a delete requested at the (lower) processing offset 2 must be fenced on the buffered offset 7
+    val program = snapshots.delete(true, Offset.unsafe(2))
+    val result  = program.runS(context).value
+
+    assertEquals(result.deletedOffset, Offset.unsafe(7).some)
+    assert(liveValue(result.state).isEmpty)
+  }
+
+  test("Snapshots recovers an offset-carrying tombstone as the high-water floor (reads back absent)") {
+    val f = new ConstFixture
+
+    // a store whose `read` reports a deleted key as a value-less Stored carrying the tombstone offset 5
+    val database = new SnapshotDatabase[F, K, S] {
+      def write(key: K, stored: Stored[S]) = ().pure[F]
+      def read(key: K)                     = (Stored.Tombstone(Offset.unsafe(5)): Stored[S]).some.pure[F]
+    }
+    val snapshots = Snapshots("key1", database, f.state, intOffset)
+
+    // read returns no state (the key is deleted) but seeds the floor at 5
+    val result = snapshots.read.runS(Context()).value
+    assertEquals(result.state, tombstone(Offset.unsafe(5)))
+  }
+
+  test("Snapshots drops a replayed append below the recovered tombstone floor, keeps one at/above it") {
+    val f = new ConstFixture
+
+    val database  = SnapshotDatabase.memory(f.database)
+    val snapshots = Snapshots("key1", database, f.state, intOffset)
+    // recovered from a tombstone at offset 5 (no buffered snapshot, floor = 5)
+    val context = Context(state = tombstone(Offset.unsafe(5)))
+
+    // a replayed event at offset 3 (< 5) must be dropped; a later event at offset 7 (>= 5) is buffered and persisted
+    val program = snapshots.append(3) *> snapshots.flush *> snapshots.append(7) *> snapshots.flush
+    val result  = program.runS(context).value
+
+    assertEquals(result.database.get("key1"), Some(7))
+    assertEquals(liveValue(result.state), Some(7))
+  }
+
+  test("Snapshots keeps the recovered tombstone floor when initPersisted seeds a lower-offset state") {
+    val f = new ConstFixture
+
+    val database  = SnapshotDatabase.memory(f.database)
+    val snapshots = Snapshots("key1", database, f.state, intOffset)
+    // a recovery seeded the tombstone floor at 5 (events-recovery reads the store before folding the journal)
+    val context = Context(state = tombstone(Offset.unsafe(5)))
+
+    // the journal fold can trail the floor (a delete clears the journal only partially, or a TTL reaps it):
+    // its init at offset 3 must not regress the floor, or replay-window writes below 5 would self-fence again
+    val program = snapshots.initPersisted(3) *> snapshots.append(4) *> snapshots.flush
+    val result  = program.runS(context).value
+
+    assert(!result.database.contains("key1"))
+    assertEquals(result.state, tombstone(Offset.unsafe(5)))
+  }
+
+  test("Snapshots initPersisted above the tombstone floor replaces it, still marked persisted") {
+    val f = new ConstFixture
+
+    val database  = countingSnapshotDb(f.database)
+    val snapshots = Snapshots("key1", database, f.state, intOffset)
+    val context   = Context(state = tombstone(Offset.unsafe(5)))
+
+    val program = snapshots.initPersisted(7) *> snapshots.flush
+    val result  = program.runS(context).value
+
+    assertEquals(liveValue(result.state), Some(7))
+    assert(database.persistsCounted == 0) // initialized from persistence: not re-persisted
+  }
+
+  test("Snapshots read seeds the buffer cell from a live stored snapshot") {
+    val f = new ConstFixture
+
+    // a store whose `read` reports the snapshot with its stored offset (as the fenced Cassandra store does)
+    val database = new SnapshotDatabase[F, K, S] {
+      def write(key: K, stored: Stored[S]) = ().pure[F]
+      def read(key: K)                     = (Stored.Live(10, Offset.unsafe(10).some): Stored[S]).some.pure[F]
+    }
+    val snapshots = Snapshots("key1", database, f.state, intOffset)
+
+    val (context, recovered) = snapshots.read.run(Context()).value
+
+    assertEquals(recovered, Some(10))
+    // the cell now holds the store's view (persisted), so `reconcile` has something to compare a journal fold against
+    assertEquals(context.state, live(10, persisted = true, offset = Offset.unsafe(10).some))
+  }
+
+  // The journal-revive guard's floor: events-recovery filters journal events at or below the seeded cell's
+  // offset (see ReadState) - `floor` exposes it. The journal is unfenced, so rows below the fenced store's
+  // offset are either already reflected in the store's view or stale residue of a deleted key.
+
+  test("Snapshots floor is the stored tombstone's offset after read") {
+    val f = new ConstFixture
+
+    val database = new SnapshotDatabase[F, K, S] {
+      def write(key: K, stored: Stored[S]) = ().pure[F]
+      def read(key: K)                     = (Stored.Tombstone(Offset.unsafe(5)): Stored[S]).some.pure[F]
+    }
+    val snapshots = Snapshots("key1", database, f.state, intOffset)
+
+    val floor = (snapshots.read *> snapshots.floor).runA(Context()).value
+    assertEquals(floor, Offset.unsafe(5).some)
+  }
+
+  test("Snapshots floor is the stored live snapshot's offset after read") {
+    val f = new ConstFixture
+
+    val database = new SnapshotDatabase[F, K, S] {
+      def write(key: K, stored: Stored[S]) = ().pure[F]
+      def read(key: K)                     = (Stored.Live(10, Offset.unsafe(10).some): Stored[S]).some.pure[F]
+    }
+    val snapshots = Snapshots("key1", database, f.state, intOffset)
+
+    val floor = (snapshots.read *> snapshots.floor).runA(Context()).value
+    assertEquals(floor, Offset.unsafe(10).some)
+  }
+
+  test("Snapshots floor is empty for an absent key, an empty cell, or an unfenced buffer") {
+    val f = new ConstFixture
+
+    val database = SnapshotDatabase.memory(f.database)
+
+    // fenced, store empty: read seeds nothing
+    val fenced = Snapshots("key1", database, f.state, intOffset)
+    assertEquals((fenced.read *> fenced.floor).runA(Context()).value, none[Offset])
+    // never read: cell empty
+    assertEquals(fenced.floor.runA(Context()).value, none[Offset])
+    // unfenced: the cell never carries an offset
+    val unfenced = Snapshots("key1", database, f.state, noFence)
+    val context  = Context(state = live(10, persisted = true, offset = none))
+    assertEquals(unfenced.floor.runA(context).value, none[Offset])
   }
 
   test("Snapshots does not persist the same snapshot more than once") {
@@ -109,10 +365,10 @@ class SnapshotsSpec extends FunSuite {
 
     // Given("database with contents")
     val database  = countingSnapshotDb(f.database)
-    val snapshots = Snapshots("key1", database, f.buffer)
+    val snapshots = Snapshots("key1", database, f.state, noFence)
     val context = Context(
       database = Map("key1" -> 102),
-      buffer   = Some(Snapshots.Snapshot(103, persisted = false))
+      state    = live(103, persisted = false, offset = none)
     )
 
     // When("flush is requested multiple times")
@@ -132,10 +388,10 @@ class SnapshotsSpec extends FunSuite {
 
     // Given("database without contents")
     val database  = countingSnapshotDb(f.database)
-    val snapshots = Snapshots("key1", database, f.buffer)
+    val snapshots = Snapshots("key1", database, f.state, noFence)
     val context = Context(
       database = Map.empty,
-      buffer   = None
+      state    = none
     )
 
     // When("snapshot is initialized and flush is requested")
@@ -155,19 +411,43 @@ object SnapshotsSpec {
   type K = String
   type S = Int
 
+  // no offset fence (last-write-wins); and the Int state as its own offset (fence active)
+  val noFence: Option[S => Offset]   = None
+  val intOffset: Option[S => Offset] = Some(i => Offset.unsafe(i.toLong))
+
+  // a live buffer cell at `offset` (the fence path supplies one, the last-write-wins path passes none)
+  def live(value: S, persisted: Boolean, offset: Option[Offset]): Option[Cell[S]] =
+    Cell(Stored.Live(value, offset), persisted).some
+
+  // a recovered/left tombstone floor: value-less but carrying its offset, already persisted
+  def tombstone(offset: Offset): Option[Cell[S]] =
+    Cell(Stored.Tombstone(offset), persisted = true).some
+
+  // the live snapshot's value if the buffer holds one, else None (a tombstone floor or an empty cell holds no value)
+  def liveValue(state: Option[Cell[S]]): Option[S] = state.flatMap(_.stored.value)
+
   case class Context(
-    database: Map[K, S]                   = Map.empty,
-    buffer: Option[Snapshots.Snapshot[S]] = None
+    database: Map[K, S]           = Map.empty,
+    state: Option[Cell[S]]        = None,
+    deletedOffset: Option[Offset] = None
   )
 
   class ConstFixture {
     val database = Stateful[F, Context] focus GenLens[Context](_.database)
-    val buffer   = Stateful[F, Context] focus GenLens[Context](_.buffer)
+    val state    = Stateful[F, Context] focus GenLens[Context](_.state)
   }
 
   implicit val log: Log[F] = Log.empty[F]
 
-  implicit val withOffset: ToOffset[S] = Offset.unsafe(_)
+  // captures the offset of a value-less (delete) write, so a test can assert the offset forwarded to the store
+  val offsetCapturingDb: SnapshotDatabase[F, K, S] = new SnapshotDatabase[F, K, S] {
+    def read(key: K) = none[Stored[S]].pure[F]
+    def write(key: K, stored: Stored[S]) =
+      stored.value match {
+        case Some(_) => ().pure[F]
+        case None    => State.modify[Context](_.copy(deletedOffset = stored.offset))
+      }
+  }
 
   trait SnapshotDatabaseWithPersistCount extends SnapshotDatabase[F, K, S] {
     def persistsCounted: Int
@@ -177,18 +457,15 @@ object SnapshotsSpec {
     new SnapshotDatabaseWithPersistCount {
       val db             = SnapshotDatabase.memory(storage)
       var persistCounter = 0
-      def persist(key: K, snapshot: S) = {
-        persistCounter += 1
-        db.persist(key, snapshot)
+      def write(key: K, stored: Stored[S]) = {
+        if (stored.value.isDefined) persistCounter += 1 // count persists, not tombstone deletes
+        db.write(key, stored)
       }
 
-      def get(key: K) =
-        db.get(key)
+      def read(key: K) =
+        db.read(key)
 
-      def delete(key: K) =
-        db.delete(key)
-
-      def persistsCounted: SnapshotsSpec.S = persistCounter
+      def persistsCounted: Int = persistCounter
     }
   }
 

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotsSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotsSpec.scala
@@ -268,8 +268,8 @@ object SnapshotsSpec {
   type S = Int
 
   // no offset fence (last-write-wins); and the Int state as its own offset (fence active)
-  val noFence: S => Offset   = _ => Offset.min
-  val intOffset: S => Offset = i => Offset.unsafe(i.toLong)
+  val noFence: Option[S => Offset]   = None
+  val intOffset: Option[S => Offset] = Some(i => Offset.unsafe(i.toLong))
 
   case class Context(
     database: Map[K, S]                   = Map.empty,

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotsSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotsSpec.scala
@@ -66,7 +66,7 @@ class SnapshotsSpec extends FunSuite {
     val snapshots = Snapshots("key1", database, f.state, noFence)
     val context = Context(
       database = Map("key1" -> 102),
-      state    = Buffered.Live(Snapshots.Snapshot(103, persisted = false))
+      state    = Buffered.Live(103, persisted = false)
     )
 
     // When("delete is requested")
@@ -89,7 +89,7 @@ class SnapshotsSpec extends FunSuite {
     val snapshots = Snapshots("key1", database, f.state, noFence)
     val context = Context(
       database = Map("key1" -> 102),
-      state    = Buffered.Live(Snapshots.Snapshot(103, persisted = false))
+      state    = Buffered.Live(103, persisted = false)
     )
 
     // When("delete is requested")
@@ -151,7 +151,7 @@ class SnapshotsSpec extends FunSuite {
     // the key was recovered/persisted at offset 10
     val context = Context(
       database = Map("key1" -> 10),
-      state    = Buffered.Live(Snapshots.Snapshot(10, persisted = true))
+      state    = Buffered.Live(10, persisted = true)
     )
 
     // a replayed event at offset 3 followed by a flush must not re-persist at the lower offset
@@ -172,7 +172,7 @@ class SnapshotsSpec extends FunSuite {
     }
     val snapshots = Snapshots("key1", database, f.state, intOffset)
     // buffer holds the recovered snapshot at offset 7
-    val context = Context(state = Buffered.Live(Snapshots.Snapshot(7, persisted = true)))
+    val context = Context(state = Buffered.Live(7, persisted = true))
 
     // a delete requested at the (lower) processing offset 2 must be fenced on the buffered offset 7
     val program = snapshots.delete(true, Offset.unsafe(2))
@@ -225,7 +225,7 @@ class SnapshotsSpec extends FunSuite {
     val snapshots = Snapshots("key1", database, f.state, noFence)
     val context = Context(
       database = Map("key1" -> 102),
-      state    = Buffered.Live(Snapshots.Snapshot(103, persisted = false))
+      state    = Buffered.Live(103, persisted = false)
     )
 
     // When("flush is requested multiple times")
@@ -274,7 +274,7 @@ object SnapshotsSpec {
 
   // the live snapshot's value if the buffer holds one, else None (a tombstone floor or an empty cell holds no value)
   def liveValue(state: Buffered[S]): Option[S] = state match {
-    case Buffered.Live(snapshot) => snapshot.value.some
+    case Buffered.Live(value, _) => value.some
     case _                       => none[S]
   }
 

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotsSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotsSpec.scala
@@ -5,6 +5,7 @@ import cats.mtl.Stateful
 import cats.syntax.all.*
 import com.evolutiongaming.catshelper.Log
 import com.evolutiongaming.kafka.flow.MonadStateHelper.*
+import com.evolutiongaming.kafka.flow.snapshot.Snapshots.Buffered
 import com.evolutiongaming.kafka.flow.snapshot.SnapshotsSpec.*
 import com.evolutiongaming.skafka.Offset
 import monocle.macros.GenLens
@@ -18,7 +19,7 @@ class SnapshotsSpec extends FunSuite {
 
     // Given("empty database")
     val database  = SnapshotDatabase.memory(f.database)
-    val snapshots = Snapshots("key1", database, f.buffer, f.floor, noFence)
+    val snapshots = Snapshots("key1", database, f.state, noFence)
 
     // When("buffer is filled with state")
     val program =
@@ -39,7 +40,7 @@ class SnapshotsSpec extends FunSuite {
 
     // Given("empty database")
     val database  = SnapshotDatabase.memory(f.database)
-    val snapshots = Snapshots("key1", database, f.buffer, f.floor, noFence)
+    val snapshots = Snapshots("key1", database, f.state, noFence)
 
     // When("buffer is filled with state")
     // And("Snapshots is flushed")
@@ -62,18 +63,18 @@ class SnapshotsSpec extends FunSuite {
 
     // Given("database with contents")
     val database  = SnapshotDatabase.memory(f.database)
-    val snapshots = Snapshots("key1", database, f.buffer, f.floor, noFence)
+    val snapshots = Snapshots("key1", database, f.state, noFence)
     val context = Context(
       database = Map("key1" -> 102),
-      buffer   = Some(Snapshots.Snapshot(103, persisted = false))
+      state    = Buffered.Live(Snapshots.Snapshot(103, persisted = false))
     )
 
     // When("delete is requested")
     val program = snapshots.delete(true, Offset.min)
     val result  = program.runS(context).value
 
-    // Then("buffer is cleared")
-    assert(result.buffer.isEmpty)
+    // Then("buffer no longer holds a live snapshot")
+    assert(liveValue(result.state).isEmpty)
     // And("key is deleted")
     assert(!result.database.contains("key1"))
 
@@ -85,18 +86,18 @@ class SnapshotsSpec extends FunSuite {
 
     // Given("database with contents")
     val database  = SnapshotDatabase.memory(f.database)
-    val snapshots = Snapshots("key1", database, f.buffer, f.floor, noFence)
+    val snapshots = Snapshots("key1", database, f.state, noFence)
     val context = Context(
       database = Map("key1" -> 102),
-      buffer   = Some(Snapshots.Snapshot(103, persisted = false))
+      state    = Buffered.Live(Snapshots.Snapshot(103, persisted = false))
     )
 
     // When("delete is requested")
     val program = snapshots.delete(false, Offset.min)
     val result  = program.runS(context).value
 
-    // Then("buffer is cleared")
-    assert(result.buffer.isEmpty)
+    // Then("buffer no longer holds a live snapshot")
+    assert(liveValue(result.state).isEmpty)
     // And("key is not deleted")
     assert(result.database.contains("key1"))
 
@@ -112,7 +113,7 @@ class SnapshotsSpec extends FunSuite {
       def get(key: K)                    = none[S].pure[F]
       def delete(key: K, offset: Offset) = State.modify[Context](_.copy(deletedOffset = offset.some))
     }
-    val snapshots = Snapshots("key1", database, f.buffer, f.floor, noFence)
+    val snapshots = Snapshots("key1", database, f.state, noFence)
 
     // When("delete is requested with a specific offset")
     val offset  = Offset.unsafe(77)
@@ -131,7 +132,7 @@ class SnapshotsSpec extends FunSuite {
     val f = new ConstFixture
 
     val database  = SnapshotDatabase.memory(f.database)
-    val snapshots = Snapshots("key1", database, f.buffer, f.floor, intOffset)
+    val snapshots = Snapshots("key1", database, f.state, intOffset)
 
     // append at offset 5, then a replayed append at offset 3 (lower) which must be dropped, then flush
     val program = snapshots.append(5) *> snapshots.append(3) *> snapshots.flush
@@ -139,18 +140,18 @@ class SnapshotsSpec extends FunSuite {
 
     // the higher-offset snapshot survives; the lower-offset append did not regress the buffer
     assertEquals(result.database.get("key1"), Some(5))
-    assertEquals(result.buffer.map(_.value), Some(5))
+    assertEquals(liveValue(result.state), Some(5))
   }
 
   test("Snapshots does not re-persist after a lower-offset (replayed) append onto a persisted snapshot") {
     val f = new ConstFixture
 
     val database  = countingSnapshotDb(f.database)
-    val snapshots = Snapshots("key1", database, f.buffer, f.floor, intOffset)
+    val snapshots = Snapshots("key1", database, f.state, intOffset)
     // the key was recovered/persisted at offset 10
     val context = Context(
       database = Map("key1" -> 10),
-      buffer   = Some(Snapshots.Snapshot(10, persisted = true))
+      state    = Buffered.Live(Snapshots.Snapshot(10, persisted = true))
     )
 
     // a replayed event at offset 3 followed by a flush must not re-persist at the lower offset
@@ -169,16 +170,16 @@ class SnapshotsSpec extends FunSuite {
       def get(key: K)                    = none[S].pure[F]
       def delete(key: K, offset: Offset) = State.modify[Context](_.copy(deletedOffset = offset.some))
     }
-    val snapshots = Snapshots("key1", database, f.buffer, f.floor, intOffset)
+    val snapshots = Snapshots("key1", database, f.state, intOffset)
     // buffer holds the recovered snapshot at offset 7
-    val context = Context(buffer = Some(Snapshots.Snapshot(7, persisted = true)))
+    val context = Context(state = Buffered.Live(Snapshots.Snapshot(7, persisted = true)))
 
     // a delete requested at the (lower) processing offset 2 must be fenced on the buffered offset 7
     val program = snapshots.delete(true, Offset.unsafe(2))
     val result  = program.runS(context).value
 
     assertEquals(result.deletedOffset, Offset.unsafe(7).some)
-    assert(result.buffer.isEmpty)
+    assert(liveValue(result.state).isEmpty)
   }
 
   test("Snapshots recovers an offset-carrying tombstone as the high-water floor (reads back absent)") {
@@ -192,27 +193,27 @@ class SnapshotsSpec extends FunSuite {
       override def recover(key: K)(implicit F0: cats.Functor[F]) =
         (Recovered.Deleted(Offset.unsafe(5)): Recovered[S]).pure[F]
     }
-    val snapshots = Snapshots("key1", database, f.buffer, f.floor, intOffset)
+    val snapshots = Snapshots("key1", database, f.state, intOffset)
 
     // read returns no state (the key is deleted) but seeds the floor at 5
     val result = snapshots.read.runS(Context()).value
-    assertEquals(result.floor, Offset.unsafe(5).some)
+    assertEquals(result.state, Buffered.Deleted(Offset.unsafe(5)): Buffered[S])
   }
 
   test("Snapshots drops a replayed append below the recovered tombstone floor, keeps one at/above it") {
     val f = new ConstFixture
 
     val database  = SnapshotDatabase.memory(f.database)
-    val snapshots = Snapshots("key1", database, f.buffer, f.floor, intOffset)
+    val snapshots = Snapshots("key1", database, f.state, intOffset)
     // recovered from a tombstone at offset 5 (no buffered snapshot, floor = 5)
-    val context = Context(floor = Offset.unsafe(5).some)
+    val context = Context(state = Buffered.Deleted(Offset.unsafe(5)))
 
     // a replayed event at offset 3 (< 5) must be dropped; a later event at offset 7 (>= 5) is buffered and persisted
     val program = snapshots.append(3) *> snapshots.flush *> snapshots.append(7) *> snapshots.flush
     val result  = program.runS(context).value
 
     assertEquals(result.database.get("key1"), Some(7))
-    assertEquals(result.buffer.map(_.value), Some(7))
+    assertEquals(liveValue(result.state), Some(7))
   }
 
   test("Snapshots does not persist the same snapshot more than once") {
@@ -221,10 +222,10 @@ class SnapshotsSpec extends FunSuite {
 
     // Given("database with contents")
     val database  = countingSnapshotDb(f.database)
-    val snapshots = Snapshots("key1", database, f.buffer, f.floor, noFence)
+    val snapshots = Snapshots("key1", database, f.state, noFence)
     val context = Context(
       database = Map("key1" -> 102),
-      buffer   = Some(Snapshots.Snapshot(103, persisted = false))
+      state    = Buffered.Live(Snapshots.Snapshot(103, persisted = false))
     )
 
     // When("flush is requested multiple times")
@@ -244,10 +245,10 @@ class SnapshotsSpec extends FunSuite {
 
     // Given("database without contents")
     val database  = countingSnapshotDb(f.database)
-    val snapshots = Snapshots("key1", database, f.buffer, f.floor, noFence)
+    val snapshots = Snapshots("key1", database, f.state, noFence)
     val context = Context(
       database = Map.empty,
-      buffer   = None
+      state    = Buffered.Empty
     )
 
     // When("snapshot is initialized and flush is requested")
@@ -271,17 +272,21 @@ object SnapshotsSpec {
   val noFence: Option[S => Offset]   = None
   val intOffset: Option[S => Offset] = Some(i => Offset.unsafe(i.toLong))
 
+  // the live snapshot's value if the buffer holds one, else None (a tombstone floor or an empty cell holds no value)
+  def liveValue(state: Buffered[S]): Option[S] = state match {
+    case Buffered.Live(snapshot) => snapshot.value.some
+    case _                       => none[S]
+  }
+
   case class Context(
-    database: Map[K, S]                   = Map.empty,
-    buffer: Option[Snapshots.Snapshot[S]] = None,
-    floor: Option[Offset]                 = None,
-    deletedOffset: Option[Offset]         = None
+    database: Map[K, S]           = Map.empty,
+    state: Buffered[S]            = Buffered.Empty,
+    deletedOffset: Option[Offset] = None
   )
 
   class ConstFixture {
     val database = Stateful[F, Context] focus GenLens[Context](_.database)
-    val buffer   = Stateful[F, Context] focus GenLens[Context](_.buffer)
-    val floor    = Stateful[F, Context] focus GenLens[Context](_.floor)
+    val state    = Stateful[F, Context] focus GenLens[Context](_.state)
   }
 
   implicit val log: Log[F] = Log.empty[F]

--- a/docs/cassandra-single-writer-design.md
+++ b/docs/cassandra-single-writer-design.md
@@ -147,6 +147,16 @@ absent — and the floor is re-established on every recovery, so the livelock ca
 defaults to `get` for stores without tombstones; a wrapper such as the metrics one must delegate to the
 underlying `recover`, or it silently downgrades a tombstone back to `Absent`.)
 
+The same hazard reaches the **events-recovery** mode (`restoreEvents`), where state is restored by folding
+the journal rather than reading the snapshot. A delete clears the key's journal, so the fold yields `None`
+and the high-water `X` survives only on the snapshot tombstone — the buffer would again start with no floor.
+So events-recovery reads the snapshot store for its tombstone floor (`ReadState` runs `Snapshots.read` for
+that side-effect) before folding the journal; the recovered state still comes from the journal. A *live* key
+needs no floor here — its journal is intact, so the fold reconstructs `X` itself. Note compare-and-set
+protects the snapshot store, which events-recovery does not read for state, so pairing the two buys no
+stale-writer safety; seeding the floor only removes the deleted-key livelock for setups that nonetheless
+enable both.
+
 ## Equal-offset writes and determinism
 
 `IF offset <= :offset` admits an *equal* offset, so a stale writer holding exactly the stored offset is

--- a/docs/cassandra-single-writer-design.md
+++ b/docs/cassandra-single-writer-design.md
@@ -33,9 +33,7 @@ UPDATE snapshots_v2 SET ... , offset = :offset WHERE <key> IF offset <= :offset
 The first write of a key finds no row, so the conditional `UPDATE` does not apply; it falls back to
 `INSERT ... IF NOT EXISTS`. If that loses a race to a concurrent insert, the conditional `UPDATE` is
 retried once, so the newest snapshot still wins a first-write race. A rejected write raises
-`SnapshotWriteConflict` (handled uniformly, see [Persistence](persistence.md#protecting-against-stale-snapshot-writes)).
-Result classification (`applied` / newer-stored-offset / row-absent) is shared by persist and delete
-in `resolveConditional`; a not-applied result reports the stored `offset` when Cassandra returns it
+`SnapshotWriteConflict`. A not-applied result reports the stored `offset` when Cassandra returns it
 and treats its absence (or a null) as "row absent".
 
 The guard is per **key**, the right granularity: #732 corruption is per key and keys are independent,
@@ -216,23 +214,35 @@ conditional one. Negligible with NTP-synced clocks, and gone once every instance
 ## Implementation
 
 Entry point: `CassandraSnapshots.withSchema(compareAndSet = true)` (or
-`CassandraPersistence.withSchema(snapshotCompareAndSet = true)`). `persistCompareAndSet` issues the
-offset-gated `UPDATE` with the `INSERT ... IF NOT EXISTS` first-write fallback, and `resolveConditional`
-classifies the result; `delete` stays an unguarded last-write-wins `DELETE`. `WriteMode.CompareAndSet`
-carries the extra `INSERT` statement, so it exists exactly in compare-and-set mode.
+`CassandraPersistence.withSchema(snapshotCompareAndSet = true)`). In the current code:
+
+- **Conditional write / delete** — `CassandraSnapshots.persistCompareAndSet` and `deleteCompareAndSet`
+  issue the offset-gated `UPDATE`/`INSERT`; `resolveConditional` classifies the result
+  (`applied` / newer-stored-offset / row-absent), shared by both.
+- **Monotonic buffer** — `Snapshots.append` drops a lower-offset append; recovery establishes the
+  high-water floor through `SnapshotDatabase.recover`, which returns `Recovered.Deleted` for a
+  tombstone and `Recovered.Absent` for a reaped or never-written key.
+- **Replay filter** — `SnapshotFold` drops replayed events above the recovered offset; a timer-driven
+  `TickToState` delete bypasses that filter, which is why the monotonic buffer is what carries the
+  tick-delete case.
+- **Events-recovery floor** — `ReadState` runs `Snapshots.read` for its tombstone-floor side effect
+  before folding the journal.
+- **Offset accessor** — the offset-carrying wiring passes `Some(_.offset)` (live fence); other stores
+  pass `None` (unfenced, last-write-wins).
 
 ## Testing
 
-- Store-level against real Cassandra (persistence-cassandra-it-tests) — monotonic writes,
-  stale-write rejection, the tombstone (no resurrection, replayed/stale delete, equal-offset),
+- Store-level against real Cassandra (`SnapshotSpec`, persistence-cassandra-it-tests) — monotonic
+  writes, stale-write rejection, the tombstone (no resurrection, replayed/stale delete, equal-offset),
   idempotent delete, TTL on both the insert and update paths, and concurrent first-writers racing on a
   fresh key (the highest offset wins, no corruption — exercising the first-write retry path).
-- Through the real PartitionFlow / eager-recovery / flush-on-revoke machinery
-  (persistence-cassandra-it-tests) — the #732 reproduction asserts corruption under last-write-wins;
+- Through the real PartitionFlow / eager-recovery / flush-on-revoke machinery (`FlowSpec`,
+  persistence-cassandra-it-tests) — the #732 reproduction asserts corruption under last-write-wins;
   the prevention asserts the stale flush is rejected; and a delete during replay below the recovered
   snapshot offset applies (fenced on the high-water), not rejected.
-- In core — the monotonic buffer and the delete fence: a unit test directly, and a flow-level test
-  against an offset-gated in-memory store.
+- In core — the monotonic buffer and the delete fence: `SnapshotsSpec` (the buffer directly) and
+  `SnapshotsOfSpec` (the offset-of fencing wiring), with `SnapshotReplayFencingSpec` driving the
+  replay-window cases flow-level against an offset-gated in-memory store.
 
 ## Assumptions
 

--- a/docs/cassandra-single-writer-design.md
+++ b/docs/cassandra-single-writer-design.md
@@ -1,0 +1,246 @@
+---
+id: cassandra-single-writer-design
+title: "Cassandra single-writer design: persist only"
+sidebar_label: "Cassandra single-writer design: persist only"
+---
+
+Design notes for the compare-and-set snapshot mode of `kafka-flow-persistence-cassandra`
+(`CassandraSnapshots.withSchema(compareAndSet = true)`). What ships is small — one conditional
+predicate on each `persist` — so these notes spend little time on mechanics. Their weight is on the
+design choices: where the persist-only line is drawn and why, and the full solution (offset-gated
+deletes) that was designed and then deferred — because the reasons it was deferred are
+the main thing a future author needs before reopening it.
+
+Operational guidance (enabling, consistency levels, TTL, rollout) is in
+[Persistence](persistence.md). The Kafka backend solves the same problem with a different mechanism —
+see [Kafka single-writer design](kafka-single-writer-design.md).
+
+## Problem
+
+[kafka-flow#732](https://github.com/evolution-gaming/kafka-flow/issues/732): consumer-group ownership
+of the input topic does not extend to the snapshot store. During a rebalance a previous owner that has
+not yet observed the revocation keeps flushing snapshots alongside the new owner; the snapshots table
+is last-write-wins, so a stale snapshot can overwrite a newer one, and the next recovery loads stale
+state while resuming from the committed offset — the events in between are lost from the state. The
+[Kafka design doc](kafka-single-writer-design.md) covers the failure in full, with a diagram.
+
+Kafka's fix does not transfer. There, the snapshot write is bound to the input-offset commit in one
+broker transaction, and the consumer generation — authoritative for ownership — fences the commit.
+Cassandra offers no transaction to bind a Kafka offset commit into, and holds no notion of who owns a
+partition. What it does offer is a conditional write: a lightweight transaction (LWT), linearizable
+per partition key. So the fence must be built from something the snapshot itself carries, and checked
+per write, per key.
+
+## Design
+
+The stored offset is the per-key
+[fencing token](https://martin.kleppmann.com/2016/02/08/how-to-do-distributed-locking.html). Every
+snapshot already carries the offset it was folded up to, and #732 corruption is stale *by offset* — a
+lower-offset snapshot replacing a higher-offset one. So each persist asserts the stored offset is not
+greater than the one being written, and the newest-by-offset snapshot wins, whoever writes it:
+
+```sql
+UPDATE snapshots_v2 SET ..., offset = :offset WHERE <key> IF offset <= :offset
+```
+
+A key's first persist finds no row, so the `UPDATE` does not apply and falls back to
+`INSERT ... IF NOT EXISTS`, retried once through the gated `UPDATE` if it loses an insert race. This
+compound of separate LWTs is the one non-atomic path, and it is safe by construction: both `UPDATE`s
+are offset-gated and the `INSERT` only writes an absent cell, so no interleaving overwrites a newer
+snapshot. Its worst case is an over-rejection, never corruption: a delete slipping between the
+`INSERT` and its retry surfaces as a spurious conflict, cleared on the next flush. A rejected write
+raises `SnapshotWriteConflict`.
+
+Three choices in the predicate carry most of the design:
+
+- **Per key, not per partition.** #732 corruption is per key and keys are independent, so per-key
+  monotonic durability is exactly the guarantee needed. Anything per-partition would require an
+  ownership authority Cassandra does not have (see *Rejected alternatives* for what importing one
+  would cost).
+- **`<=`, not `<`.** The legitimate owner can write at an offset it has already stored — a
+  timer-driven re-flush of the buffered high-water snapshot — and a strict `<` would fence the owner
+  against itself. Admitting an equal offset is safe because a same-offset write cannot move the
+  recovery point, so it cannot drop committed events. It also means a stale writer holding *exactly*
+  the stored offset goes undetected — accepted for the same reason.
+- **Ordered by data, not by identity.** The token orders writes by what they contain, not by who sent
+  them, so the fence needs no clock synchronisation, no lease and no liveness protocol — but it can
+  never say "you are not the owner", only "you are behind". Closing that gap needs a generation in
+  the token (see *Rejected alternatives* and *Forward-looking*).
+
+Two snapshots at the same offset have folded the same records, so admitting equal offsets is sound
+only when folds are deterministic and replayable — already a precondition of recovery generally, but
+this mode leans on it harder.
+
+### Why the store is the whole change
+
+The mode deliberately changes nothing outside `CassandraSnapshots`: no buffer change, no recovery
+change, no new read. That is possible because core already guarantees the legitimate owner never
+presents an offset below what it recovered: `SnapshotFold` drops replayed records at or below the
+recovered snapshot's offset before they reach the fold, so nothing is re-derived — or re-persisted —
+below a key's recovered high-water even while the partition replays from a lower committed offset.
+The fence therefore only ever rejects genuinely stale writers, and liveness comes for free.
+
+That property is load-bearing, not incidental. The deferred design below is the story of what happens
+when it stops holding: fencing deletes breaks it, and repairing it pulls the buffer and both recovery
+paths into the change.
+
+## Scope: deletes are not fenced
+
+`delete` stays a plain last-write-wins row `DELETE`. During an ownership overlap a stale writer can
+therefore still erase a newer snapshot, or resurrect a just-deleted key by writing at a lower
+offset — #732 residual for exactly the keys a fold deletes concurrently with re-writes.
+
+Drawing the line here is a choice, not an oversight:
+
+- **A fenced deletion is still expressible.** Instead of folding to `None`, fold to an
+  offset-carrying *empty* state (`Some(empty)`): the deletion then travels the fenced persist path
+  and a lower-offset zombie is rejected exactly as for any persist. The store's row lives until its
+  TTL — the cost of the workaround.
+- **Fencing `delete` itself costs out of all proportion to the predicate above** — a breaking API and
+  new recovery machinery, with a liveness trap on each recovery path. That is the deferred design
+  below.
+
+## The expired guard (TTL reconfiguration)
+
+Cassandra TTLs are per **cell** and fixed at write time, and a row stays visible while any live cell —
+or the first write's `INSERT` row marker (immortal only when that first write ran without a `ttl` and
+the table has no `default_time_to_live`) — survives. Under a uniform `ttl` from the first deployment
+it is unreachable: the delete co-writes `offset` with `value`, so a visible row always carries a live
+guard. It is a **reconfiguration / pre-TTL-legacy** hazard — enabling (or shortening) the `ttl` between writes of a key can leave a
+visible row whose `offset` guard cell has expired while an earlier, longer-lived cell or marker
+survives: e.g. a no-TTL deployment's first write (immortal marker), TTL'd re-persists, then idleness
+past the TTL — every column null, nothing to fence. `get` already reads such a row as absent (its `value` cell is expired)
+and a plain delete removes it entirely, but no regular persist could ever claim it: the null guard
+fails `IF offset <= :offset`, the not-applied result looks like "row absent" (it is not — Cassandra
+returns the condition column, null, exactly when the row exists), `INSERT ... IF NOT EXISTS` loses to
+the still-visible row, and the retry conflicts — every write of the key raising
+`SnapshotWriteConflict`, forever. So the write path distinguishes the guard-expired result and repairs
+it with a Paxos-safe `IF offset = null` persist that reinstates the guard
+(`Statements.prepareRepairPersist`; racing repairs serialize, the loser conflicts as usual). The
+repair re-arms the guard but (being an `UPDATE`) cannot remove an immortal marker, so such a row
+re-poisons after each `ttl` until an owner deletes/reaps it — palliative, not curative. `SnapshotTtlEdgeSpec` pins the state and the repair against real
+Cassandra. Prefer configuring the `ttl` from the first deployment anyway.
+
+## Compatibility
+
+- **No public API change**, hence no major version: the mode is an opt-in flag
+  (`compareAndSet = true`, default `false`) on the existing entry points.
+- **No schema migration in either direction**: the condition reads the `offset` column every version
+  already writes. Rolling deploys are safe; the mixed-mode clock-skew caveat is in
+  [Persistence](persistence.md).
+- **The fence is write-side only.** Recovery reads at the regular (non-serial) consistency level, so
+  the guarantee reaches the reader only when `R + W > N` — with weaker levels a recovery read can
+  miss the newest committed snapshot and reintroduce #732 on the read side. Required levels and the
+  serial-consistency setting are in [Persistence](persistence.md).
+
+## Testing
+
+Store-level tests against real Cassandra (`SnapshotSpec`) cover monotonic persists, stale-write
+rejection, equal-offset re-persist, TTL on both write paths, and concurrent first-writers racing a
+fresh key (exercising the insert-retry compound). Flow-level tests (`FlowSpec`) run through the real
+recovery and flush machinery: the #732 reproduction shows corruption under last-write-wins, and its
+counterpart shows the stale flush rejected under compare-and-set.
+
+## The full solution, and why it was deferred
+
+Persist-only was carved out of a full design that also fenced deletes. That full design was
+implemented and reviewed, and none of it ships. It is summarised here because its trajectory is
+the main learning of this work: **a fence that looked like one more predicate turned into a chain of
+core changes, each forced by the previous one.**
+
+1. **A fenced delete cannot remove the row.** The offset guard *is* the row: remove it and a lagging
+   zombie's `INSERT ... IF NOT EXISTS` at a lower offset succeeds, resurrecting a stale snapshot. So
+   a fenced delete must be a logical **tombstone** — the row kept, value nulled, offset gated on the
+   same predicate as a persist (`SET value = null ... IF offset <= :offset`).
+
+2. **The tombstone forces a breaking API.** The gate needs the delete's offset, but
+   `SnapshotWriteDatabase.delete(key)` does not carry one — fencing deletes means a source- and
+   binary-breaking `delete(key, offset)` through every delete path and every custom store. A major
+   version, for this alone.
+
+3. **The buffer must become monotonic, or the owner fences itself.** After recovery a key can hold a
+   durable snapshot at offset `X` while the partition replays from a lower committed offset `C` (a
+   slow *other* key held `C` back). A timer-driven delete in that window would be gated on the
+   processing offset `< X` and rejected — the fence crashing the *legitimate* owner. The fix keeps
+   the per-key buffer monotonic in offset and gates a delete on the key's high-water `X`, which the
+   true owner presents and a genuinely stale writer never reached. Note the persist case needs no
+   such fix (`SnapshotFold` filters replayed records); it is the timer-driven *delete*, which
+   bypasses that filter, that forces the buffer change.
+
+4. **Recovery must learn to see tombstones, or the owner livelocks.** The base read is `get`, typed
+   `Option[S]`: a value or nothing. A tombstone comes back as `None`, indistinguishable from a
+   never-written key — so recovery seeds no high-water, the buffer climbs from replayed offsets
+   `< X`, and the offset-`X` tombstone rejects the owner's own flush. The flow tears down,
+   re-recovers the same floorless tombstone, and repeats:
+
+   ```mermaid
+   sequenceDiagram
+       participant O as Owner (recovering)
+       participant DB as snapshots table
+       Note over DB: tombstone: value = null, offset = X
+       O->>DB: recover: get(key) → None (offset X invisible)
+       O->>O: replay events from committed offset C < X
+       O->>DB: flush re-derived snapshot at offset < X
+       DB-->>O: IF offset <= X fails: SnapshotWriteConflict
+       Note over O: tear down, re-recover the same None,<br/>repeat — livelock
+   ```
+
+   The fix is a new recovery read that surfaces `Deleted(offset)` where `get` says `None`, seeding
+   the buffer's floor.
+
+5. **Events-recovery re-opens the livelock on its own.** `restoreEvents` rebuilds state by folding
+   the *journal*, not by reading the snapshot store — and a delete clears the journal, so the fold
+   yields nothing and the floor is lost again, untouched by the fix above. Events-recovery must read
+   the snapshot store purely for the tombstone floor before folding. A delete fence that seeds the
+   floor only on snapshot recovery still livelocks here; the two seedings are independent.
+
+**What the analysis showed.** Safety was never at risk: a rejected write changes nothing and the
+durable offset never regresses, in every configuration. Every defect was a **liveness** failure — the
+self-fence and the livelocks above — and each fix proved necessary: with the monotonic buffer or the
+tombstone floor removed, liveness fails while safety still holds, reached through a live snapshot in
+one configuration and through a deleted key in another. With both in place, a single writer's durable
+offsets stay monotonic for both safety and liveness.
+
+**The deferral decision.** On the benefit side, fencing `delete` protects only folds that return
+`None` — a need already coverable by the empty-state persist above. On the cost side: a major version
+for every custom snapshot store; invasive changes to the buffer and both recovery paths — the hottest
+code in core; and a liveness surface subtle enough to be a maintenance risk in its own right, not
+just implementation effort. Timing sharpened the call:
+[KIP-939](https://cwiki.apache.org/confluence/display/KAFKA/KIP-939:+Support+Participation+in+2PC)
+(participation in 2PC) may eventually let a Cassandra snapshot write bind to a generation-fenced
+Kafka offset commit, giving per-partition ownership that supersedes a per-key delete fence — making
+the deferred machinery potentially throwaway. So the full design was parked where it can be resumed,
+and the persist-only subset shipped.
+
+The learning generalises: in a last-write-wins store, fencing *writes* is cheap — the token rides the
+data. It is *deletion* that is expensive, because deletion removes the very cell that carries the
+fence, and every fix for that (tombstones, floors, monotonic buffers) leaks upward into recovery.
+
+## Rejected alternatives
+
+- **Offset-as-write-timestamp (LWW register)**: write each snapshot `USING TIMESTAMP <offset>` and
+  let Cassandra's own last-write-wins reconciliation keep the highest-offset cell — a plain quorum
+  write, much cheaper than Paxos, and a delete becomes a tombstone ordered by offset for free.
+  Rejected: equal-offset replacement breaks (at equal timestamps Cassandra breaks ties by value, not
+  write order), a rolling deploy inverts catastrophically (old instances' wall-clock timestamps
+  dominate every offset-as-timestamp value), and it discards the real write timestamps.
+- **Lease / ownership table**: a per-partition lease acquired with one LWT, then cheap plain writes.
+  The lease alone does not stop a paused leaseholder's in-flight plain writes (last-write-wins still
+  applies), so a per-write fencing token is still required — at which point the lease adds only
+  liveness and expiry concerns on top of the per-write CAS.
+- **Composite `(offset, generation)` token**: gate on the consumer generation as well as the offset,
+  closing the equal-offset gap and giving per-partition ownership. Rejected as the default because it
+  couples the self-contained Cassandra module to the live consumer generation; reasonable as a future
+  strict mode.
+- **Recovery-side reconciliation** (store the offset, reconcile on read): does not prevent the stale
+  overwrite — last-write-wins still corrupts the store — so strictly weaker than fencing the write.
+
+## Forward-looking
+
+- **Offset-gated deletes** — the deferred design above; a candidate for a future major
+  version if the empty-state workaround proves insufficient in practice.
+- **Per-partition ownership** — a composite `(offset, generation)` strict mode, or, further out,
+  [KIP-939](https://cwiki.apache.org/confluence/display/KAFKA/KIP-939:+Support+Participation+in+2PC):
+  an externally-coordinated two-phase commit binding the Cassandra snapshot write to a
+  generation-fenced Kafka offset commit — per-partition ownership without per-key CAS. Not actionable
+  now; see the Kafka design doc's forward-looking note.

--- a/docs/cassandra-single-writer-design.md
+++ b/docs/cassandra-single-writer-design.md
@@ -1,246 +1,399 @@
 ---
 id: cassandra-single-writer-design
-title: "Cassandra single-writer design: persist only"
-sidebar_label: "Cassandra single-writer design: persist only"
+title: Cassandra single-writer design
+sidebar_label: Cassandra single-writer design
 ---
 
 Design notes for the compare-and-set snapshot mode of `kafka-flow-persistence-cassandra`
-(`CassandraSnapshots.withSchema(compareAndSet = true)`). What ships is small — one conditional
-predicate on each `persist` — so these notes spend little time on mechanics. Their weight is on the
-design choices: where the persist-only line is drawn and why, and the full solution (offset-gated
-deletes) that was designed and then deferred — because the reasons it was deferred are
-the main thing a future author needs before reopening it.
+(`CassandraSnapshots.withSchema(compareAndSet = true)`) — the mechanism and its subtleties. User-facing
+enablement, costs and rollout guidance are in
+[Persistence](persistence.md#protecting-against-stale-snapshot-writes). The Kafka backend solves the
+same problem differently — see [Kafka single-writer design](kafka-single-writer-design.md).
 
-Operational guidance (enabling, consistency levels, TTL, rollout) is in
-[Persistence](persistence.md). The Kafka backend solves the same problem with a different mechanism —
-see [Kafka single-writer design](kafka-single-writer-design.md).
+The conditional write itself is the easy part. Most of this document is about not fencing the
+*legitimate* owner: the delete path, the replay window and deleted-key recovery are where a
+lightweight-transaction guard that looks trivial turns out not to be.
 
 ## Problem
 
-[kafka-flow#732](https://github.com/evolution-gaming/kafka-flow/issues/732): consumer-group ownership
-of the input topic does not extend to the snapshot store. During a rebalance a previous owner that has
-not yet observed the revocation keeps flushing snapshots alongside the new owner; the snapshots table
-is last-write-wins, so a stale snapshot can overwrite a newer one, and the next recovery loads stale
-state while resuming from the committed offset — the events in between are lost from the state. The
-[Kafka design doc](kafka-single-writer-design.md) covers the failure in full, with a diagram.
+[kafka-flow#732](https://github.com/evolution-gaming/kafka-flow/issues/732): during a rebalance a
+previous owner that has not yet observed the revocation keeps flushing snapshots alongside the new
+owner, and the last-write-wins snapshots table lets a stale write overwrite a newer one — the next
+recovery then loads stale state and skips the events in between. The
+[Kafka design doc](kafka-single-writer-design.md) covers the failure in full. The Cassandra-specific
+point: Cassandra has a conditional write (a Paxos lightweight transaction) but no transaction to bind
+the input-offset commit to, so the fence is **per write**, not a transaction.
 
-Kafka's fix does not transfer. There, the snapshot write is bound to the input-offset commit in one
-broker transaction, and the consumer generation — authoritative for ownership — fences the commit.
-Cassandra offers no transaction to bind a Kafka offset commit into, and holds no notion of who owns a
-partition. What it does offer is a conditional write: a lightweight transaction (LWT), linearizable
-per partition key. So the fence must be built from something the snapshot itself carries, and checked
-per write, per key.
+## Mechanism: compare-and-set
 
-## Design
-
-The stored offset is the per-key
-[fencing token](https://martin.kleppmann.com/2016/02/08/how-to-do-distributed-locking.html). Every
-snapshot already carries the offset it was folded up to, and #732 corruption is stale *by offset* — a
-lower-offset snapshot replacing a higher-offset one. So each persist asserts the stored offset is not
-greater than the one being written, and the newest-by-offset snapshot wins, whoever writes it:
+The stored offset is a per-key [fencing token](https://martin.kleppmann.com/2016/02/08/how-to-do-distributed-locking.html):
+every persist asserts the stored offset is not greater than the one being written, so the
+newest-by-offset writer wins regardless of who it is. The write is a Paxos lightweight transaction,
+linearizable per partition key, so concurrent writers to one key are ordered without relying on clock
+synchronisation:
 
 ```sql
-UPDATE snapshots_v2 SET ..., offset = :offset WHERE <key> IF offset <= :offset
+UPDATE snapshots_v2 SET ... , offset = :offset WHERE <key> IF offset <= :offset
 ```
 
-A key's first persist finds no row, so the `UPDATE` does not apply and falls back to
-`INSERT ... IF NOT EXISTS`, retried once through the gated `UPDATE` if it loses an insert race. This
-compound of separate LWTs is the one non-atomic path, and it is safe by construction: both `UPDATE`s
-are offset-gated and the `INSERT` only writes an absent cell, so no interleaving overwrites a newer
-snapshot. Its worst case is an over-rejection, never corruption: a delete slipping between the
-`INSERT` and its retry surfaces as a spurious conflict, cleared on the next flush. A rejected write
-raises `SnapshotWriteConflict`.
+The first write of a key finds no row, so the conditional `UPDATE` does not apply; it falls back to
+`INSERT ... IF NOT EXISTS`. If that loses a race to a concurrent insert, the conditional `UPDATE` is
+retried once, so the newest snapshot still wins a first-write race. A rejected write raises
+`SnapshotWriteConflict`. A not-applied result reports the stored `offset` when Cassandra returns it
+and treats its absence as "row absent" (a present-but-null `offset` is instead a guard-expired row —
+see *TTL reconfiguration and the expired guard*).
 
-Three choices in the predicate carry most of the design:
+The guard is per **key**, the right granularity: #732 corruption is per key and keys are independent,
+so per-key monotonic durability is exactly what prevents it.
 
-- **Per key, not per partition.** #732 corruption is per key and keys are independent, so per-key
-  monotonic durability is exactly the guarantee needed. Anything per-partition would require an
-  ownership authority Cassandra does not have (see *Rejected alternatives* for what importing one
-  would cost).
-- **`<=`, not `<`.** The legitimate owner can write at an offset it has already stored — a
-  timer-driven re-flush of the buffered high-water snapshot — and a strict `<` would fence the owner
-  against itself. Admitting an equal offset is safe because a same-offset write cannot move the
-  recovery point, so it cannot drop committed events. It also means a stale writer holding *exactly*
-  the stored offset goes undetected — accepted for the same reason.
-- **Ordered by data, not by identity.** The token orders writes by what they contain, not by who sent
-  them, so the fence needs no clock synchronisation, no lease and no liveness protocol — but it can
-  never say "you are not the owner", only "you are behind". Closing that gap needs a generation in
-  the token (see *Rejected alternatives* and *Forward-looking*).
+## Delete: offset-carrying tombstone
 
-Two snapshots at the same offset have folded the same records, so admitting equal offsets is sound
-only when folds are deterministic and replayable — already a precondition of recovery generally, but
-this mode leans on it harder.
+A delete cannot be a plain `DELETE`. Removing the row removes the `offset` guard with it, so a lagging
+zombie's `INSERT ... IF NOT EXISTS` at a lower offset would then succeed — resurrecting a stale
+snapshot. A later recovery would fold new events onto that resurrected base, silently losing the
+delete: #732 reintroduced for that key.
 
-### Why the store is the whole change
+So the compare-and-set delete (`deleteCompareAndSet`) writes an offset-carrying logical **tombstone**
 
-The mode deliberately changes nothing outside `CassandraSnapshots`: no buffer change, no recovery
-change, no new read. That is possible because core already guarantees the legitimate owner never
-presents an offset below what it recovered: `SnapshotFold` drops replayed records at or below the
-recovered snapshot's offset before they reach the fold, so nothing is re-derived — or re-persisted —
-below a key's recovered high-water even while the partition replays from a lower committed offset.
-The fence therefore only ever rejects genuinely stale writers, and liveness comes for free.
+```sql
+UPDATE snapshots_v2 SET value = null, offset = :offset WHERE <key> IF offset <= :offset
+```
 
-That property is load-bearing, not incidental. The deferred design below is the story of what happens
-when it stops holding: fencing deletes breaks it, and repairing it pulls the buffer and both recovery
-paths into the change.
+keeping the row (and its `offset`). A stale lower-offset writer is then rejected, not resurrected; a
+replayed delete is a no-op (equal offset) or a conflict (a newer write exists), never a resurrection;
+a read surfaces the null `value` as a `Stored.Tombstone` (no live value). The tombstone is reaped by
+the TTL, if configured. Keeping the row also routes the delete through Paxos, avoiding the well-known
+hazard of mixing lightweight transactions and regular mutations on the same row.
 
-## Scope: deletes are not fenced
+### A never-persisted key
 
-`delete` stays a plain last-write-wins row `DELETE`. During an ownership overlap a stale writer can
-therefore still erase a newer snapshot, or resurrect a just-deleted key by writing at a lower
-offset — #732 residual for exactly the keys a fold deletes concurrently with re-writes.
+The tombstone above assumes the delete finds a row to gate. A key created and deleted within a single
+flush window is never durably persisted, so its delete finds no row — and `Persistence.delete`
+dispatches such a buffer-only delete `persist = false`, which for economy would normally skip the store
+write. In a *fenced* store that skip reopens exactly the resurrection above: with no tombstone, and the
+consumer offset committed past the delete, a revoked owner (zombie) still holding the key's buffered
+pre-delete snapshot can flush it onto the absent row — gated only by this store's compare-and-set, not
+the consumer generation — durably resurrecting the deleted key, permanently, since recovery then resumes
+past the delete. So a fenced store writes the tombstone even for a never-persisted key:
+`Snapshots.delete` overrides `persist = false` when fenced, and `deleteCompareAndSet`'s row-absent branch
+INSERTs the offset-carrying tombstone `IF NOT EXISTS` (mirroring the persist first-write compound, with
+the same lost-race retry) rather than no-opping. The economy — skip the write — is kept only for the
+unfenced last-write-wins store, which has no offset gate to arm anyway. The window is narrow (a
+create-and-delete within one flush interval, overlapping a zombie that still holds the pre-delete
+snapshot), but the resurrection it admits is permanent, so the fence is unconditional in fenced mode.
 
-Drawing the line here is a choice, not an oversight:
+Gating deletes has an API cost — the offset must reach the store through the delete path, a breaking
+change for custom stores; see [Compatibility and rollout](#compatibility-and-rollout).
 
-- **A fenced deletion is still expressible.** Instead of folding to `None`, fold to an
-  offset-carrying *empty* state (`Some(empty)`): the deletion then travels the fenced persist path
-  and a lower-offset zombie is rejected exactly as for any persist. The store's row lives until its
-  TTL — the cost of the workaround.
-- **Fencing `delete` itself costs out of all proportion to the predicate above** — a breaking API and
-  new recovery machinery, with a liveness trap on each recovery path. That is the deferred design
-  below.
+## The replay window
 
-## The expired guard (TTL reconfiguration)
+A delete and a re-persist are fenced on an offset that, just after recovery, can legitimately trail
+the key's own stored snapshot. The partition resumes from the committed offset `C` (the minimum offset
+still held across all of its keys); a single slow key can hold `C` well below a fast key's durable
+snapshot offset `X` (the offset-lags-state invariant only guarantees `C <= X`). On recovery the
+partition's processing offset starts at `C`, while the recovered snapshot's offset is `X`.
 
-Cassandra TTLs are per **cell** and fixed at write time, and a row stays visible while any live cell —
-or the first write's `INSERT` row marker (immortal only when that first write ran without a `ttl` and
-the table has no `default_time_to_live`) — survives. Under a uniform `ttl` from the first deployment
-it is unreachable: the delete co-writes `offset` with `value`, so a visible row always carries a live
-guard. It is a **reconfiguration / pre-TTL-legacy** hazard — enabling (or shortening) the `ttl` between writes of a key can leave a
-visible row whose `offset` guard cell has expired while an earlier, longer-lived cell or marker
-survives: e.g. a no-TTL deployment's first write (immortal marker), TTL'd re-persists, then idleness
-past the TTL — every column null, nothing to fence. `get` already reads such a row as absent (its `value` cell is expired)
-and a plain delete removes it entirely, but no regular persist could ever claim it: the null guard
-fails `IF offset <= :offset`, the not-applied result looks like "row absent" (it is not — Cassandra
-returns the condition column, null, exactly when the row exists), `INSERT ... IF NOT EXISTS` loses to
-the still-visible row, and the retry conflicts — every write of the key raising
-`SnapshotWriteConflict`, forever. So the write path distinguishes the guard-expired result and repairs
-it with a Paxos-safe `IF offset = null` persist that reinstates the guard
-(`Statements.prepareRepairPersist`; racing repairs serialize, the loser conflicts as usual). The
-repair re-arms the guard but (being an `UPDATE`) cannot remove an immortal marker, so such a row
-re-poisons after each `ttl` until an owner deletes/reaps it — palliative, not curative. `SnapshotTtlEdgeSpec` pins the state and the repair against real
-Cassandra. Prefer configuring the `ttl` from the first deployment anyway.
+```mermaid
+sequenceDiagram
+    participant F as Owner<br/>(just recovered)
+    participant B as Snapshot buffer
+    participant DB as snapshots_v2<br/>(IF offset <= :offset)
 
-## Compatibility
+    Note over DB,F: key recovered at snapshot offset X.<br/>partition resumes at committed offset C < X (a slow key held C back)
+    F->>B: replay event at offset < X
+    Note over B: buffer kept monotonic — holds high-water X,<br/>does not regress to the replayed offset
+    F->>B: tick deletes the key (processing offset < X)
+    B->>DB: delete gated on max(processing offset, X) = X
+    Note over DB: IF offset <= X holds, the legitimate owner applies.<br/>Gating on the processing offset (< X) would be rejected<br/>as stale — the owner fencing itself.
+```
 
-- **No public API change**, hence no major version: the mode is an opt-in flag
-  (`compareAndSet = true`, default `false`) on the existing entry points.
-- **No schema migration in either direction**: the condition reads the `offset` column every version
-  already writes. Rolling deploys are safe; the mixed-mode clock-skew caveat is in
-  [Persistence](persistence.md).
-- **The fence is write-side only.** Recovery reads at the regular (non-serial) consistency level, so
-  the guarantee reaches the reader only when `R + W > N` — with weaker levels a recovery read can
-  miss the newest committed snapshot and reintroduce #732 on the read side. Required levels and the
-  serial-consistency setting are in [Persistence](persistence.md).
+If, in this window, the owner issues a write for that key:
+
+- a **time-driven tick** that deletes the key would gate the delete on the processing offset `C` —
+  `IF offset <= C` against the stored `X > C` rejects it, **crashing the legitimate owner** with a
+  `SnapshotWriteConflict` that reads as if another writer owned the key;
+- a **periodic flush** during replay would re-derive the snapshot and try to persist it at the
+  replayed offset (`< X`) — the same rejection.
+
+Neither is a safety problem (the durable snapshot stays at `X`), but both are a liveness problem: the
+owner fences *itself*. The cause is that a naive buffer `append` regresses the in-memory snapshot's
+offset while replaying events below `X`.
+
+The fix keeps the buffered snapshot **monotonic in offset**: `Snapshots.append` drops a lower-offset
+append rather than regressing the buffer (sound because, under the determinism the design already
+assumes, re-folding events `<= X` reproduces the same state — see below). The buffer therefore stays
+at the key's high-water `X`, so
+
+- a delete is fenced on `max(currentOffset, highWater)` — the legitimate owner presents `X` and
+  applies, while a genuinely stale writer (which only ever *reached* its own lower offset, never `X`)
+  still presents that lower offset and stays fenced;
+- a re-derived snapshot is not re-persisted below `X` (the buffer stays `persisted`), so the flush is
+  a no-op.
+
+Of these two, only the **delete** is irreducible *for a live recovered snapshot*. `SnapshotFold` folds
+only records past the recovered offset (`record.offset > snapshot.offset`), so a re-derived snapshot
+below `X` is never even appended — the monotonic `append` is belt-and-suspenders for the persist case. A **tick-delete**
+(`TickToState`) is timer-driven and bypasses that filter, so only the monotonic buffer lets a legitimate
+tick-delete apply during replay.
+
+The fence is live only for the compare-and-set wiring, which passes `Some(_.offset)`; the
+last-write-wins Cassandra module and other stores wire unfenced (`None`) — their stores never reject a
+write or return a tombstone floor, so the fenced buffer would only change their buffering semantics
+and add a per-key floor read to events-recovery (`CassandraPersistence.snapshotsOf` keeps the fence
+mode-scoped). It is surgical even when live: `max(currentOffset, highWater)` differs from
+`currentOffset` only inside this replay window.
+
+This fence and the tombstone above are independent and complementary: presenting the higher `highWater`
+for a delete makes the tombstone it writes *more* protective against a lower-offset revive, never less.
+
+### Recovering a deleted key
+
+Both protections above are keyed on the high-water `X`, which a recovery establishes from the *recovered
+snapshot's* offset. But a deleted key's row is a tombstone — its `value` is null, read back as absent — so
+a read that surfaced only the value would establish no floor: the buffer would start empty and
+`Snapshots.append` would climb from the replayed offsets (all `< X`), re-persisting below `X`. The
+offset-`X` tombstone then rejects that write, fencing the *legitimate* owner; the flow tears down,
+re-recovers the same tombstone (again no floor), and loops — a livelock. (`SnapshotFold`'s filter is keyed
+on the same recovered offset, so it too has no floor for a tombstone; the monotonic buffer is what carries
+the deleted-key case. A replay-window tick-**delete** here is dispatched `persist = false`; in a fenced
+store that still writes the tombstone — see *A never-persisted key* above — but harmlessly, either creating
+the fence or, when a tombstone floor was recovered, idempotently re-stamping it at the high-water `X`.)
+
+So recovery must surface the tombstone's offset as the floor, not collapse it to "nothing there".
+`SnapshotDatabase.read` returns `Stored.Tombstone(X)` for a tombstone — value-less but carrying the
+offset — distinct from `None` for a reaped or never-written key (and from `Stored.Live(v, X)` for a
+live snapshot); `Snapshots` holds `X` as the buffer high-water even with no buffered value, so a re-derived
+snapshot below `X` is dropped exactly as for a live snapshot and the owner makes progress. The deleted-key
+recovery is thus symmetric with the live one — same floor, only the value is absent — and the floor is
+re-established on every recovery, so the livelock cannot form. (Because `read` returns one `Stored`, a
+wrapper such as the metrics one has a single read to delegate — there is no separate value-only path that
+could silently drop the tombstone's offset.)
+
+The same hazard reaches the **events-recovery** mode (`restoreEvents`), where state is restored by folding
+the journal rather than reading the snapshot. A delete clears the key's journal, so the fold yields `None`
+and the high-water `X` survives only on the snapshot tombstone — the buffer would again start with no floor.
+So events-recovery reads the snapshot store (`ReadState` runs `Snapshots.read`, seeding the buffer cell —
+a tombstone's floor, or a live snapshot) before folding the journal. The read runs only for a fencing
+buffer — an unfenced one never reads back a tombstone, so the per-key round-trip is skipped.
+
+Events-recovery has a second, subtler exposure: **the journal revive**. The journal is *unfenced* —
+appends are plain inserts, so nothing stops a stale owner's replayed appends from landing *after* a
+delete cleared the journal (nor a journal TTL from reaping its tail below a live snapshot). Those
+residue rows sit *below* the deletion tombstone's offset. A recovery that folds the whole journal
+resurrects the deleted key *durably*, because the flow then persists forward from a fresh offset and
+every later write legitimately passes the fence.
+
+The guard folds the journal **onto the fenced store's view, skipping every journal row at or below the
+store's offset** (`ReadState`, via `Snapshots.floor`): a tombstone's offset or a live snapshot's offset
+is the floor, and residue below it is dropped — it is either already reflected in the recovered base or
+stale pre-delete garbage. Crucially the filter is on the *event offset*, not on the fold's result. An
+earlier attempt compared the fold's result to the store and discarded a fold that *trailed* it; that
+holds at the first recovery but fails at the next: once legitimate post-delete events advance the
+journal to or past the store's offset, the polluted fold no longer trails and the pre-delete residue
+sails back through (offset is not provenance — a corrupt fold can trail, equal, *or* lead the store).
+Filtering rows by offset keeps the residue below the floor forever, so the guard holds at *every*
+recovery. This guard is only possible in the fenced mode: last-write-wins keeps no trustworthy floor to
+filter against, so under LWW events-recovery remains exposed to the revive (a pre-existing property of
+the unfenced journal, not something compare-and-set introduces — see `persistence.md`).
+
+The delete's two-store order is load-bearing here: `Buffers.delete` writes the snapshot tombstone
+*before* clearing the journal, so a crash between them leaves the durable tombstone plus journal residue
+below it — which the floor filter drops — rather than a cleared journal with no tombstone, which would
+silently lose the delete. The filter tolerates residue; it cannot recover a delete that never became
+durable.
+
+## Equal-offset writes and determinism
+
+`IF offset <= :offset` admits an *equal* offset, so a stale writer holding exactly the stored offset is
+not detected. This is deliberate. The legitimate owner can act at an offset it has already stored: a
+tick can change state — or delete — without consuming a new record, and in the replay window above a
+tick-delete is fenced on the high-water `X`, which equals the stored offset; a strict `<` would reject
+these and fence the owner against itself. Admitting equal is safe not because the new value is identical
+but because a same-offset write does not move the recovery point — unlike a lower-offset write it cannot
+drop committed events (#732). The *records* folded into any two snapshots at the same offset are the
+same, so a same-offset re-persist differs at most in time-driven tick state, never in event data; a
+replayed delete is a no-op. Deterministic, replayable folds are therefore a precondition of the CAS
+mode (as they already are of recovery generally) — the same property that lets the monotonic buffer
+drop a lower-offset replay as a no-op.
+
+## Consistency
+
+The write-side fence only closes #732 if recovery reads can see what fenced writes committed, so
+compare-and-set requires read **and** write consistency at a quorum (`R + W > N`). The conditional
+write reaches consensus on a serial quorum but *materialises* at `ConsistencyOverrides.write`; with a
+weaker write level a quorum recovery read can miss the newest committed snapshot even with no in-flight
+Paxos — #732 reintroduced on the read side, which the write-side fence does not heal. And this is not
+defaulted: `ConsistencyOverrides` is empty unless you set it, so the snapshot table inherits the
+session's default level (often `LOCAL_ONE`) — you must configure both to a quorum.
+
+A *serial* read is not required: `R + W > N` already makes a non-serial read see every committed
+snapshot, and a still-in-flight write — one whose `persist` has not completed — is safe to miss
+(recovery re-folds from the committed offset).
+
+The Paxos consensus itself runs at the *serial* consistency level, which is separate from
+`ConsistencyOverrides` (whose write level governs only the commit phase) and defaults to `SERIAL` — a
+cross-datacenter quorum. For single-datacenter partition ownership (the common case) set the scassandra
+client's `query.serial-consistency = LOCAL_SERIAL`, or every conditional write and delete pays a
+cross-datacenter round-trip.
+
+Pick the levels by ownership locality, not by the replication footprint (which may still span DCs for
+DR): what matters is that a key's writers and its recovery read share one consistency domain. Single-DC
+ownership pairs `LOCAL_QUORUM` reads/writes with `LOCAL_SERIAL`; ownership that can fail over between
+DCs (or write a key from two DCs) needs the cross-DC `QUORUM` / `SERIAL` levels.
+
+## Compatibility and rollout
+
+**A breaking store API.** Gating deletes means a delete must carry an offset to the store, and recovery
+must read a tombstone's offset back (the replay-window floor above). The store interface therefore
+exchanges one `Stored` unit both ways — `read` distinguishes a live snapshot, an offset-carrying
+tombstone and an absent row; `write` takes a `Stored.Live` or a `Stored.Tombstone` — replacing the
+previous `get` / `persist` / `delete` triple, and the per-key buffer's delete gains the offset
+(`delete(persist, offset)`). Source- and binary-breaking for custom `SnapshotDatabase` implementations,
+hence a major-version bump. The alternative — fencing persists only — needs no API change but leaves
+every deleted key open to resurrection (see Rejected alternatives).
+
+**Rolling deploy.** Enabling on a running system needs no data migration (the condition reads the
+`offset` column every version already writes). The one caveat: a lightweight transaction uses a
+coordinator-generated write timestamp while a regular write uses a client-side one, so during a mixed
+deploy an application clock running ahead of the coordinators can let an old (plain-write) instance's
+snapshot shadow a newer conditional one. Negligible with NTP-synced clocks, and gone once every
+instance writes conditionally.
+
+**TTL.** The `offset` guard lives in the snapshot row, so it expires with the row's TTL: once a row's
+TTL lapses a stale write can land a fresh `INSERT`. Harmless when the TTL far exceeds the
+rebalance/zombie overlap window (the usual case — a zombie outliving the TTL is not realistic), but the
+monotonicity guarantee only holds within the TTL. Without a TTL the offset-carrying tombstone is never
+reaped — the table grows by one row per deleted key — so configure a TTL (comfortably above the overlap
+window) for workloads that delete keys.
+
+**TTL reconfiguration and the expired guard.** Cassandra TTLs are per **cell**, and only the delete
+writes a subset of the columns (a persist rewrites all four), so enabling or shortening the `ttl`
+between a key's persist and its delete lets the `offset` guard cell expire while older, longer-lived
+cells — or the first write's `INSERT` row marker (immortal only when that write ran without a `ttl` and
+the table has no `default_time_to_live`) — keep the row visible: a row that fences nothing
+(`value = null`, `offset = null`). Under a uniform `ttl` from the first write this is unreachable — the
+delete co-writes `offset` with `value`, so a visible row always carries a live guard; it is a
+reconfiguration / pre-TTL-legacy state. Naively that row is poison: reading its offset
+decodes the null as 0 (a silently absent floor), and no regular write can claim it (`IF offset <=
+:offset` fails on the null guard while `INSERT ... IF NOT EXISTS` loses to the still-visible row — a
+permanent conflict). So the mode handles the state explicitly: `read` reports a guard-expired row as
+**absent** (a guard that is gone fences nothing — exactly a reaped row), a delete on it is an
+idempotent no-op, and a persist claims it through the Paxos-safe repair write `IF offset = null`
+(`Statements.prepareRepairPersist`), which reinstates the guard. The repair re-arms the guard but
+(being an `UPDATE`) cannot remove an immortal marker, so such a row re-poisons after each `ttl` until
+an owner deletes/reaps it — palliative, not curative. Concurrent claimants
+serialize on Paxos — but note the repair condition is `offset = null`, a nullness check, not an offset comparison:
+whoever wins reinstates the guard at *its* offset and any loser then conflicts on the reinstated guard,
+so the repair is convergent but does not by itself order two claimants by offset (it is a first-write
+claim of a guardless row, equivalent to `INSERT IF NOT EXISTS` after a full reap).
+`SnapshotTtlEdgeSpec` reproduces the state against real Cassandra and pins the
+handling. Prefer configuring the TTL from the first deployment anyway.
+
+**Cassandra preconditions.** The fence inherits the store's linearizability: run Cassandra
+≥ 3.0.24 / 3.11.10 / 4.0 — CASSANDRA-12126 broke linearizability for exactly the non-applying
+conditional-write shape this mode issues — and leave the
+`cassandra.unsafe.disable-serial-reads-linearizability` flag unset. Legacy Paxos also does not
+guarantee linearizability across range movements (bootstrap, decommission, move); Cassandra 4.1's
+Paxos v2 (`paxos_variant: v2`, with paxos repair scheduled) closes that window and is recommended.
+And only this mode's statements may touch the table — mixing plain writes into LWT-managed rows voids
+the guarantee (see the tombstone rationale above).
+
+## Implementation
+
+Entry point: `CassandraSnapshots.withSchema(compareAndSet = true)` (or
+`CassandraPersistence.withSchema(snapshotCompareAndSet = true)`). In the current code:
+
+- **Unified write / read** — `CassandraSnapshots.write` routes a `Stored`: a present value to
+  `persistCompareAndSet`, an absent value (a delete) to `deleteCompareAndSet`, both issuing the offset-gated
+  `UPDATE`/`INSERT`; `resolveConditional` classifies the result (`applied` / newer-stored-offset /
+  row-absent), shared by both. `read` returns the stored unit — a `Stored.Live` or, for a tombstone, a
+  `Stored.Tombstone` — or `None` for no row.
+- **Monotonic buffer** — `Snapshots` holds one `Stored` cell (a live snapshot or an offset-carrying
+  tombstone floor); `append` and `delete` both flow through one monotonic `put` that drops a lower-offset
+  re-persist and lifts a lower-offset delete to the high-water. Recovery seeds the cell (and thus the floor)
+  from `SnapshotDatabase.read`: `Stored.Tombstone(X)` is a tombstone at `X`, `None` is a reaped or
+  never-written key.
+- **Replay filter** — `SnapshotFold` folds only events past the recovered offset, dropping replayed
+  ones at or below it; a timer-driven
+  `TickToState` delete bypasses that filter, which is why the monotonic buffer is what carries the
+  tick-delete case.
+- **Events-recovery floor and revive guard** — `ReadState` runs `Snapshots.read` before folding the
+  journal, seeding the buffer cell from the store (a tombstone's floor or a live snapshot), gated on
+  `Snapshots.fenced` (skipped for an unfenced buffer). It then folds only the journal events whose
+  offset exceeds the seeded floor (`Snapshots.floor`) onto the store's snapshot as the base — the
+  offset filter that drops sub-floor residue at every recovery (the journal revive above).
+- **Offset accessor** — the offset-carrying wiring passes `Some(_.offset)` (live fence); other stores
+  pass `None` (unfenced, last-write-wins).
 
 ## Testing
 
-Store-level tests against real Cassandra (`SnapshotSpec`) cover monotonic persists, stale-write
-rejection, equal-offset re-persist, TTL on both write paths, and concurrent first-writers racing a
-fresh key (exercising the insert-retry compound). Flow-level tests (`FlowSpec`) run through the real
-recovery and flush machinery: the #732 reproduction shows corruption under last-write-wins, and its
-counterpart shows the stale flush rejected under compare-and-set.
+- Store-level against real Cassandra (`SnapshotSpec`, persistence-cassandra-it-tests) — monotonic
+  writes, stale-write rejection, the tombstone (no resurrection, replayed/stale delete, equal-offset),
+  idempotent delete, TTL on both the insert and update paths, and concurrent first-writers racing on a
+  fresh key (the highest offset wins, no corruption — exercising the first-write retry path).
+- Through the real PartitionFlow / eager-recovery / flush-on-revoke machinery (`FlowSpec`,
+  persistence-cassandra-it-tests) — the #732 reproduction asserts corruption under last-write-wins;
+  the prevention asserts the stale flush is rejected; and a delete during replay below the recovered
+  snapshot offset applies (fenced on the high-water), not rejected.
+- In core — the monotonic buffer and the delete fence: `SnapshotsSpec` (the buffer directly, including
+  the recovered `floor`) and `SnapshotsOfSpec` (the offset-of fencing wiring), with
+  `SnapshotReplayFencingSpec` driving the replay-window cases flow-level against an offset-gated
+  in-memory store, and `ReadStateFloorGateSpec` pinning the events-recovery seam — the fenced-only
+  floor read and the journal-revive filter, including the second-recovery re-entry on both the
+  tombstone and the live-snapshot arm.
 
-## The full solution, and why it was deferred
+## Assumptions
 
-Persist-only was carved out of a full design that also fenced deletes. That full design was
-implemented and reviewed, and none of it ships. It is summarised here because its trajectory is
-the main learning of this work: **a fence that looked like one more predicate turned into a chain of
-core changes, each forced by the previous one.**
+This design takes four things as given:
 
-1. **A fenced delete cannot remove the row.** The offset guard *is* the row: remove it and a lagging
-   zombie's `INSERT ... IF NOT EXISTS` at a lower offset succeeds, resurrecting a stale snapshot. So
-   a fenced delete must be a logical **tombstone** — the row kept, value nulled, offset gated on the
-   same predicate as a persist (`SET value = null ... IF offset <= :offset`).
-
-2. **The tombstone forces a breaking API.** The gate needs the delete's offset, but
-   `SnapshotWriteDatabase.delete(key)` does not carry one — fencing deletes means a source- and
-   binary-breaking `delete(key, offset)` through every delete path and every custom store. A major
-   version, for this alone.
-
-3. **The buffer must become monotonic, or the owner fences itself.** After recovery a key can hold a
-   durable snapshot at offset `X` while the partition replays from a lower committed offset `C` (a
-   slow *other* key held `C` back). A timer-driven delete in that window would be gated on the
-   processing offset `< X` and rejected — the fence crashing the *legitimate* owner. The fix keeps
-   the per-key buffer monotonic in offset and gates a delete on the key's high-water `X`, which the
-   true owner presents and a genuinely stale writer never reached. Note the persist case needs no
-   such fix (`SnapshotFold` filters replayed records); it is the timer-driven *delete*, which
-   bypasses that filter, that forces the buffer change.
-
-4. **Recovery must learn to see tombstones, or the owner livelocks.** The base read is `get`, typed
-   `Option[S]`: a value or nothing. A tombstone comes back as `None`, indistinguishable from a
-   never-written key — so recovery seeds no high-water, the buffer climbs from replayed offsets
-   `< X`, and the offset-`X` tombstone rejects the owner's own flush. The flow tears down,
-   re-recovers the same floorless tombstone, and repeats:
-
-   ```mermaid
-   sequenceDiagram
-       participant O as Owner (recovering)
-       participant DB as snapshots table
-       Note over DB: tombstone: value = null, offset = X
-       O->>DB: recover: get(key) → None (offset X invisible)
-       O->>O: replay events from committed offset C < X
-       O->>DB: flush re-derived snapshot at offset < X
-       DB-->>O: IF offset <= X fails: SnapshotWriteConflict
-       Note over O: tear down, re-recover the same None,<br/>repeat — livelock
-   ```
-
-   The fix is a new recovery read that surfaces `Deleted(offset)` where `get` says `None`, seeding
-   the buffer's floor.
-
-5. **Events-recovery re-opens the livelock on its own.** `restoreEvents` rebuilds state by folding
-   the *journal*, not by reading the snapshot store — and a delete clears the journal, so the fold
-   yields nothing and the floor is lost again, untouched by the fix above. Events-recovery must read
-   the snapshot store purely for the tombstone floor before folding. A delete fence that seeds the
-   floor only on snapshot recovery still livelocks here; the two seedings are independent.
-
-**What the analysis showed.** Safety was never at risk: a rejected write changes nothing and the
-durable offset never regresses, in every configuration. Every defect was a **liveness** failure — the
-self-fence and the livelocks above — and each fix proved necessary: with the monotonic buffer or the
-tombstone floor removed, liveness fails while safety still holds, reached through a live snapshot in
-one configuration and through a deleted key in another. With both in place, a single writer's durable
-offsets stay monotonic for both safety and liveness.
-
-**The deferral decision.** On the benefit side, fencing `delete` protects only folds that return
-`None` — a need already coverable by the empty-state persist above. On the cost side: a major version
-for every custom snapshot store; invasive changes to the buffer and both recovery paths — the hottest
-code in core; and a liveness surface subtle enough to be a maintenance risk in its own right, not
-just implementation effort. Timing sharpened the call:
-[KIP-939](https://cwiki.apache.org/confluence/display/KAFKA/KIP-939:+Support+Participation+in+2PC)
-(participation in 2PC) may eventually let a Cassandra snapshot write bind to a generation-fenced
-Kafka offset commit, giving per-partition ownership that supersedes a per-key delete fence — making
-the deferred machinery potentially throwaway. So the full design was parked where it can be resumed,
-and the persist-only subset shipped.
-
-The learning generalises: in a last-write-wins store, fencing *writes* is cheap — the token rides the
-data. It is *deletion* that is expensive, because deletion removes the very cell that carries the
-fence, and every fix for that (tombstones, floors, monotonic buffers) leaks upward into recovery.
+- **Per-key linearizable compare-and-set.** Each Cassandra lightweight transaction on a row is an atomic,
+  linearizable operation (Paxos). The first-write `UPDATE`/`INSERT`/retry compound is *not* atomic.
+- **Deterministic, replayable folds (a user contract).** Re-folding a recovered base over the same events
+  reproduces the same state. This is what makes a lower-offset replay a no-op (so the buffer can stay
+  monotonic) and what makes equal-offset writes idempotent. A non-deterministic fold breaks both.
+- **Per-key independence.** #732 corruption is per key; keys are independent, so per-key monotonic
+  durability is the whole guarantee.
+- **Per-key serialization of a key's fold, tick and flush.** The buffer cell's individual operations are
+  atomic, but `Snapshots`' flush (read the cell → write the database → mark it persisted) is not one
+  atomic step; nor is a delete's decision to persist. kafka-flow never runs a key's processing, its
+  timers, and its flush concurrently (one poll thread per partition drives them in sequence), so no
+  concurrent `append` can slip between a flush's database write and its mark-persisted. A mid-flush timer
+  on another thread would break this — a concurrency hazard, not a clock one, and out of scope here.
 
 ## Rejected alternatives
 
-- **Offset-as-write-timestamp (LWW register)**: write each snapshot `USING TIMESTAMP <offset>` and
-  let Cassandra's own last-write-wins reconciliation keep the highest-offset cell — a plain quorum
-  write, much cheaper than Paxos, and a delete becomes a tombstone ordered by offset for free.
-  Rejected: equal-offset replacement breaks (at equal timestamps Cassandra breaks ties by value, not
-  write order), a rolling deploy inverts catastrophically (old instances' wall-clock timestamps
-  dominate every offset-as-timestamp value), and it discards the real write timestamps.
-- **Lease / ownership table**: a per-partition lease acquired with one LWT, then cheap plain writes.
-  The lease alone does not stop a paused leaseholder's in-flight plain writes (last-write-wins still
-  applies), so a per-write fencing token is still required — at which point the lease adds only
-  liveness and expiry concerns on top of the per-write CAS.
+- **Persist-only scope (deletes unfenced)**: gate `persist` and keep `delete` a plain row removal — no
+  store-API change, no major-version bump. Rejected as the end state: removing the row removes the
+  `offset` guard with it, so a zombie's lower-offset `INSERT ... IF NOT EXISTS` resurrects any deleted
+  key (see Delete above) — #732 stays open exactly where keys are deleted, and the plain delete mixes a
+  regular mutation into a lightweight-transaction row. Viable only as an interim step for workloads
+  that never delete keys.
+- **Offset-as-write-timestamp (LWW register)**: write each snapshot `USING TIMESTAMP <offset>` and let
+  Cassandra's last-write-wins reconciliation keep the highest-offset cell — a plain quorum write, much
+  cheaper than a Paxos round, and a delete becomes a tombstone ordered by offset. Rejected as the
+  default: equal-offset replacement breaks (at equal timestamps Cassandra breaks ties by value, not
+  write order), a rolling deploy inverts catastrophically (old instances write wall-clock timestamps
+  that dominate every offset-as-timestamp value), and it discards the real write timestamps.
+- **Lease / ownership table**: a per-partition lease acquired with one LWT, then cheap writes. The
+  lease alone does not stop a paused leaseholder's plain writes (last-write-wins still applies), so a
+  per-write fencing token is still required — at which point the lease only adds liveness/expiry
+  concerns on top of the per-write CAS.
 - **Composite `(offset, generation)` token**: gate on the consumer generation as well as the offset,
-  closing the equal-offset gap and giving per-partition ownership. Rejected as the default because it
-  couples the self-contained Cassandra module to the live consumer generation; reasonable as a future
-  strict mode.
-- **Recovery-side reconciliation** (store the offset, reconcile on read): does not prevent the stale
-  overwrite — last-write-wins still corrupts the store — so strictly weaker than fencing the write.
+  closing the equal-offset gap and giving per-partition (not just per-key) ownership. Generation
+  *alone* — the Kafka mode's sole mechanism — is not enough here: there the group coordinator validates
+  the generation server-side, while a Cassandra condition only compares self-reported numbers, so
+  correctness would rest on every ownership change bumping the generation (static membership shares a
+  generation across incarnations of an instance; a recreated or renamed group resets it) — whereas the
+  offset is the #732 invariant itself and already in the row. Generation can therefore only complement
+  the offset, never replace it. Rejected as a default because it couples the self-contained Cassandra
+  module to the live consumer generation; reasonable as a future strict mode.
+- **Recovery-side reconciliation** (store the offset, recover from the lowest): does not prevent the
+  stale overwrite (last-write-wins still corrupts), so strictly weaker than fencing the write.
 
 ## Forward-looking
 
-- **Offset-gated deletes** — the deferred design above; a candidate for a future major
-  version if the empty-state workaround proves insufficient in practice.
-- **Per-partition ownership** — a composite `(offset, generation)` strict mode, or, further out,
-  [KIP-939](https://cwiki.apache.org/confluence/display/KAFKA/KIP-939:+Support+Participation+in+2PC):
-  an externally-coordinated two-phase commit binding the Cassandra snapshot write to a
-  generation-fenced Kafka offset commit — per-partition ownership without per-key CAS. Not actionable
-  now; see the Kafka design doc's forward-looking note.
+[KIP-939 (participation in 2PC)](https://cwiki.apache.org/confluence/display/KAFKA/KIP-939:+Support+Participation+in+2PC)
+could extend a Kafka generation fence to this Cassandra store: a transactional producer in an
+externally-coordinated two-phase commit could bind the Cassandra snapshot write to a generation-fenced
+Kafka input-offset commit, giving Cassandra per-partition ownership without the per-key compare-and-set.
+Not actionable now; see the Kafka design doc's forward-looking note.

--- a/docs/cassandra-single-writer-design.md
+++ b/docs/cassandra-single-writer-design.md
@@ -118,8 +118,8 @@ appended — the monotonic `append` is belt-and-suspenders for the persist case.
 (`TickToState`) is timer-driven and bypasses that filter, so only the monotonic buffer lets a legitimate
 tick-delete apply during replay.
 
-The fence is live only for the offset-carrying `KafkaSnapshot` / compare-and-set wiring; other stores
-pass `Offset.min` as the offset, making it inert (last-write-wins). It is surgical even when live:
+The fence is live only for the offset-carrying `KafkaSnapshot` / compare-and-set wiring, which passes
+`Some(_.offset)`; other stores pass `None` (unfenced, last-write-wins). It is surgical even when live:
 `max(currentOffset, highWater)` differs from `currentOffset` only inside this replay window.
 
 This fence and the tombstone above are independent and complementary: presenting the higher `highWater`

--- a/docs/cassandra-single-writer-design.md
+++ b/docs/cassandra-single-writer-design.md
@@ -112,11 +112,11 @@ at the key's high-water `X`, so
 - a re-derived snapshot is not re-persisted below `X` (the buffer stays `persisted`), so the flush is
   a no-op.
 
-Of these two, only the **delete** is irreducible. `SnapshotFold` already drops replayed events
-(`record.offset > snapshot.offset`), so a re-derived snapshot below `X` is never even appended — the
-monotonic `append` is belt-and-suspenders for the persist case. A **tick-delete** (`TickToState`) is
-timer-driven and bypasses that filter, so only the monotonic buffer lets a legitimate tick-delete
-apply during replay.
+Of these two, only the **delete** is irreducible *for a live recovered snapshot*. `SnapshotFold` drops
+replayed events (`record.offset > snapshot.offset`), so a re-derived snapshot below `X` is never even
+appended — the monotonic `append` is belt-and-suspenders for the persist case. A **tick-delete**
+(`TickToState`) is timer-driven and bypasses that filter, so only the monotonic buffer lets a legitimate
+tick-delete apply during replay.
 
 The fence is live only for the offset-carrying `KafkaSnapshot` / compare-and-set wiring; other stores
 pass `Offset.min` as the offset, making it inert (last-write-wins). It is surgical even when live:
@@ -124,6 +124,28 @@ pass `Offset.min` as the offset, making it inert (last-write-wins). It is surgic
 
 This fence and the tombstone above are independent and complementary: presenting the higher `highWater`
 for a delete makes the tombstone it writes *more* protective against a lower-offset revive, never less.
+
+### Recovering a deleted key
+
+Both protections above are keyed on the high-water `X`, which a recovery establishes from the *recovered
+snapshot's* offset. But a deleted key's row is a tombstone — `get` reads its null `value` back as `None`
+(absent) — so a recovery that only knew `get` would establish no floor: the buffer would start empty and
+`Snapshots.append` would climb from the replayed offsets (all `< X`), re-persisting below `X`. The
+offset-`X` tombstone then rejects that write, fencing the *legitimate* owner; the flow tears down,
+re-recovers the same tombstone (again no floor), and loops — a livelock. (`SnapshotFold`'s filter is keyed
+on the same recovered offset, so it too has no floor for a tombstone; the monotonic buffer is what carries
+the deleted-key case. The tick-**delete** path does not arise here: after a `None` recovery nothing is yet
+persisted, so a replay-window tick-delete is dispatched `persist = false` — buffer-only, never reaching the
+store.)
+
+So recovery must surface the tombstone's offset as the floor, not collapse it to "nothing there".
+`SnapshotDatabase.recover` returns `Recovered.Deleted(X)` for a tombstone (distinct from `Recovered.Absent`
+for a reaped or never-written key); `Snapshots` holds `X` as the buffer high-water even with no buffered
+value, so a re-derived snapshot below `X` is dropped exactly as for a live snapshot and the owner makes
+progress. The deleted-key recovery is thus symmetric with the live one — same floor, only the value is
+absent — and the floor is re-established on every recovery, so the livelock cannot form. (`recover`
+defaults to `get` for stores without tombstones; a wrapper such as the metrics one must delegate to the
+underlying `recover`, or it silently downgrades a tombstone back to `Absent`.)
 
 ## Equal-offset writes and determinism
 

--- a/docs/cassandra-single-writer-design.md
+++ b/docs/cassandra-single-writer-design.md
@@ -1,0 +1,200 @@
+---
+id: cassandra-single-writer-design
+title: Cassandra single-writer design
+sidebar_label: Cassandra single-writer design
+---
+
+Design notes for the compare-and-set snapshot mode of `kafka-flow-persistence-cassandra`
+(`CassandraSnapshots.withSchema(compareAndSet = true)`) — the mechanism and its subtleties. The Kafka
+backend solves the same problem differently — see [Kafka single-writer design](kafka-single-writer-design.md).
+
+## Problem
+
+[kafka-flow#732](https://github.com/evolution-gaming/kafka-flow/issues/732): during a rebalance a
+previous owner that has not yet observed the revocation keeps flushing snapshots alongside the new
+owner, and the last-write-wins snapshots table lets a stale write overwrite a newer one — the next
+recovery then loads stale state and skips the events in between. The
+[Kafka design doc](kafka-single-writer-design.md) covers the failure in full.
+
+## Mechanism: compare-and-set
+
+Cassandra has no transaction to bind the input-offset commit to, the way the Kafka backend does — but
+it does offer a conditional write (a Paxos lightweight transaction), so the fence is **per write**. The
+stored offset is the per-key [fencing token](https://martin.kleppmann.com/2016/02/08/how-to-do-distributed-locking.html):
+every persist asserts the stored offset is not greater than the one being written, so the
+newest-by-offset write wins, whoever issued it. The write is linearizable per partition key, so
+concurrent writers to one key are ordered without relying on clock synchronisation:
+
+```sql
+UPDATE snapshots_v2 SET ... , offset = :offset WHERE <key> IF offset <= :offset
+```
+
+A key's first write finds no row, so the `UPDATE` does not apply and it falls back to
+`INSERT ... IF NOT EXISTS` (retried once via the `UPDATE` if it loses an insert race). This is the one
+non-atomic path — a compound of separate Paxos transactions — but it is safe by construction: both
+`UPDATE`s are offset-gated and the `INSERT` only writes an absent cell, so no interleaving overwrites a
+newer snapshot. A rejected write raises `SnapshotWriteConflict` — including a spurious one if a delete
+slips between the first-write `INSERT` and its retry (an over-rejection, never corruption, cleared on
+the next flush).
+
+The guard is per **key**, the right granularity: #732 corruption is per key and keys are independent,
+so per-key monotonic durability is exactly what prevents it.
+
+## Scope: persist-only — and fencing a deletion without gating delete
+
+This mode fences **persists** only. A delete is an ordinary last-write-wins `DELETE`; the
+`IF offset <= :offset` guard does not apply to it. The residual gap, for anyone who hard-deletes: a
+lagging zombie can resurrect a just-deleted key by inserting at a lower offset, and a later recovery then
+folds new events onto that revived base — #732 for that one key.
+
+Fencing a deletion, though, needs no gated `delete`. The obvious way to gate one — a logical *tombstone*
+that keeps the row and its `offset` instead of removing it — is just a persisted null:
+
+```sql
+-- gating delete (the rejected route): a value-less logical tombstone
+UPDATE snapshots_v2 SET value = null,   offset = :offset WHERE <key> IF offset <= :offset
+-- the equivalent that already works: persist an empty state
+UPDATE snapshots_v2 SET value = :empty, offset = :offset WHERE <key> IF offset <= :offset
+```
+
+It is the same gated write, and the row survives until its TTL either way — the guard has to outlive the
+rebalance overlap window, so neither reclaims sooner. So model a deletion as an offset-carrying *empty*
+snapshot and persist it through the already-fenced persist path: a lower-offset zombie write is rejected
+exactly as it is for any persist. Routing the same thing through `delete` instead would cost on two
+fronts to buy nothing.
+
+**A breaking API.** The offset has to reach the store through `SnapshotWriteDatabase.delete`, forcing a
+source/binary-breaking `delete(key, offset)` signature and offset plumbing through every delete path.
+Persisting an empty snapshot makes **no public API change** and needs no major-version bump.
+
+**A replay-window livelock.** A value-less tombstone recovers with no offset *floor*. A partition resumes
+from the committed offset `C` (the minimum still held across its keys), which a slow key can hold well
+below a fast key's durable snapshot offset `X`; the buffer then climbs from the replayed offsets (all
+`< X`), a tick-delete or flush mid-replay writes below `X`, and `IF offset <= X` rejects the **legitimate
+owner**, which tears down, re-recovers the same floorless tombstone, and loops — safety holds (`X` never
+regresses), but it is a pure **liveness** failure. Closing it needs a snapshot buffer kept *monotonic in
+offset* with a floor seeded from the tombstone's offset (a dedicated recovery type), plus the same floor
+on the journal (events-recovery) path. A persisted snapshot has all of this already: `SnapshotFold`
+deduplicates replayed records by offset (`record.offset > snapshot.offset`), so a key recovered at `X`
+drops events `<= X` before the fold and never re-derives a snapshot below `X` to persist — the floor for
+free.
+
+Gating `delete` would therefore rebuild, behind a breaking API, the offset floor the persist path already
+gives — which is why offset-gated deletes are **unnecessary**, not merely deferred (see *Rejected
+alternatives*). The plain last-write-wins `delete` stays for callers who want a real row removal and have
+no need to fence it.
+
+## Equal-offset writes and determinism
+
+`IF offset <= :offset` admits an *equal* offset, so a stale writer holding exactly the stored offset is
+not detected. This is deliberate. The legitimate owner can act at an offset it has already stored — a
+re-persist of the high-water `X` equals the stored offset, and a strict `<` would reject it and fence the
+owner against itself. Admitting equal is safe not because the new value is identical but because a
+same-offset write does not move the recovery point — unlike a lower-offset write it cannot drop committed
+events (#732). The *records* folded into any two snapshots at the same offset are the same, so a
+same-offset re-persist differs at most in time-driven tick state, never in event data. Deterministic,
+replayable folds are therefore a precondition of the compare-and-set mode (as they already are of
+recovery generally).
+
+## Consistency
+
+A lightweight transaction has two consistency levels. The *serial* level (`SERIAL` by default — a
+quorum across all replicas, which spans datacenters under multi-DC replication) runs the Paxos
+consensus; `ConsistencyOverrides.write` governs only the commit that materialises the agreed value. So
+the serial level decides *agreement*, not *visibility*: the value becomes readable to a normal read
+only once that commit lands at the write level. Recovery uses a non-serial read
+(`ConsistencyOverrides.read`), so it sees the latest committed snapshot only when **`R + W > N`** on the
+regular levels — the write side must be a quorum, not just the serial consensus. (A non-serial read can
+also miss an *accepted-but-not-yet-committed* LWT left by a failed coordinator — but that coincides with
+an incomplete `persist`, which never held its offset, so recovery just re-folds those events. A serial
+read would avoid both cases; the design forgoes that cost.)
+
+So configure `ConsistencyOverrides` read **and** write to a quorum — `LOCAL_QUORUM` for single-DC,
+paired with the scassandra client's `query.serial-consistency = LOCAL_SERIAL` to keep Paxos in-DC
+(otherwise each conditional write pays a cross-DC round-trip; a plain delete is unaffected). This is
+**not** a default: `ConsistencyOverrides` is empty unless you set it, so the table inherits the session
+default (often `LOCAL_ONE`), which reintroduces #732 on the read side — the write-side fence does not
+heal that. What matters is access locality (a key's writers and its recovery read in one DC), not the
+replication footprint, which may still span DCs for DR; ownership that fails over between DCs needs the
+cross-DC `SERIAL` / `QUORUM` levels.
+
+## TTL and rollout
+
+The `offset` guard lives in the snapshot row, so it expires with the row's TTL. After a row's TTL
+lapses the guard is gone and a stale write can land a fresh `INSERT`; this is harmless when the TTL far
+exceeds the rebalance/zombie overlap window (the usual case — a zombie outliving the TTL is not
+realistic), but the monotonicity guarantee only holds within the TTL.
+
+Enabling on a running system needs no migration (the condition reads the `offset` column every version
+already writes). The one rolling-deploy caveat: a lightweight transaction uses a coordinator-generated
+write timestamp while a regular write uses a client-side one, so during a mixed deploy an application
+clock running ahead of the coordinators can let an old (plain-write) instance's snapshot shadow a newer
+conditional one. Negligible with NTP-synced clocks, and gone once every instance writes conditionally.
+
+## Implementation
+
+Entry point: `CassandraSnapshots.withSchema(compareAndSet = true)` (or
+`CassandraPersistence.withSchema(snapshotCompareAndSet = true)`). `persistCompareAndSet` issues the
+offset-gated `UPDATE` with the `INSERT ... IF NOT EXISTS` first-write fallback, and `resolveConditional`
+classifies the result; `delete` stays an unguarded last-write-wins `DELETE`. `WriteMode.CompareAndSet`
+carries the extra `INSERT` statement, so it exists exactly in compare-and-set mode.
+
+## Testing
+
+- Store-level against real Cassandra (`SnapshotSpec`, persistence-cassandra-it-tests) — monotonic
+  persists applied (including an equal-offset re-persist), stale-write rejection, TTL on both the insert
+  and update paths, and concurrent first-writers racing on a fresh key (the highest offset wins, no
+  corruption — exercising the first-write retry path). The persist-only delete gap is pinned by a
+  characterization test: a lower-offset write after a delete resurrects the key — the residual of the
+  unfenced last-write-wins delete (a caller who needs the deletion fenced persists an empty snapshot
+  instead; see *Scope*).
+- Through the real PartitionFlow / eager-recovery / flush-on-revoke machinery (`FlowSpec`,
+  persistence-cassandra-it-tests) — the #732 reproduction asserts corruption under last-write-wins;
+  the prevention asserts the stale flush is rejected.
+
+## Assumptions
+
+This design takes three things as given:
+
+- **Per-key linearizable compare-and-set.** Each Cassandra lightweight transaction on a row is an atomic,
+  linearizable operation (Paxos). The first-write `UPDATE`/`INSERT`/retry compound is *not* atomic.
+- **Deterministic, replayable folds (a user contract).** Re-folding a recovered base over the same events
+  reproduces the same state. This is what makes equal-offset writes idempotent. A non-deterministic fold
+  breaks it.
+- **Per-key independence.** #732 corruption is per key; keys are independent, so per-key monotonic
+  durability is the whole guarantee.
+
+## Rejected alternatives
+
+- **Offset-as-write-timestamp (LWW register)**: write each snapshot `USING TIMESTAMP <offset>` and let
+  Cassandra's last-write-wins reconciliation keep the highest-offset cell — a plain quorum write, much
+  cheaper than a Paxos round, and a delete becomes a tombstone ordered by offset. Rejected as the
+  default: equal-offset replacement breaks (at equal timestamps Cassandra breaks ties by value, not
+  write order), a rolling deploy inverts catastrophically (old instances write wall-clock timestamps
+  that dominate every offset-as-timestamp value), and it discards the real write timestamps.
+- **Lease / ownership table**: a per-partition lease acquired with one LWT, then cheap writes. The
+  lease alone does not stop a paused leaseholder's plain writes (last-write-wins still applies), so a
+  per-write fencing token is still required — at which point the lease only adds liveness/expiry
+  concerns on top of the per-write CAS.
+- **Composite `(offset, generation)` token**: gate on the consumer generation as well as the offset,
+  closing the equal-offset gap and giving per-partition (not just per-key) ownership. Couples the
+  self-contained Cassandra module to the live consumer generation; reasonable as a future strict mode,
+  not a default.
+- **Recovery-side reconciliation** (store the offset, recover from the lowest): does not prevent the
+  stale overwrite (last-write-wins still corrupts), so strictly weaker than fencing the write.
+- **Offset-gated deletes (logical tombstone)**: gate `delete` like `persist` by keeping a value-less
+  tombstone (`SET value = null`) that carries the offset, closing the resurrection gap. Rejected as
+  redundant — a tombstone is a persisted null, so the same fencing comes from persisting an
+  offset-carrying *empty* snapshot through the already-fenced persist path, without a breaking
+  `delete(key, offset)` API and without the replay-window livelock a value-less tombstone reintroduces
+  (see *Scope*).
+
+## Forward-looking
+
+- **Per-partition ownership** — the equal-offset gap and per-key (rather than per-partition) granularity
+  could be closed by a composite `(offset, generation)` token (see Rejected alternatives) or, further out, by
+  [KIP-939 (participation in 2PC)](https://cwiki.apache.org/confluence/display/KAFKA/KIP-939:+Support+Participation+in+2PC):
+  a transactional producer in an externally-coordinated two-phase commit could bind the Cassandra
+  snapshot write to a generation-fenced Kafka input-offset commit, giving Cassandra per-partition
+  ownership without the per-key compare-and-set. Not actionable now; see the Kafka design doc's
+  forward-looking note.

--- a/docs/cassandra-single-writer-design.md
+++ b/docs/cassandra-single-writer-design.md
@@ -14,41 +14,53 @@ backend solves the same problem differently — see [Kafka single-writer design]
 previous owner that has not yet observed the revocation keeps flushing snapshots alongside the new
 owner, and the last-write-wins snapshots table lets a stale write overwrite a newer one — the next
 recovery then loads stale state and skips the events in between. The
-[Kafka design doc](kafka-single-writer-design.md) covers the failure in full.
+[Kafka design doc](kafka-single-writer-design.md) covers the failure in full. The Cassandra-specific
+point: Cassandra has a conditional write (a Paxos lightweight transaction) but no transaction to bind
+the input-offset commit to, so the fence is **per write**, not a transaction.
 
 ## Mechanism: compare-and-set
 
-Cassandra has no transaction to bind the input-offset commit to, the way the Kafka backend does — but
-it does offer a conditional write (a Paxos lightweight transaction), so the fence is **per write**. The
-stored offset is the per-key [fencing token](https://martin.kleppmann.com/2016/02/08/how-to-do-distributed-locking.html):
+The stored offset is a per-key [fencing token](https://martin.kleppmann.com/2016/02/08/how-to-do-distributed-locking.html):
 every persist asserts the stored offset is not greater than the one being written, so the
-newest-by-offset write wins, whoever issued it. The write is linearizable per partition key, so
-concurrent writers to one key are ordered without relying on clock synchronisation:
+newest-by-offset writer wins regardless of who it is. The write is a Paxos lightweight transaction,
+linearizable per partition key, so concurrent writers to one key are ordered without relying on clock
+synchronisation:
 
 ```sql
 UPDATE snapshots_v2 SET ... , offset = :offset WHERE <key> IF offset <= :offset
 ```
 
-A key's first write finds no row, so the `UPDATE` does not apply and it falls back to
-`INSERT ... IF NOT EXISTS` (retried once via the `UPDATE` if it loses an insert race). This is the one
-non-atomic path — a compound of separate Paxos transactions — but it is safe by construction: both
-`UPDATE`s are offset-gated and the `INSERT` only writes an absent cell, so no interleaving overwrites a
-newer snapshot. A rejected write raises `SnapshotWriteConflict` — including a spurious one if a delete
-slips between the first-write `INSERT` and its retry (an over-rejection, never corruption, cleared on
-the next flush).
+The first write of a key finds no row, so the conditional `UPDATE` does not apply; it falls back to
+`INSERT ... IF NOT EXISTS`. If that loses a race to a concurrent insert, the conditional `UPDATE` is
+retried once, so the newest snapshot still wins a first-write race. A rejected write raises
+`SnapshotWriteConflict` (handled uniformly, see [Persistence](persistence.md#protecting-against-stale-snapshot-writes)).
+Result classification (`applied` / newer-stored-offset / row-absent) is shared by persist and delete
+in `resolveConditional`; a not-applied result reports the stored `offset` when Cassandra returns it
+and treats its absence (or a null) as "row absent".
 
 The guard is per **key**, the right granularity: #732 corruption is per key and keys are independent,
 so per-key monotonic durability is exactly what prevents it.
 
 ## Scope: persist-only — and fencing a deletion without gating delete
 
-This mode fences **persists** only. A delete is an ordinary last-write-wins `DELETE`; the
-`IF offset <= :offset` guard does not apply to it. The residual gap, for anyone who hard-deletes: a
-lagging zombie can resurrect a just-deleted key by inserting at a lower offset, and a later recovery then
-folds new events onto that revived base — #732 for that one key.
+## Delete: offset-carrying tombstone
 
-Fencing a deletion, though, needs no gated `delete`. The obvious way to gate one — a logical *tombstone*
-that keeps the row and its `offset` instead of removing it — is just a persisted null:
+A delete cannot be a plain `DELETE`. Removing the row removes the `offset` guard with it, so a lagging
+zombie's `INSERT ... IF NOT EXISTS` at a lower offset would then succeed — resurrecting a stale
+snapshot. A later recovery would fold new events onto that resurrected base, silently losing the
+delete: #732 reintroduced for that key.
+
+So the compare-and-set delete (`deleteCompareAndSet`) writes an offset-carrying logical **tombstone**
+
+```sql
+UPDATE snapshots_v2 SET value = null, offset = :offset WHERE <key> IF offset <= :offset
+```
+
+keeping the row (and its `offset`). A stale lower-offset writer is then rejected, not resurrected; a
+replayed delete is a no-op (equal offset) or a conflict (a newer write exists), never a resurrection;
+`get` reads a null `value` back as `None`. The tombstone is reaped by the TTL, if configured. Keeping
+the row also routes the delete through Paxos, avoiding the well-known hazard of mixing lightweight
+transactions and regular mutations on the same row.
 
 ```sql
 -- gating delete (the rejected route): a value-less logical tombstone
@@ -57,66 +69,100 @@ UPDATE snapshots_v2 SET value = null,   offset = :offset WHERE <key> IF offset <
 UPDATE snapshots_v2 SET value = :empty, offset = :offset WHERE <key> IF offset <= :offset
 ```
 
-It is the same gated write, and the row survives until its TTL either way — the guard has to outlive the
-rebalance overlap window, so neither reclaims sooner. So model a deletion as an offset-carrying *empty*
-snapshot and persist it through the already-fenced persist path: a lower-offset zombie write is rejected
-exactly as it is for any persist. Routing the same thing through `delete` instead would cost on two
-fronts to buy nothing.
+A delete and a re-persist are fenced on an offset that, just after recovery, can legitimately trail
+the key's own stored snapshot. The partition resumes from the committed offset `C` (the minimum offset
+still held across all of its keys); a single slow key can hold `C` well below a fast key's durable
+snapshot offset `X` (the offset-lags-state invariant only guarantees `C <= X`). On recovery the
+partition's processing offset starts at `C`, while the recovered snapshot's offset is `X`.
 
-**A breaking API.** The offset has to reach the store through `SnapshotWriteDatabase.delete`, forcing a
-source/binary-breaking `delete(key, offset)` signature and offset plumbing through every delete path.
-Persisting an empty snapshot makes **no public API change** and needs no major-version bump.
+```mermaid
+sequenceDiagram
+    participant F as Owner<br/>(just recovered)
+    participant B as Snapshot buffer
+    participant DB as snapshots_v2<br/>(IF offset <= :offset)
 
-**A replay-window livelock.** A value-less tombstone recovers with no offset *floor*. A partition resumes
-from the committed offset `C` (the minimum still held across its keys), which a slow key can hold well
-below a fast key's durable snapshot offset `X`; the buffer then climbs from the replayed offsets (all
-`< X`), a tick-delete or flush mid-replay writes below `X`, and `IF offset <= X` rejects the **legitimate
-owner**, which tears down, re-recovers the same floorless tombstone, and loops — safety holds (`X` never
-regresses), but it is a pure **liveness** failure. Closing it needs a snapshot buffer kept *monotonic in
-offset* with a floor seeded from the tombstone's offset (a dedicated recovery type), plus the same floor
-on the journal (events-recovery) path. A persisted snapshot has all of this already: `SnapshotFold`
-deduplicates replayed records by offset (`record.offset > snapshot.offset`), so a key recovered at `X`
-drops events `<= X` before the fold and never re-derives a snapshot below `X` to persist — the floor for
-free.
+    Note over DB,F: key recovered at snapshot offset X.<br/>partition resumes at committed offset C < X (a slow key held C back)
+    F->>B: replay event at offset < X
+    Note over B: buffer kept monotonic — holds high-water X,<br/>does not regress to the replayed offset
+    F->>B: tick deletes the key (processing offset < X)
+    B->>DB: delete gated on max(processing offset, X) = X
+    Note over DB: IF offset <= X holds, the legitimate owner applies.<br/>Gating on the processing offset (< X) would be rejected<br/>as stale — the owner fencing itself.
+```
 
-Gating `delete` would therefore rebuild, behind a breaking API, the offset floor the persist path already
-gives — which is why offset-gated deletes are **unnecessary**, not merely deferred (see *Rejected
-alternatives*). The plain last-write-wins `delete` stays for callers who want a real row removal and have
-no need to fence it.
+If, in this window, the owner issues a write for that key:
+
+- a **time-driven tick** that deletes the key would gate the delete on the processing offset `C` —
+  `IF offset <= C` against the stored `X > C` rejects it, **crashing the legitimate owner** with a
+  `SnapshotWriteConflict` that reads as if another writer owned the key;
+- a **periodic flush** during replay would re-derive the snapshot and try to persist it at the
+  replayed offset (`< X`) — the same rejection.
+
+Neither is a safety problem (the durable snapshot stays at `X`), but both are a liveness problem: the
+owner fences *itself*. The cause is that the in-memory snapshot buffer's offset *regresses* while
+replaying events below `X` (a naive buffer `append` would overwrite it with the replayed, lower offset).
+
+The fix keeps the buffered snapshot **monotonic in offset**: `Snapshots.append` drops a lower-offset
+append rather than regressing the buffer (sound because, under the determinism the design already
+assumes, re-folding events `<= X` reproduces the same state — see below). The buffer therefore stays
+at the key's high-water `X`, so
+
+- a delete is fenced on `max(currentOffset, highWater)` — the legitimate owner presents `X` and
+  applies, while a genuinely stale writer (which only ever *reached* its own lower offset, never `X`)
+  still presents that lower offset and stays fenced;
+- a re-derived snapshot is not re-persisted below `X` (the buffer stays `persisted`), so the flush is
+  a no-op.
+
+Of these two, only the **delete** is irreducible. `SnapshotFold` already drops replayed events
+(`record.offset > snapshot.offset`), so a re-derived snapshot below `X` is never even appended — the
+monotonic `append` is belt-and-suspenders for the persist case. A **tick-delete** (`TickToState`) is
+timer-driven and bypasses that filter, so only the monotonic buffer lets a legitimate tick-delete
+apply during replay.
+
+The fence is live only for the offset-carrying `KafkaSnapshot` / compare-and-set wiring; other stores
+pass `Offset.min` as the offset, making it inert (last-write-wins). It is surgical even when live:
+`max(currentOffset, highWater)` differs from `currentOffset` only inside this replay window.
+
+This fence and the tombstone above are independent and complementary: presenting the higher `highWater`
+for a delete makes the tombstone it writes *more* protective against a lower-offset revive, never less.
 
 ## Equal-offset writes and determinism
 
 `IF offset <= :offset` admits an *equal* offset, so a stale writer holding exactly the stored offset is
-not detected. This is deliberate. The legitimate owner can act at an offset it has already stored — a
-re-persist of the high-water `X` equals the stored offset, and a strict `<` would reject it and fence the
-owner against itself. Admitting equal is safe not because the new value is identical but because a
-same-offset write does not move the recovery point — unlike a lower-offset write it cannot drop committed
-events (#732). The *records* folded into any two snapshots at the same offset are the same, so a
-same-offset re-persist differs at most in time-driven tick state, never in event data. Deterministic,
-replayable folds are therefore a precondition of the compare-and-set mode (as they already are of
-recovery generally).
+not detected. This is deliberate. The legitimate owner can act at an offset it has already stored: a
+tick can change state — or delete — without consuming a new record, and in the replay window above a
+tick-delete is fenced on the high-water `X`, which equals the stored offset; a strict `<` would reject
+these and fence the owner against itself. Admitting equal is safe not because the new value is identical
+but because a same-offset write does not move the recovery point — unlike a lower-offset write it cannot
+drop committed events (#732). The *records* folded into any two snapshots at the same offset are the
+same, so a same-offset re-persist differs at most in time-driven tick state, never in event data; a
+replayed delete is a no-op. Deterministic, replayable folds are therefore a precondition of the CAS
+mode (as they already are of recovery generally) — the same property that lets the monotonic buffer
+drop a lower-offset replay as a no-op.
 
 ## Consistency
 
-A lightweight transaction has two consistency levels. The *serial* level (`SERIAL` by default — a
-quorum across all replicas, which spans datacenters under multi-DC replication) runs the Paxos
-consensus; `ConsistencyOverrides.write` governs only the commit that materialises the agreed value. So
-the serial level decides *agreement*, not *visibility*: the value becomes readable to a normal read
-only once that commit lands at the write level. Recovery uses a non-serial read
-(`ConsistencyOverrides.read`), so it sees the latest committed snapshot only when **`R + W > N`** on the
-regular levels — the write side must be a quorum, not just the serial consensus. (A non-serial read can
-also miss an *accepted-but-not-yet-committed* LWT left by a failed coordinator — but that coincides with
-an incomplete `persist`, which never held its offset, so recovery just re-folds those events. A serial
-read would avoid both cases; the design forgoes that cost.)
+The lightweight transaction reaches consensus at the *serial* consistency level, which is distinct
+from the read/write levels in `ConsistencyOverrides` and defaults to `SERIAL` (a cross-datacenter
+quorum). `ConsistencyOverrides.write` governs only the transaction's commit phase, not its consensus.
+For single-datacenter partition ownership (the common case) set the scassandra client's
+`query.serial-consistency = LOCAL_SERIAL` to keep the Paxos rounds in-DC; otherwise every conditional
+write and delete pays a cross-datacenter round-trip. Recovery reads at `ConsistencyOverrides.read`;
+a serial read is not required, because `R + W > N` makes a non-serial read see every committed
+snapshot, and a still-in-flight write — one whose `persist` has not completed — is safe to miss
+(recovery re-folds from the committed offset).
 
-So configure `ConsistencyOverrides` read **and** write to a quorum — `LOCAL_QUORUM` for single-DC,
-paired with the scassandra client's `query.serial-consistency = LOCAL_SERIAL` to keep Paxos in-DC
-(otherwise each conditional write pays a cross-DC round-trip; a plain delete is unaffected). This is
-**not** a default: `ConsistencyOverrides` is empty unless you set it, so the table inherits the session
-default (often `LOCAL_ONE`), which reintroduces #732 on the read side — the write-side fence does not
-heal that. What matters is access locality (a key's writers and its recovery read in one DC), not the
-replication footprint, which may still span DCs for DR; ownership that fails over between DCs needs the
-cross-DC `SERIAL` / `QUORUM` levels.
+Compare-and-set does require read and write consistency at `QUORUM` or stronger (so `R + W > N`).
+For single-datacenter ownership, `LOCAL_QUORUM` at both levels satisfies `R + W > N` within the
+local DC and pairs with `LOCAL_SERIAL`. What matters is access locality — a key's writers and its
+recovery read all in one DC — not the replication footprint, which may still span DCs for DR. The
+conditional write reaches consensus on a serial quorum but *materialises* at `ConsistencyOverrides.write`;
+with a weaker write level a (non-serial) `QUORUM` recovery read can miss the newest committed snapshot
+even with no in-flight Paxos, reintroducing #732 on the read side — which the write-side fence does not
+heal. This is not a default: `ConsistencyOverrides` is empty unless you set it, so the snapshot table
+inherits the session's default level (often `LOCAL_ONE`) — you must configure read and write to a
+quorum. Keep `R + W > N` within one consistency domain and a key's Paxos in one DC: the `LOCAL_*` set
+is for single-DC ownership, while ownership that can fail over between DCs (or write a key from two
+DCs) needs the cross-DC `SERIAL` / `QUORUM` levels.
 
 ## TTL and rollout
 
@@ -124,6 +170,10 @@ The `offset` guard lives in the snapshot row, so it expires with the row's TTL. 
 lapses the guard is gone and a stale write can land a fresh `INSERT`; this is harmless when the TTL far
 exceeds the rebalance/zombie overlap window (the usual case — a zombie outliving the TTL is not
 realistic), but the monotonicity guarantee only holds within the TTL.
+
+Without a TTL the offset-carrying tombstone is never reaped, so a deleted key leaves its row behind
+indefinitely and the table grows by one row per deleted key. Configure a TTL (comfortably above the
+overlap window) for workloads that delete keys.
 
 Enabling on a running system needs no migration (the condition reads the `offset` column every version
 already writes). The one rolling-deploy caveat: a lightweight transaction uses a coordinator-generated
@@ -141,16 +191,16 @@ carries the extra `INSERT` statement, so it exists exactly in compare-and-set mo
 
 ## Testing
 
-- Store-level against real Cassandra (`SnapshotSpec`, persistence-cassandra-it-tests) — monotonic
-  persists applied (including an equal-offset re-persist), stale-write rejection, TTL on both the insert
-  and update paths, and concurrent first-writers racing on a fresh key (the highest offset wins, no
-  corruption — exercising the first-write retry path). The persist-only delete gap is pinned by a
-  characterization test: a lower-offset write after a delete resurrects the key — the residual of the
-  unfenced last-write-wins delete (a caller who needs the deletion fenced persists an empty snapshot
-  instead; see *Scope*).
-- Through the real PartitionFlow / eager-recovery / flush-on-revoke machinery (`FlowSpec`,
-  persistence-cassandra-it-tests) — the #732 reproduction asserts corruption under last-write-wins;
-  the prevention asserts the stale flush is rejected.
+- Store-level against real Cassandra (persistence-cassandra-it-tests) — monotonic writes,
+  stale-write rejection, the tombstone (no resurrection, replayed/stale delete, equal-offset),
+  idempotent delete, TTL on both the insert and update paths, and concurrent first-writers racing on a
+  fresh key (the highest offset wins, no corruption — exercising the first-write retry path).
+- Through the real PartitionFlow / eager-recovery / flush-on-revoke machinery
+  (persistence-cassandra-it-tests) — the #732 reproduction asserts corruption under last-write-wins;
+  the prevention asserts the stale flush is rejected; and a delete during replay below the recovered
+  snapshot offset applies (fenced on the high-water), not rejected.
+- In core — the monotonic buffer and the delete fence: a unit test directly, and a flow-level test
+  against an offset-gated in-memory store.
 
 ## Assumptions
 
@@ -159,8 +209,8 @@ This design takes three things as given:
 - **Per-key linearizable compare-and-set.** Each Cassandra lightweight transaction on a row is an atomic,
   linearizable operation (Paxos). The first-write `UPDATE`/`INSERT`/retry compound is *not* atomic.
 - **Deterministic, replayable folds (a user contract).** Re-folding a recovered base over the same events
-  reproduces the same state. This is what makes equal-offset writes idempotent. A non-deterministic fold
-  breaks it.
+  reproduces the same state. This is what makes a lower-offset replay a no-op (so the buffer can stay
+  monotonic) and what makes equal-offset writes idempotent. A non-deterministic fold breaks both.
 - **Per-key independence.** #732 corruption is per key; keys are independent, so per-key monotonic
   durability is the whole guarantee.
 
@@ -191,6 +241,9 @@ This design takes three things as given:
 
 ## Forward-looking
 
+- **Offset-gated deletes** — a future mode could close the delete-resurrection gap by gating deletes on
+  an offset-carrying tombstone exactly as persists are; deferred here for the breaking API and
+  replay-window machinery it brings (see *Scope* above).
 - **Per-partition ownership** — the equal-offset gap and per-key (rather than per-partition) granularity
   could be closed by a composite `(offset, generation)` token (see Rejected alternatives) or, further out, by
   [KIP-939 (participation in 2PC)](https://cwiki.apache.org/confluence/display/KAFKA/KIP-939:+Support+Participation+in+2PC):

--- a/docs/cassandra-single-writer-design.md
+++ b/docs/cassandra-single-writer-design.md
@@ -56,7 +56,7 @@ UPDATE snapshots_v2 SET value = null, offset = :offset WHERE <key> IF offset <= 
 
 keeping the row (and its `offset`). A stale lower-offset writer is then rejected, not resurrected; a
 replayed delete is a no-op (equal offset) or a conflict (a newer write exists), never a resurrection;
-`get` reads a null `value` back as `None`. The tombstone is reaped by the TTL, if configured. Keeping
+a read surfaces the null `value` as a `Stored.Tombstone` (no live value). The tombstone is reaped by the TTL, if configured. Keeping
 the row also routes the delete through Paxos, avoiding the well-known hazard of mixing lightweight
 transactions and regular mutations on the same row.
 
@@ -126,24 +126,25 @@ for a delete makes the tombstone it writes *more* protective against a lower-off
 ### Recovering a deleted key
 
 Both protections above are keyed on the high-water `X`, which a recovery establishes from the *recovered
-snapshot's* offset. But a deleted key's row is a tombstone — `get` reads its null `value` back as `None`
-(absent) — so a recovery that only knew `get` would establish no floor: the buffer would start empty and
+snapshot's* offset. But a deleted key's row is a tombstone — its `value` is null, read back as absent — so
+a read that surfaced only the value would establish no floor: the buffer would start empty and
 `Snapshots.append` would climb from the replayed offsets (all `< X`), re-persisting below `X`. The
 offset-`X` tombstone then rejects that write, fencing the *legitimate* owner; the flow tears down,
 re-recovers the same tombstone (again no floor), and loops — a livelock. (`SnapshotFold`'s filter is keyed
 on the same recovered offset, so it too has no floor for a tombstone; the monotonic buffer is what carries
-the deleted-key case. The tick-**delete** path does not arise here: after a `None` recovery nothing is yet
+the deleted-key case. The tick-**delete** path does not arise here: after an absent recovery nothing is yet
 persisted, so a replay-window tick-delete is dispatched `persist = false` — buffer-only, never reaching the
 store.)
 
 So recovery must surface the tombstone's offset as the floor, not collapse it to "nothing there".
-`SnapshotDatabase.recover` returns `Recovered.Deleted(X)` for a tombstone (distinct from `Recovered.Absent`
-for a reaped or never-written key); `Snapshots` holds `X` as the buffer high-water even with no buffered
-value, so a re-derived snapshot below `X` is dropped exactly as for a live snapshot and the owner makes
-progress. The deleted-key recovery is thus symmetric with the live one — same floor, only the value is
-absent — and the floor is re-established on every recovery, so the livelock cannot form. (`recover`
-defaults to `get` for stores without tombstones; a wrapper such as the metrics one must delegate to the
-underlying `recover`, or it silently downgrades a tombstone back to `Absent`.)
+`SnapshotDatabase.read` returns `Some(Stored(None, X))` for a tombstone — value-less but carrying the
+offset — distinct from `None` for a reaped or never-written key (and from `Some(Stored(Some(v), X))` for a
+live snapshot); `Snapshots` holds `X` as the buffer high-water even with no buffered value, so a re-derived
+snapshot below `X` is dropped exactly as for a live snapshot and the owner makes progress. The deleted-key
+recovery is thus symmetric with the live one — same floor, only the value is absent — and the floor is
+re-established on every recovery, so the livelock cannot form. (Because `read` returns one `Stored`, a
+wrapper such as the metrics one has a single read to delegate — there is no separate value-only path that
+could silently drop the tombstone's offset.)
 
 The same hazard reaches the **events-recovery** mode (`restoreEvents`), where state is restored by folding
 the journal rather than reading the snapshot. A delete clears the key's journal, so the fold yields `None`
@@ -216,12 +217,16 @@ conditional one. Negligible with NTP-synced clocks, and gone once every instance
 Entry point: `CassandraSnapshots.withSchema(compareAndSet = true)` (or
 `CassandraPersistence.withSchema(snapshotCompareAndSet = true)`). In the current code:
 
-- **Conditional write / delete** — `CassandraSnapshots.persistCompareAndSet` and `deleteCompareAndSet`
-  issue the offset-gated `UPDATE`/`INSERT`; `resolveConditional` classifies the result
-  (`applied` / newer-stored-offset / row-absent), shared by both.
-- **Monotonic buffer** — `Snapshots.append` drops a lower-offset append; recovery establishes the
-  high-water floor through `SnapshotDatabase.recover`, which returns `Recovered.Deleted` for a
-  tombstone and `Recovered.Absent` for a reaped or never-written key.
+- **Unified write / read** — `CassandraSnapshots.write` routes a `Stored`: a present value to
+  `persistCompareAndSet`, an absent value (a delete) to `deleteCompareAndSet`, both issuing the offset-gated
+  `UPDATE`/`INSERT`; `resolveConditional` classifies the result (`applied` / newer-stored-offset /
+  row-absent), shared by both. `read` returns the stored unit — `Some(Stored(value, offset))`, with an
+  absent value for a tombstone — or `None` for no row.
+- **Monotonic buffer** — `Snapshots` holds one `Stored` cell (a live snapshot or an offset-carrying
+  tombstone floor); `append` and `delete` both flow through one monotonic `put` that drops a lower-offset
+  re-persist and lifts a lower-offset delete to the high-water. Recovery seeds the cell (and thus the floor)
+  from `SnapshotDatabase.read`: `Some(Stored(None, X))` is a tombstone at `X`, `None` is a reaped or
+  never-written key.
 - **Replay filter** — `SnapshotFold` drops replayed events above the recovered offset; a timer-driven
   `TickToState` delete bypasses that filter, which is why the monotonic buffer is what carries the
   tick-delete case.
@@ -283,13 +288,8 @@ This design takes three things as given:
 
 ## Forward-looking
 
-- **Offset-gated deletes** — a future mode could close the delete-resurrection gap by gating deletes on
-  an offset-carrying tombstone exactly as persists are; deferred here for the breaking API and
-  replay-window machinery it brings (see *Scope* above).
-- **Per-partition ownership** — the equal-offset gap and per-key (rather than per-partition) granularity
-  could be closed by a composite `(offset, generation)` token (see Rejected alternatives) or, further out, by
-  [KIP-939 (participation in 2PC)](https://cwiki.apache.org/confluence/display/KAFKA/KIP-939:+Support+Participation+in+2PC):
-  a transactional producer in an externally-coordinated two-phase commit could bind the Cassandra
-  snapshot write to a generation-fenced Kafka input-offset commit, giving Cassandra per-partition
-  ownership without the per-key compare-and-set. Not actionable now; see the Kafka design doc's
-  forward-looking note.
+[KIP-939 (participation in 2PC)](https://cwiki.apache.org/confluence/display/KAFKA/KIP-939:+Support+Participation+in+2PC)
+could extend a Kafka generation fence to this Cassandra store: a transactional producer in an
+externally-coordinated two-phase commit could bind the Cassandra snapshot write to a generation-fenced
+Kafka input-offset commit, giving Cassandra per-partition ownership without the per-key compare-and-set.
+Not actionable now; see the Kafka design doc's forward-looking note.

--- a/docs/cassandra-single-writer-design.md
+++ b/docs/cassandra-single-writer-design.md
@@ -39,7 +39,7 @@ and treats its absence (or a null) as "row absent".
 The guard is per **key**, the right granularity: #732 corruption is per key and keys are independent,
 so per-key monotonic durability is exactly what prevents it.
 
-## Scope: persist-only — and fencing a deletion without gating delete
+## Scope: persist-only — and what the full fence would cost
 
 ## Delete: offset-carrying tombstone
 
@@ -60,12 +60,12 @@ a read surfaces the null `value` as a `Stored.Tombstone` (no live value). The to
 the row also routes the delete through Paxos, avoiding the well-known hazard of mixing lightweight
 transactions and regular mutations on the same row.
 
-```sql
--- gating delete (the rejected route): a value-less logical tombstone
-UPDATE snapshots_v2 SET value = null,   offset = :offset WHERE <key> IF offset <= :offset
--- the equivalent that already works: persist an empty state
-UPDATE snapshots_v2 SET value = :empty, offset = :offset WHERE <key> IF offset <= :offset
-```
+**A breaking API.** Gating deletes means a delete must carry an offset: an offset-carrying logical
+*tombstone* (`SET value = null`, keeping the row and its `offset`) instead of a row removal, so a
+lower-offset writer is rejected rather than allowed to resurrect. But that offset has to reach the store
+through `SnapshotWriteDatabase.delete`, forcing a source/binary-breaking `delete(key, offset)` signature
+and offset plumbing through every delete path. Persist-only makes **no public API change** and needs no
+major-version bump.
 
 A delete and a re-persist are fenced on an offset that, just after recovery, can legitimately trail
 the key's own stored snapshot. The partition resumes from the committed offset `C` (the minimum offset
@@ -279,12 +279,6 @@ This design takes three things as given:
   not a default.
 - **Recovery-side reconciliation** (store the offset, recover from the lowest): does not prevent the
   stale overwrite (last-write-wins still corrupts), so strictly weaker than fencing the write.
-- **Offset-gated deletes (logical tombstone)**: gate `delete` like `persist` by keeping a value-less
-  tombstone (`SET value = null`) that carries the offset, closing the resurrection gap. Rejected as
-  redundant — a tombstone is a persisted null, so the same fencing comes from persisting an
-  offset-carrying *empty* snapshot through the already-fenced persist path, without a breaking
-  `delete(key, offset)` API and without the replay-window livelock a value-less tombstone reintroduces
-  (see *Scope*).
 
 ## Forward-looking
 

--- a/docs/kafka-single-writer-design.md
+++ b/docs/kafka-single-writer-design.md
@@ -5,9 +5,7 @@ sidebar_label: Kafka single-writer design
 ---
 
 Design notes for the transactional snapshot mode of `kafka-flow-persistence-kafka`
-(`KafkaPersistenceModuleOf.cachingTransactional`) — the mechanism and the measurements behind it. The
-Cassandra backend solves the same problem differently — see
-[Cassandra single-writer design: persist only](cassandra-single-writer-design.md).
+(`KafkaPersistenceModuleOf.cachingTransactional`) — the mechanism and the measurements behind it.
 
 ## Problem
 

--- a/docs/kafka-single-writer-design.md
+++ b/docs/kafka-single-writer-design.md
@@ -5,7 +5,9 @@ sidebar_label: Kafka single-writer design
 ---
 
 Design notes for the transactional snapshot mode of `kafka-flow-persistence-kafka`
-(`KafkaPersistenceModuleOf.cachingTransactional`) — the mechanism and the measurements behind it.
+(`KafkaPersistenceModuleOf.cachingTransactional`) — the mechanism and the measurements behind it. The
+Cassandra backend solves the same problem differently — see
+[Cassandra single-writer design: persist only](cassandra-single-writer-design.md).
 
 ## Problem
 

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -34,21 +34,28 @@ state — losing the events between the two snapshots even though their offsets 
 [kafka-flow#732](https://github.com/evolution-gaming/kafka-flow/issues/732); overlaps of tens of
 seconds have been seen in production.
 
-This page is about turning the protection on and running it; for *how* it fences a stale writer, see
-the [Kafka single-writer design](kafka-single-writer-design.md).
+This page is about turning the protection on and running it; for *how* each backend fences a stale
+writer, see the design docs:
+[Cassandra](cassandra-single-writer-design.md), [Kafka](kafka-single-writer-design.md).
 
 Timer settings change how often the window is hit:
 `TimerFlowOf.persistPeriodically(flushOnRevoke = true)` makes it **more** likely (revoked partitions
 flush while the new owner starts up); a higher `persistEvery` makes it **less** likely, at the cost of
 more events to replay on recovery.
 
-For the Kafka snapshot backend the protection is **transactional** snapshot writes — opt-in, off by
-default, enabled with `KafkaPersistenceModuleOf.cachingTransactional`. (A custom `SnapshotDatabase`
-can implement its own protection — see [Custom snapshot storage](#custom-snapshot-storage).)
+The protections are **opt-in and off by default** — pick the one for your snapshot backend:
+
+|                    | Compare-and-set (Cassandra)                  | Transactional (Kafka)                                        |
+| ------------------ | -------------------------------------------- | ------------------------------------------------------------ |
+| **Enable**         | `compareAndSet = true`                       | `KafkaPersistenceModuleOf.cachingTransactional`              |
+| **Rejects with**   | `CassandraSnapshots.SnapshotWriteConflict`   | `CommitFailedException` (the fenced offset commit)           |
+| **Per-write cost** | a Cassandra lightweight transaction (Paxos)  | a Kafka transaction (concurrent writes are group-committed)  |
+| **Rolling deploy** | safe (clock-skew caveat below)               | safe; full protection once every instance is transactional   |
+| **Output**         | unchanged                                    | at-least-once (output produces stay outside the transaction) |
 
 ### What a rejected write looks like
 
-You do not catch the rejection yourself; it is handled for you:
+You do not catch the rejection yourself; it is handled the same way for both backends:
 
 - **Periodic flush** — the conflict fails the stale instance's flow. That is safe (it no longer owns
   the partition), unless you set `persistPeriodically(ignorePersistErrors = true)`, in which case it
@@ -58,6 +65,60 @@ You do not catch the rejection yourself; it is handled for you:
 
 Either way the rejected write does not land and no offset is committed for it, so the new owner
 replays the affected events.
+
+### Compare-and-set snapshot writes (Cassandra)
+
+Enable with the `compareAndSet` flag:
+
+```scala
+CassandraSnapshots.withSchema[F, State](
+  session,
+  sync,
+  compareAndSet = true,
+)
+// or via the persistence module:
+CassandraPersistence.withSchema[F, State](
+  session,
+  sync,
+  consistencyOverrides,
+  keysSegments,
+  snapshotCompareAndSet = true,
+)
+```
+
+Each snapshot **persist** becomes an offset-guarded conditional write; a stale write is rejected with
+`CassandraSnapshots.SnapshotWriteConflict`. Deletes remain ordinary last-write-wins (offset-gated deletes
+are out of scope for this mode).
+
+- **Cost** — every persist becomes a lightweight transaction (Paxos): several inter-replica
+  round-trips, a few times slower and more coordinator-CPU-intensive than a quorum write. A
+  `persistEvery` wave flushes a partition's whole changed-key population, so the added load scales with
+  that wave. Measure it against your write rate first.
+- **Consistency** — set `ConsistencyOverrides` read **and** write to a quorum (`QUORUM`, or
+  `LOCAL_QUORUM` for single-DC): the fence's read side needs `R + W > N`, and these are **not**
+  defaulted (an unset override uses the session default, often `LOCAL_ONE`). For single-DC also set
+  the scassandra client's `query.serial-consistency = LOCAL_SERIAL` — the lightweight transaction's
+  serial level is separate from `ConsistencyOverrides` and defaults to cross-DC `SERIAL`, so a
+  conditional write otherwise pays a cross-datacenter round-trip.
+- **TTL** — set a `ttl` to bound Paxos-partition growth.
+- **Rollout** — no migration either direction (the condition reads the `offset` column every version
+  already writes). A rolling deploy is safe; while the two modes coexist there is a clock-skew caveat
+  (design doc), negligible with NTP-synced clocks.
+
+Limitations:
+- **Deletes are not fenced.** A delete is a plain last-write-wins remove, issued when your fold returns
+  `None` for a key. During a rebalance overlap a stale writer can then erase a newer owner's snapshot, or
+  resurrect a just-deleted key by writing at a lower offset — #732 for that key. If a deleted key can be
+  concurrently re-written, **fold to an empty/"tombstone" state (`Some(empty)`) instead of `None`**: the
+  deletion then goes through the offset-gated persist path and is protected like any other write, at the
+  cost of the row living until its TTL. Returning `None` stays fine for keys never concurrently re-persisted.
+- Offsets must be monotonic per key: after a consumer-group offset reset, writes at lower offsets are
+  rejected until the stored snapshots are passed or truncated.
+- Writes at an *equal* offset are allowed (e.g. a timer-driven state change at the same offset), so a
+  stale writer holding exactly the stored offset is not detected. It is safe: a same-offset write
+  cannot drop committed events — it does not move the recovery point.
+- The guard lives in the row, so it expires with the `ttl`: once a row's TTL lapses a stale write can
+  land a fresh `INSERT`. Harmless when the TTL far exceeds the overlap window (the usual case).
 
 ### Transactional snapshot writes (Kafka)
 

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -37,31 +37,104 @@ between the two snapshots even though their offsets were committed. See
 [kafka-flow#732](https://github.com/evolution-gaming/kafka-flow/issues/732); overlaps of tens of
 seconds have been seen in production.
 
-This page is about turning the protection on and running it; for *how* it fences a stale writer, see
-the [Kafka single-writer design](kafka-single-writer-design.md).
+This page is about turning the protection on and running it; for *how* each backend fences a stale
+writer, see the design docs:
+[Cassandra](cassandra-single-writer-design.md), [Kafka](kafka-single-writer-design.md).
 
 Timer settings change how often the window is hit:
 `TimerFlowOf.persistPeriodically(flushOnRevoke = true)` makes it **more** likely (revoked partitions
 flush while the new owner starts up); a higher `persistEvery` makes it **less** likely, at the cost of
 more events to replay on recovery.
 
-For the Kafka snapshot backend the protection is **transactional** snapshot writes — opt-in, off by
-default, enabled with `KafkaPersistenceModuleOf.cachingTransactional`. (A custom `SnapshotDatabase`
-can implement its own protection — see [Custom snapshot storage](#custom-snapshot-storage).)
+The protections are **opt-in and off by default** — pick the one for your snapshot backend:
+
+|                    | Compare-and-set (Cassandra)                  | Transactional (Kafka)                                        |
+| ------------------ | -------------------------------------------- | ------------------------------------------------------------ |
+| **Enable**         | `compareAndSet = true`                       | `KafkaPersistenceModuleOf.cachingTransactional`              |
+| **Rejects with**   | `CassandraSnapshots.SnapshotWriteConflict`   | `CommitFailedException` (the fenced offset commit)           |
+| **Per-write cost** | a Cassandra lightweight transaction (Paxos)  | a Kafka transaction (concurrent writes are group-committed)  |
 
 ### What a rejected write looks like
 
-You do not catch the rejection yourself; it is handled for you:
+You do not catch the rejection yourself; it is handled the same way for both backends:
 
-- **Periodic flush** — the conflict fails the stale instance's flow. That is safe (it no longer owns
-  the partition), unless you set `persistPeriodically(ignorePersistErrors = true)`, in which case it
-  is logged and swallowed.
+- **Periodic flush** — the conflict fails the stale instance's flow, a harmless outcome since it no
+  longer owns the partition. Setting `persistPeriodically(ignorePersistErrors = true)` logs and
+  swallows it instead, so the flow keeps running — still safe either way: the fence already rejected
+  the write, and the flag only decides whether the stale flow tears down or keeps getting rejected.
 - **Flush-on-revoke** — the conflict surfaces as a cache-entry release error that scache prints to
   `System.err` — not via the logging framework — and swallows
   (`scache: failed to release cache entry: ...`), so the partition hands off cleanly.
 
 Either way the rejected write does not land and no offset is committed for it, so the new owner
 replays the affected events.
+
+### Compare-and-set snapshot writes (Cassandra)
+
+Enable with the `compareAndSet` flag:
+
+```scala
+CassandraSnapshots.withSchema[F, State](
+  session,
+  sync,
+  compareAndSet = true,
+)
+// or via the persistence module:
+CassandraPersistence.withSchema[F, State](
+  session,
+  sync,
+  consistencyOverrides,
+  keysSegments,
+  snapshotCompareAndSet = true,
+)
+```
+
+Each snapshot **persist** becomes an offset-guarded conditional write; a stale write is rejected with
+`CassandraSnapshots.SnapshotWriteConflict`. Deletes remain ordinary last-write-wins (offset-gated deletes
+are out of scope for this mode).
+
+- **Cost** — every persist becomes a lightweight transaction (Paxos): several inter-replica
+  round-trips, a few times slower and more coordinator-CPU-intensive than a quorum write. A
+  `persistEvery` wave flushes a partition's whole changed-key population, so the added load scales with
+  that wave.
+- **Consistency** — set `ConsistencyOverrides` read **and** write to a quorum (`QUORUM`, or
+  `LOCAL_QUORUM` single-DC); they are **not** defaulted, and the usual `LOCAL_ONE` default is too weak.
+  Recovery reads at the regular (non-serial) level, so it sees the fenced write only when `R + W > N`; a
+  too-weak read still lets the write-side LWT apply but can miss the newest snapshot, silently
+  reintroducing #732 on the read side. Single-DC ownership (a key contended only within one DC, whatever
+  its replication footprint) also needs `query.serial-consistency = LOCAL_SERIAL` on
+  the scassandra client — the LWT's serial level is separate and defaults to cross-DC `SERIAL`, so a
+  conditional write otherwise pays a cross-DC round-trip.
+- **TTL** — set a `ttl` to bound the live key set; the TTL rides onto each key's Paxos state too
+  (`system.paxos`, written per key by every LWT), so it bounds that internal table's growth as well. (A
+  plain `delete` also leaves a Cassandra row tombstone reclaimed only after `gc_grace_seconds` — the
+  cluster default, not set here; not a tombstone-scan risk since keys are single-row partitions read by
+  point lookup, but it feeds compaction and repair under create/delete churn.)
+- **Rollout** — no migration either direction (the condition reads the `offset` column every version
+  already writes). A rolling deploy is safe, with one caveat while the two modes coexist: a
+  conditional write is timestamped by the Cassandra coordinator, a plain write by the client, so an
+  application clock running ahead of the coordinators can let an old instance's plain write shadow a
+  newer conditional one. Negligible with NTP-synced clocks (application hosts and the Cassandra
+  cluster on one source), and gone once every instance writes conditionally.
+
+Limitations:
+- **Deletes are not fenced.** A delete is a plain last-write-wins `DELETE`, issued when your fold
+  returns `None` for a key whose state was already persisted or recovered (a `None` fold for a
+  never-persisted key touches only the in-memory buffer). During a rebalance overlap a stale writer can
+  then erase a newer owner's snapshot, or resurrect a just-deleted key by writing at a lower offset —
+  #732 for that key. For any key that can be concurrently re-written, **avoid the `None` delete — fold
+  to an empty/"tombstone" state (`Some(empty)`) instead**: the deletion then rides the offset-gated
+  persist path and is protected like any other write, at the cost of the row living until its TTL (which
+  also moves the tombstone from an immediate `DELETE` to a TTL expiry). Plain `None` is safe only for
+  keys never concurrently re-persisted.
+- Offsets must be monotonic per key: after a backward consumer-group offset reset every persist
+  conflicts and the affected flows **stall** until reprocessing passes the stored offsets — to replay
+  from an earlier offset, `truncate` the snapshot table first (`CassandraSnapshots.truncate`).
+- Writes at an *equal* offset are allowed (e.g. a timer-driven state change at the same offset), so a
+  stale writer holding exactly the stored offset is not detected. It is safe: a same-offset write
+  cannot drop committed events — it does not move the recovery point.
+- The guard lives in the row, so it expires with the `ttl`: once a row's TTL lapses a stale write can
+  land a fresh `INSERT`. Harmless when the TTL far exceeds the overlap window (the usual case).
 
 ### Transactional snapshot writes (Kafka)
 

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -9,7 +9,7 @@ sidebar_label: Persistence
 kafka-flow keeps the state of each key in memory while it processes a partition. To survive a
 restart or a partition rebalance without replaying the whole input topic from the beginning, that
 state is **persisted** and recovered when the partition is next assigned. Persistence is optional —
-it is only needed when reprocessing the full journal on every recovery is too expensive — and two
+it is only needed when reprocessing the input topic on every recovery is too expensive — and two
 backends are provided:
 
 - **Cassandra** (`kafka-flow-persistence-cassandra`) — stores per-key *journals* (the folded
@@ -53,6 +53,8 @@ The protections are **opt-in and off by default** — pick the one for your snap
 | **Enable**         | `compareAndSet = true`                       | `KafkaPersistenceModuleOf.cachingTransactional`              |
 | **Rejects with**   | `CassandraSnapshots.SnapshotWriteConflict`   | `CommitFailedException` (the fenced offset commit)           |
 | **Per-write cost** | a Cassandra lightweight transaction (Paxos)  | a Kafka transaction (concurrent writes are group-committed)  |
+| **Rolling deploy** | safe (clock-skew caveat below)               | safe; full protection once every instance is transactional   |
+| **Output**         | unchanged                                    | at-least-once (output produces stay outside the transaction) |
 
 ### What a rejected write looks like
 
@@ -89,52 +91,57 @@ CassandraPersistence.withSchema[F, State](
 )
 ```
 
-Each snapshot **persist** becomes an offset-guarded conditional write; a stale write is rejected with
-`CassandraSnapshots.SnapshotWriteConflict`. Deletes remain ordinary last-write-wins (offset-gated deletes
-are out of scope for this mode).
+Each snapshot write becomes an offset-guarded conditional write, and each delete an offset-carrying
+tombstone reaped by the `ttl`; a stale write is rejected with `CassandraSnapshots.SnapshotWriteConflict`.
 
-- **Cost** — every persist becomes a lightweight transaction (Paxos): several inter-replica
+- **Cost** — every write and delete becomes a lightweight transaction (Paxos): several inter-replica
   round-trips, a few times slower and more coordinator-CPU-intensive than a quorum write. A
   `persistEvery` wave flushes a partition's whole changed-key population, so the added load scales with
-  that wave.
+  that wave. Measure it against your write rate first.
 - **Consistency** — set `ConsistencyOverrides` read **and** write to a quorum (`QUORUM`, or
-  `LOCAL_QUORUM` single-DC); they are **not** defaulted, and the usual `LOCAL_ONE` default is too weak.
-  Recovery reads at the regular (non-serial) level, so it sees the fenced write only when `R + W > N`; a
-  too-weak read still lets the write-side LWT apply but can miss the newest snapshot, silently
-  reintroducing #732 on the read side. Single-DC ownership (a key contended only within one DC, whatever
-  its replication footprint) also needs `query.serial-consistency = LOCAL_SERIAL` on
-  the scassandra client — the LWT's serial level is separate and defaults to cross-DC `SERIAL`, so a
-  conditional write otherwise pays a cross-DC round-trip.
-- **TTL** — set a `ttl` to bound the live key set; the TTL rides onto each key's Paxos state too
-  (`system.paxos`, written per key by every LWT), so it bounds that internal table's growth as well. (A
-  plain `delete` also leaves a Cassandra row tombstone reclaimed only after `gc_grace_seconds` — the
-  cluster default, not set here; not a tombstone-scan risk since keys are single-row partitions read by
-  point lookup, but it feeds compaction and repair under create/delete churn.)
+  `LOCAL_QUORUM` for single-DC): the fence's read side needs `R + W > N`, and these are **not**
+  defaulted (an unset override uses the session default, often `LOCAL_ONE`). For single-DC also set
+  the scassandra client's `query.serial-consistency = LOCAL_SERIAL` — the lightweight transaction's
+  serial level is separate from `ConsistencyOverrides` and defaults to cross-DC `SERIAL`, so a
+  conditional write otherwise pays a cross-datacenter round-trip.
+- **TTL** — set a `ttl` to bound tombstone (and Paxos-partition) growth, preferably from the first
+  deployment: Cassandra TTLs are per cell, so changing the `ttl` around deletes can leave rows whose
+  guard cell expired early — handled (they read as absent and the next persist repairs them, see the
+  design doc's TTL notes), but best avoided.
 - **Rollout** — no migration either direction (the condition reads the `offset` column every version
-  already writes). A rolling deploy is safe, with one caveat while the two modes coexist: a
-  conditional write is timestamped by the Cassandra coordinator, a plain write by the client, so an
-  application clock running ahead of the coordinators can let an old instance's plain write shadow a
-  newer conditional one. Negligible with NTP-synced clocks (application hosts and the Cassandra
-  cluster on one source), and gone once every instance writes conditionally.
+  already writes). A rolling deploy is safe; while the two modes coexist there is a clock-skew caveat
+  (design doc), negligible with NTP-synced clocks.
+- **Cassandra version** — run ≥ 3.0.24 / 3.11.10 / 4.0: CASSANDRA-12126 broke linearizability for
+  exactly the non-applying conditional-write shape this mode issues (and leave the
+  `cassandra.unsafe.disable-serial-reads-linearizability` flag unset). On 4.1+, Paxos v2
+  (`paxos_variant: v2` plus scheduled paxos repair) is recommended — it also closes the legacy-Paxos
+  linearizability gap during range movements (bootstrap/decommission/move).
 
 Limitations:
-- **Deletes are not fenced.** A delete is a plain last-write-wins `DELETE`, issued when your fold
-  returns `None` for a key whose state was already persisted or recovered (a `None` fold for a
-  never-persisted key touches only the in-memory buffer). During a rebalance overlap a stale writer can
-  then erase a newer owner's snapshot, or resurrect a just-deleted key by writing at a lower offset —
-  #732 for that key. For any key that can be concurrently re-written, **avoid the `None` delete — fold
-  to an empty/"tombstone" state (`Some(empty)`) instead**: the deletion then rides the offset-gated
-  persist path and is protected like any other write, at the cost of the row living until its TTL (which
-  also moves the tombstone from an immediate `DELETE` to a TTL expiry). Plain `None` is safe only for
-  keys never concurrently re-persisted.
-- Offsets must be monotonic per key: after a backward consumer-group offset reset every persist
-  conflicts and the affected flows **stall** until reprocessing passes the stored offsets — to replay
-  from an earlier offset, `truncate` the snapshot table first (`CassandraSnapshots.truncate`).
+- Offsets must be monotonic per key: after a consumer-group offset reset, lower-offset writes do not
+  overwrite a newer snapshot until the stored snapshots are passed or truncated. Through the fenced
+  buffer a replayed lower-offset write is *dropped* (held at the recovered high-water — silent, by
+  design); a write the buffer does not gate (a custom or unfenced path) is *rejected* at the store with
+  `SnapshotWriteConflict`. Either way the newer snapshot stands.
 - Writes at an *equal* offset are allowed (e.g. a timer-driven state change at the same offset), so a
   stale writer holding exactly the stored offset is not detected. It is safe: a same-offset write
   cannot drop committed events — it does not move the recovery point.
 - The guard lives in the row, so it expires with the `ttl`: once a row's TTL lapses a stale write can
   land a fresh `INSERT`. Harmless when the TTL far exceeds the overlap window (the usual case).
+- Only this mode's statements may touch the snapshots table: mixing plain writes into rows managed by
+  lightweight transactions voids Cassandra's linearizability guarantee (their timestamps do not
+  compose).
+- Under events-recovery (`restoreEvents`), the journal is a second, *unfenced* store: a delete spans
+  the snapshot tombstone and the journal clear with no cross-store atomicity, and a stale owner's
+  replayed appends (or a crash between the two deletes) can leave journal rows for a tombstoned key,
+  below its tombstone's offset. This gap predates the compare-and-set mode. What compare-and-set adds
+  is the guard: recovery folds only the journal rows whose offset exceeds the fenced store's offset
+  onto the store's snapshot as the base, so sub-floor residue is never folded — it cannot resurrect a
+  deleted key or regress a live one. The filter is on the event offset, not the fold's result, so it
+  holds at every recovery, not only the first (an offset comparison of the fold result would let the
+  residue back in once legitimate events advanced the journal past the store). Under last-write-wins
+  there is no trustworthy floor to filter against, so events-recovery there remains exposed;
+  snapshot-recovery modes are unaffected either way.
 
 ### Transactional snapshot writes (Kafka)
 
@@ -265,14 +272,19 @@ Limitations:
 
 ### Custom snapshot storage
 
-You can plug in your own snapshot store: implement `SnapshotDatabase` and wire it through
+You can plug in your own snapshot store: implement `SnapshotDatabase` — `read` returns the stored unit
+(a `Stored.Live`, an offset-carrying `Stored.Tombstone`, or `None` for an absent key) and `write`
+upserts a `Stored.Live` or tombstones with a `Stored.Tombstone` — and wire it through
 `SnapshotsOf.backedBy` into `PersistenceOf.snapshotsOnly`/`restoreEvents`. A custom store is
-**last-write-wins**, so it is exposed to the same stale-writer overwrite
-([#732](https://github.com/evolution-gaming/kafka-flow/issues/732)) unless its `persist` rejects a
-write when the store already holds a newer offset (taken from the snapshot) — that conditional write
-is the fence (the buffer wiring does not provide it). Note that the `delete(key)` method carries no
-offset, so a delete cannot be offset-gated through this interface; a custom store's delete stays
-unconditional.
+**last-write-wins**, so it is exposed to the same stale-writer overwrite as last-write-wins Cassandra
+([#732](https://github.com/evolution-gaming/kafka-flow/issues/732)).
+
+To protect it, its `write` must reject the write when the store already holds a newer offset (gate on
+`stored.offset`) — that conditional write is the fence (the buffer wiring does not provide it). Once
+writes are conditional, give the buffer an `offsetOf` so it does not fence the owner against itself
+during recovery: `SnapshotsOf.backedBy(db, offsetOf)` for an offset-carrying type, or a
+`KafkaSnapshot[S]` via `SnapshotDatabase.snapshotsOf`. See "The replay window" in the
+[Cassandra design doc](cassandra-single-writer-design.md) for why.
 
 ## Compression
 Kafka-flow has a built-in support for compressing application's state

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -183,16 +183,18 @@ Limitations:
 
 ### Custom snapshot storage
 
-You can plug in your own snapshot store: implement `SnapshotDatabase` and wire it through
+You can plug in your own snapshot store: implement `SnapshotDatabase` — `read` returns the stored unit
+(a `Stored.Live`, an offset-carrying `Stored.Tombstone`, or `None` for an absent key) and `write`
+upserts a `Stored.Live` or tombstones with a `Stored.Tombstone` — and wire it through
 `SnapshotsOf.backedBy` into `PersistenceOf.snapshotsOnly`/`restoreEvents`. A custom store is
 **last-write-wins**, so it is exposed to the same stale-writer overwrite as last-write-wins Cassandra
 ([#732](https://github.com/evolution-gaming/kafka-flow/issues/732)).
 
-To protect it, its own `persist`/`delete` must reject a write when the store already holds a newer
-offset — that conditional write is the fence (the buffer wiring does not provide it). Once writes are
-conditional, give the buffer an `offsetOf` so it does not fence the owner against itself during
-recovery: `SnapshotsOf.backedBy(db, offsetOf)` for an offset-carrying type, or a `KafkaSnapshot[S]`
-via `SnapshotDatabase.snapshotsOf`. See "The replay window" in the
+To protect it, its `write` must reject the write when the store already holds a newer offset (gate on
+`stored.offset`) — that conditional write is the fence (the buffer wiring does not provide it). Once
+writes are conditional, give the buffer an `offsetOf` so it does not fence the owner against itself
+during recovery: `SnapshotsOf.backedBy(db, offsetOf)` for an offset-carrying type, or a
+`KafkaSnapshot[S]` via `SnapshotDatabase.snapshotsOf`. See "The replay window" in the
 [Cassandra design doc](cassandra-single-writer-design.md) for why.
 
 ## Compression

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -86,11 +86,10 @@ CassandraPersistence.withSchema[F, State](
 )
 ```
 
-Each snapshot **persist** becomes an offset-guarded conditional write; a stale write is rejected with
-`CassandraSnapshots.SnapshotWriteConflict`. Deletes remain ordinary last-write-wins (offset-gated deletes
-are out of scope for this mode).
+Each snapshot write becomes an offset-guarded conditional write, and each delete an offset-carrying
+tombstone reaped by the `ttl`; a stale write is rejected with `CassandraSnapshots.SnapshotWriteConflict`.
 
-- **Cost** — every persist becomes a lightweight transaction (Paxos): several inter-replica
+- **Cost** — every write and delete becomes a lightweight transaction (Paxos): several inter-replica
   round-trips, a few times slower and more coordinator-CPU-intensive than a quorum write. A
   `persistEvery` wave flushes a partition's whole changed-key population, so the added load scales with
   that wave. Measure it against your write rate first.
@@ -100,7 +99,7 @@ are out of scope for this mode).
   the scassandra client's `query.serial-consistency = LOCAL_SERIAL` — the lightweight transaction's
   serial level is separate from `ConsistencyOverrides` and defaults to cross-DC `SERIAL`, so a
   conditional write otherwise pays a cross-datacenter round-trip.
-- **TTL** — set a `ttl` to bound Paxos-partition growth.
+- **TTL** — set a `ttl` to bound tombstone (and Paxos-partition) growth.
 - **Rollout** — no migration either direction (the condition reads the `offset` column every version
   already writes). A rolling deploy is safe; while the two modes coexist there is a clock-skew caveat
   (design doc), negligible with NTP-synced clocks.
@@ -186,12 +185,15 @@ Limitations:
 
 You can plug in your own snapshot store: implement `SnapshotDatabase` and wire it through
 `SnapshotsOf.backedBy` into `PersistenceOf.snapshotsOnly`/`restoreEvents`. A custom store is
-**last-write-wins**, so it is exposed to the same stale-writer overwrite
-([#732](https://github.com/evolution-gaming/kafka-flow/issues/732)) unless its `persist` rejects a
-write when the store already holds a newer offset (taken from the snapshot) — that conditional write
-is the fence (the buffer wiring does not provide it). Note that the `delete(key)` method carries no
-offset, so a delete cannot be offset-gated through this interface; a custom store's delete stays
-unconditional.
+**last-write-wins**, so it is exposed to the same stale-writer overwrite as last-write-wins Cassandra
+([#732](https://github.com/evolution-gaming/kafka-flow/issues/732)).
+
+To protect it, its own `persist`/`delete` must reject a write when the store already holds a newer
+offset — that conditional write is the fence (the buffer wiring does not provide it). Once writes are
+conditional, give the buffer an `offsetOf` so it does not fence the owner against itself during
+recovery: `SnapshotsOf.backedBy(db, offsetOf)` for an offset-carrying type, or a `KafkaSnapshot[S]`
+via `SnapshotDatabase.snapshotsOf`. See "The replay window" in the
+[Cassandra design doc](cassandra-single-writer-design.md) for why.
 
 ## Compression
 Kafka-flow has a built-in support for compressing application's state

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -105,12 +105,6 @@ tombstone reaped by the `ttl`; a stale write is rejected with `CassandraSnapshot
   (design doc), negligible with NTP-synced clocks.
 
 Limitations:
-- **Deletes are not fenced.** A delete is a plain last-write-wins remove, issued when your fold returns
-  `None` for a key. During a rebalance overlap a stale writer can then erase a newer owner's snapshot, or
-  resurrect a just-deleted key by writing at a lower offset — #732 for that key. If a deleted key can be
-  concurrently re-written, **fold to an empty/"tombstone" state (`Some(empty)`) instead of `None`**: the
-  deletion then goes through the offset-gated persist path and is protected like any other write, at the
-  cost of the row living until its TTL. Returning `None` stays fine for keys never concurrently re-persisted.
 - Offsets must be monotonic per key: after a consumer-group offset reset, writes at lower offsets are
   rejected until the stored snapshots are passed or truncated.
 - Writes at an *equal* offset are allowed (e.g. a timer-driven state change at the same offset), so a

--- a/metrics/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotDatabaseMetrics.scala
+++ b/metrics/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotDatabaseMetrics.scala
@@ -1,6 +1,6 @@
 package com.evolutiongaming.kafka.flow.snapshot
 
-import cats.Monad
+import cats.{Functor, Monad}
 import cats.syntax.all.*
 import com.evolutiongaming.catshelper.MeasureDuration
 import com.evolutiongaming.kafka.flow.KafkaKey
@@ -49,6 +49,13 @@ object SnapshotDatabaseMetrics {
           }
         def get(key: KafkaKey) =
           database.get(key) measureDuration { duration =>
+            getSummary
+              .labels(key.topicPartition.topic, key.topicPartition.partition.show)
+              .observe(duration.toNanos.nanosToSeconds)
+          }
+        // delegate to the underlying recover so an offset-carrying tombstone is not downgraded to Absent through `get`
+        override def recover(key: KafkaKey)(implicit functor: Functor[F]) =
+          database.recover(key) measureDuration { duration =>
             getSummary
               .labels(key.topicPartition.topic, key.topicPartition.partition.show)
               .observe(duration.toNanos.nanosToSeconds)

--- a/metrics/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotDatabaseMetrics.scala
+++ b/metrics/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotDatabaseMetrics.scala
@@ -34,27 +34,24 @@ object SnapshotDatabaseMetrics {
       )
       deleteSummary <- registry.summary(
         name      = "snapshot_database_delete_duration_seconds",
-        help      = "Time required to delete all snapshots for the key from a database",
+        help      = "Time required to delete the snapshot for the key from a database",
         quantiles = Quantiles(Quantile(0.9, 0.05), Quantile(0.99, 0.005)),
         labels    = LabelNames("topic", "partition")
       )
     } yield new MetricsK[SnapshotDatabase[F, KafkaKey, *]] {
       def withMetrics[S](database: SnapshotDatabase[F, KafkaKey, S]) = new SnapshotDatabase[F, KafkaKey, S] {
-        def persist(key: KafkaKey, snapshot: S) =
-          database.persist(key, snapshot) measureDuration { duration =>
-            persistSummary
+        // a present value is a persist, an absent value is a delete (tombstone) - keep the two summaries distinct
+        def write(key: KafkaKey, stored: Stored[S]) = {
+          val summary = if (stored.value.isDefined) persistSummary else deleteSummary
+          database.write(key, stored) measureDuration { duration =>
+            summary
               .labels(key.topicPartition.topic, key.topicPartition.partition.show)
               .observe(duration.toNanos.nanosToSeconds)
           }
-        def get(key: KafkaKey) =
-          database.get(key) measureDuration { duration =>
+        }
+        def read(key: KafkaKey) =
+          database.read(key) measureDuration { duration =>
             getSummary
-              .labels(key.topicPartition.topic, key.topicPartition.partition.show)
-              .observe(duration.toNanos.nanosToSeconds)
-          }
-        def delete(key: KafkaKey) =
-          database.delete(key) measureDuration { duration =>
-            deleteSummary
               .labels(key.topicPartition.topic, key.topicPartition.partition.show)
               .observe(duration.toNanos.nanosToSeconds)
           }

--- a/metrics/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotDatabaseMetrics.scala
+++ b/metrics/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotDatabaseMetrics.scala
@@ -1,13 +1,12 @@
 package com.evolutiongaming.kafka.flow.snapshot
 
-import cats.{Functor, Monad}
+import cats.Monad
 import cats.syntax.all.*
 import com.evolutiongaming.catshelper.MeasureDuration
 import com.evolutiongaming.kafka.flow.KafkaKey
 import com.evolutiongaming.kafka.flow.metrics.MetricsK
 import com.evolutiongaming.kafka.flow.metrics.MetricsKOf
 import com.evolutiongaming.kafka.flow.metrics.syntax.*
-import com.evolutiongaming.skafka.Offset
 import com.evolutiongaming.smetrics.LabelNames
 import com.evolutiongaming.smetrics.MetricsHelper.*
 import com.evolutiongaming.smetrics.Quantile
@@ -41,28 +40,18 @@ object SnapshotDatabaseMetrics {
       )
     } yield new MetricsK[SnapshotDatabase[F, KafkaKey, *]] {
       def withMetrics[S](database: SnapshotDatabase[F, KafkaKey, S]) = new SnapshotDatabase[F, KafkaKey, S] {
-        def persist(key: KafkaKey, snapshot: S) =
-          database.persist(key, snapshot) measureDuration { duration =>
-            persistSummary
+        // a present value is a persist, an absent value is a delete (tombstone) - keep the two summaries distinct
+        def write(key: KafkaKey, stored: Stored[S]) = {
+          val summary = if (stored.value.isDefined) persistSummary else deleteSummary
+          database.write(key, stored) measureDuration { duration =>
+            summary
               .labels(key.topicPartition.topic, key.topicPartition.partition.show)
               .observe(duration.toNanos.nanosToSeconds)
           }
-        def get(key: KafkaKey) =
-          database.get(key) measureDuration { duration =>
+        }
+        def read(key: KafkaKey) =
+          database.read(key) measureDuration { duration =>
             getSummary
-              .labels(key.topicPartition.topic, key.topicPartition.partition.show)
-              .observe(duration.toNanos.nanosToSeconds)
-          }
-        // delegate to the underlying recover so an offset-carrying tombstone is not downgraded to Absent through `get`
-        override def recover(key: KafkaKey)(implicit functor: Functor[F]) =
-          database.recover(key) measureDuration { duration =>
-            getSummary
-              .labels(key.topicPartition.topic, key.topicPartition.partition.show)
-              .observe(duration.toNanos.nanosToSeconds)
-          }
-        def delete(key: KafkaKey, offset: Offset) =
-          database.delete(key, offset) measureDuration { duration =>
-            deleteSummary
               .labels(key.topicPartition.topic, key.topicPartition.partition.show)
               .observe(duration.toNanos.nanosToSeconds)
           }

--- a/metrics/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotDatabaseMetrics.scala
+++ b/metrics/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotDatabaseMetrics.scala
@@ -7,6 +7,7 @@ import com.evolutiongaming.kafka.flow.KafkaKey
 import com.evolutiongaming.kafka.flow.metrics.MetricsK
 import com.evolutiongaming.kafka.flow.metrics.MetricsKOf
 import com.evolutiongaming.kafka.flow.metrics.syntax.*
+import com.evolutiongaming.skafka.Offset
 import com.evolutiongaming.smetrics.LabelNames
 import com.evolutiongaming.smetrics.MetricsHelper.*
 import com.evolutiongaming.smetrics.Quantile
@@ -34,7 +35,7 @@ object SnapshotDatabaseMetrics {
       )
       deleteSummary <- registry.summary(
         name      = "snapshot_database_delete_duration_seconds",
-        help      = "Time required to delete all snapshots for the key from a database",
+        help      = "Time required to delete the snapshot for the key from a database",
         quantiles = Quantiles(Quantile(0.9, 0.05), Quantile(0.99, 0.005)),
         labels    = LabelNames("topic", "partition")
       )
@@ -52,8 +53,8 @@ object SnapshotDatabaseMetrics {
               .labels(key.topicPartition.topic, key.topicPartition.partition.show)
               .observe(duration.toNanos.nanosToSeconds)
           }
-        def delete(key: KafkaKey) =
-          database.delete(key) measureDuration { duration =>
+        def delete(key: KafkaKey, offset: Offset) =
+          database.delete(key, offset) measureDuration { duration =>
             deleteSummary
               .labels(key.topicPartition.topic, key.topicPartition.partition.show)
               .observe(duration.toNanos.nanosToSeconds)

--- a/metrics/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotDatabaseMetricsSpec.scala
+++ b/metrics/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotDatabaseMetricsSpec.scala
@@ -1,0 +1,47 @@
+package com.evolutiongaming.kafka.flow.snapshot
+
+import cats.effect.unsafe.IORuntime
+import cats.effect.{IO, Ref}
+import cats.syntax.all.*
+import com.evolutiongaming.catshelper.MeasureDuration
+import com.evolutiongaming.kafka.flow.KafkaKey
+import com.evolutiongaming.smetrics.CollectorRegistry
+import com.evolutiongaming.skafka.{Offset, TopicPartition}
+import munit.FunSuite
+
+/** The metrics wrapper must delegate the single `read`/`write` verbatim - in particular a recovered `Stored.Tombstone`
+  * must pass through with its offset (the replay-window floor): a wrapper that collapsed it to "absent" would silently
+  * disarm the deleted-key livelock prevention. The unified `Stored` read/write exists partly so a wrapper has no
+  * separate value-only path to get this wrong; this pins it.
+  */
+class SnapshotDatabaseMetricsSpec extends FunSuite {
+  implicit val ioRuntime: IORuntime                    = IORuntime.global
+  implicit val md: MeasureDuration[IO]                 = MeasureDuration.empty[IO]
+  private val key: KafkaKey                            = KafkaKey("app", "group", TopicPartition.empty, "key")
+  private val tombstone: Stored[KafkaSnapshot[String]] = Stored.Tombstone(Offset.unsafe(5))
+  private val live: Stored[KafkaSnapshot[String]] =
+    Stored.Live(KafkaSnapshot(offset = Offset.unsafe(7), value = "v7"), Offset.unsafe(7).some)
+
+  test("the wrapper passes a tombstone read through with its offset and delegates writes verbatim") {
+    val test = for {
+      written <- Ref.of[IO, List[Stored[KafkaSnapshot[String]]]](Nil)
+      db = new SnapshotDatabase[IO, KafkaKey, KafkaSnapshot[String]] {
+        def read(key: KafkaKey)                                         = tombstone.some.pure[IO]
+        def write(key: KafkaKey, stored: Stored[KafkaSnapshot[String]]) = written.update(stored :: _)
+      }
+      result <- SnapshotDatabaseMetrics.of[IO].apply(CollectorRegistry.empty[IO]).use { metrics =>
+        val wrapped = metrics.withMetrics(db)
+        for {
+          read <- wrapped.read(key)
+          _    <- wrapped.write(key, live)
+          _    <- wrapped.write(key, tombstone)
+          ws   <- written.get
+        } yield (read, ws.reverse)
+      }
+    } yield {
+      assertEquals(result._1, tombstone.some)
+      assertEquals(result._2, List(live, tombstone))
+    }
+    test.unsafeRunSync()
+  }
+}

--- a/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/CassandraContainerResource.scala
+++ b/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/CassandraContainerResource.scala
@@ -1,13 +1,21 @@
 package com.evolutiongaming.kafka.flow
 
 import com.dimafeng.testcontainers.CassandraContainer
+import org.testcontainers.utility.DockerImageName
 
 /** Cassandra container, shared among multiple test classes. Manual stop would be preferable but not necessary as Ryuk
-  * guarantees to collect it after tests pass
+  * guarantees to collect it after tests pass.
+  *
+  * The image is pinned at or above the compare-and-set mode's documented version floor (>= 3.0.24 / 3.11.10 / 4.0 -
+  * CASSANDRA-12126 broke linearizability for exactly this mode's non-applying LWT shape; see
+  * docs/cassandra-single-writer-design.md "Cassandra preconditions"). testcontainers' unpinned default is
+  * cassandra:3.11.2, which is BELOW that floor; 4.1 is the line the design doc recommends (Paxos v2 available).
+  * Single-node containers make 12126 moot in practice, but the correctness suite must not run below the floor it
+  * documents.
   */
 object CassandraContainerResource {
   val cassandra: CassandraContainer = {
-    val container = new CassandraContainer()
+    val container = new CassandraContainer(DockerImageName.parse("cassandra:4.1.3"))
     container.start()
     container
   }

--- a/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/FlowSpec.scala
+++ b/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/FlowSpec.scala
@@ -10,7 +10,7 @@ import com.evolutiongaming.kafka.flow.kafka.{Consumer, ScheduleCommit}
 import com.evolutiongaming.kafka.flow.key.CassandraKeys
 import com.evolutiongaming.kafka.flow.persistence.PersistenceModule
 import com.evolutiongaming.kafka.flow.registry.EntityRegistry
-import com.evolutiongaming.kafka.flow.snapshot.KafkaSnapshot
+import com.evolutiongaming.kafka.flow.snapshot.{CassandraSnapshots, KafkaSnapshot}
 import com.evolutiongaming.kafka.flow.timer.{TimerFlowOf, TimersOf}
 import com.evolutiongaming.retry.Retry
 import com.evolutiongaming.skafka.consumer.ConsumerGroupMetadata
@@ -141,11 +141,11 @@ class FlowSpec extends CassandraSpec {
       (flowB_, releaseB) = flowB
       _                 <- flowB_(staleFlowRecords(eventsB, key, tp))
       _                 <- releaseB
-      newOwnerWrote     <- storage.snapshots.get(KafkaKey(appId, groupId, tp, key))
+      newOwnerWrote     <- storage.snapshots.read(KafkaKey(appId, groupId, tp, key)).map(_.flatMap(_.value))
       _                  = assertEquals(clue(newOwnerWrote.map(_.value)), Some(eventsB.mkString(",")))
       // the previous owner flushes its stale state on revoke
       staleFlush <- releaseA.attempt
-      stored     <- storage.snapshots.get(KafkaKey(appId, groupId, tp, key))
+      stored     <- storage.snapshots.read(KafkaKey(appId, groupId, tp, key)).map(_.flatMap(_.value))
     } yield (staleFlush, stored)
   }
 
@@ -174,6 +174,179 @@ class FlowSpec extends CassandraSpec {
           value            = Some(WithSize(ByteVector.encodeUtf8(event).toOption.get)),
         )
     }
+
+  // a fold that deletes the key (returns None) on a "DELETE" event, otherwise behaves like staleFlowFold
+  private val deleteOnMarkerFold: FoldOption[IO, KafkaSnapshot[String], ConsumerRecord[String, ByteVector]] =
+    FoldOption.of { (state, record) =>
+      IO {
+        val event = record.value.flatMap(_.value.decodeUtf8.toOption).getOrElse(sys.error("event payload missing"))
+        if (event == "DELETE") none[KafkaSnapshot[String]]
+        else KafkaSnapshot(offset = record.offset, value = state.fold(event)(s => s"${s.value},$event")).some
+      }
+    }
+
+  // Real-Cassandra counterpart of the (timer-driven) core SnapshotReplayFencingSpec: it covers the flow -> real
+  // CassandraSnapshots delete seam for the replay-window fix. TestControl cannot drive the real driver's async I/O, so
+  // the delete is triggered deterministically (no sleep) by a fold returning None on a replayed-offset record - the
+  // same Snapshots.delete fence path the tick would hit. A delete whose processing offset (2) trails the key's
+  // recovered snapshot offset (5) must be fenced on the high-water (5) and apply against real Cassandra, not be
+  // rejected as stale.
+  test(
+    "compare-and-set: a delete during replay below the recovered snapshot offset applies (fenced on the high-water)"
+  ) {
+    val appId            = "FlowSpec-cas-replay-delete"
+    val groupId          = "integration-tests-1"
+    val tp               = TopicPartition.empty
+    val key              = "key-replay-delete"
+    val events           = (1 to 6).toList.map(i => s"e$i") // land at offsets 0..5
+    val recoveredAt      = Offset.unsafe(5) // the recovered snapshot's high-water offset (the last event)
+    val replayedDeleteAt = Offset.unsafe(2) // a replayed DELETE that trails the recovered offset (2 < 5)
+
+    val test: IO[(Either[Throwable, Unit], Option[KafkaSnapshot[String]])] = for {
+      storage <- CassandraPersistence.withSchema[IO, String](
+        cassandra().session,
+        cassandra().sync,
+        ConsistencyOverrides.none,
+        CassandraKeys.DefaultSegments,
+        snapshotCompareAndSet = true,
+      )
+      // an owner persists the key's snapshot at offset 5 and registers the key
+      flowA             <- allocateStaleFlow(storage, appId, groupId, tp)
+      (flowA_, releaseA) = flowA
+      _                 <- flowA_(staleFlowRecords(events, key, tp))
+      _                 <- releaseA
+      stored            <- storage.snapshots.read(KafkaKey(appId, groupId, tp, key)).map(_.flatMap(_.value))
+      _                  = assertEquals(clue(stored.map(_.offset)), Some(recoveredAt))
+      // a new flow recovers the key (snapshot offset 5) at assignedAt = 0; the replayed "DELETE" makes the fold
+      // return None -> delete at the replayed offset, which must be fenced on the high-water (recoveredAt)
+      flowB             <- allocateStaleFlow(storage, appId, groupId, tp, deleteOnMarkerFold)
+      (flowB_, releaseB) = flowB
+      deleteResult <- flowB_(staleFlowRecords(List("DELETE"), key, tp).map(_.copy(offset = replayedDeleteAt))).attempt
+      _            <- releaseB.attempt
+      afterDelete  <- storage.snapshots.read(KafkaKey(appId, groupId, tp, key)).map(_.flatMap(_.value))
+    } yield (deleteResult, afterDelete)
+
+    val (deleteResult, afterDelete) = test.unsafeRunSync()
+    deleteResult match {
+      case Left(conflict: CassandraSnapshots.SnapshotWriteConflict) =>
+        fail(s"the replay-window delete was rejected by CAS instead of being fenced on the high-water: $conflict")
+      case Left(e)  => fail(s"unexpected error: $e")
+      case Right(_) => assert(clue(afterDelete.isEmpty)) // deleted; the tombstone reads back as None
+    }
+  }
+
+  // The journal revive, end to end: under events-recovery the journal is UNFENCED - a stale
+  // owner's replayed appends land as plain inserts even after a delete cleared it. The polluted journal must never
+  // fold pre-delete state back to life, and - the re-entry - must STAY dead across later recoveries, after
+  // legitimate post-delete events have advanced the journal and the snapshot together (a fold-result comparison
+  // would pass the polluted fold through at that point; only filtering rows below the fenced store's offset holds
+  // at every recovery). All through the real machinery: PartitionFlow, eager events-recovery (restoreEvents), the
+  // real Cassandra journal and CAS snapshot store, flush-on-revoke.
+  test("compare-and-set + events-recovery: deleted-key journal residue is never folded back to life (journal revive)") {
+    val appId   = "FlowSpec-cas-revive"
+    val groupId = "integration-tests-1"
+    val tp      = TopicPartition.empty
+    val key     = "key-revive"
+
+    def records(eventsWithOffsets: List[(String, Long)]): List[ConsumerRecord[String, ByteVector]] =
+      eventsWithOffsets.map {
+        case (event, offset) =>
+          ConsumerRecord[String, ByteVector](
+            topicPartition   = tp,
+            offset           = Offset.unsafe(offset),
+            timestampAndType = None,
+            key              = Some(WithSize(key)),
+            value            = Some(WithSize(ByteVector.encodeUtf8(event).toOption.get)),
+          )
+      }
+
+    val test: IO[(Option[String], Option[String])] = for {
+      storage <- CassandraPersistence.withSchema[IO, String](
+        cassandra().session,
+        cassandra().sync,
+        ConsistencyOverrides.none,
+        CassandraKeys.DefaultSegments,
+        snapshotCompareAndSet = true,
+      )
+      kafkaKey = KafkaKey(appId, groupId, tp, key)
+      // the owner folds e1..e3 (journal rows 0..2) and persists on release: snapshot Live("e1,e2,e3"@2), journal
+      // rows 0..2. This first persist is what arms the delete below - a fold-None delete is buffer-only (persist =
+      // false) until something has been persisted, so without this the delete would write no tombstone at all.
+      flowA0              <- allocateEventsFlow(storage, appId, groupId, tp, deleteOnMarkerFold)
+      (flowA0_, releaseA0) = flowA0
+      _                   <- flowA0_(records(List("e1" -> 0L, "e2" -> 1L, "e3" -> 2L)))
+      _                   <- releaseA0
+      // a second acquisition recovers the persisted state (so persistedAt is set), then the DELETE@3 dispatches
+      // persist = true: a real Tombstone(3) is written to the CAS store and journals.delete(true) clears rows 0..2
+      flowA             <- allocateEventsFlow(storage, appId, groupId, tp, deleteOnMarkerFold)
+      (flowA_, releaseA) = flowA
+      _                 <- flowA_(records(List("DELETE" -> 3L)))
+      _                 <- releaseA
+      afterDelete       <- storage.snapshots.read(kafkaKey).map(_.flatMap(_.value))
+      _                  = assertEquals(clue(afterDelete), None) // durable tombstone(3): reads back as deleted
+      // a stale owner replays e1..e2 (at-least-once redelivery below the committed offset): its folded state is
+      // dropped by the monotonic buffer, but its journal appends are UNFENCED and re-pollute the cleared journal
+      flowZ             <- allocateEventsFlow(storage, appId, groupId, tp, deleteOnMarkerFold)
+      (flowZ_, releaseZ) = flowZ
+      _                 <- flowZ_(records(List("e1" -> 0L, "e2" -> 1L)))
+      _                 <- releaseZ.attempt
+      afterZombie       <- storage.snapshots.read(kafkaKey).map(_.flatMap(_.value))
+      // recovery #1 discards the residue (tombstone leads it); the flow processes legitimate post-delete events,
+      // advancing journal and snapshot past the tombstone - the state a fold-result comparison cannot tell apart
+      flowB             <- allocateEventsFlow(storage, appId, groupId, tp, deleteOnMarkerFold)
+      (flowB_, releaseB) = flowB
+      _                 <- flowB_(records(List("n1" -> 4L, "n2" -> 5L)))
+      _                 <- releaseB
+      // recovery #2 (the re-entry): the journal now holds {residue 0..1, post-delete 4..5}; folding it from
+      // scratch would resurrect e1,e2 into the base at a correct-looking offset and persist it forward durably
+      flowC             <- allocateEventsFlow(storage, appId, groupId, tp, deleteOnMarkerFold)
+      (flowC_, releaseC) = flowC
+      _                 <- flowC_(records(List("n3" -> 6L)))
+      _                 <- releaseC
+      stored            <- storage.snapshots.read(kafkaKey).map(_.flatMap(_.value))
+    } yield (afterZombie.map(_.value), stored.map(_.value))
+
+    val (afterZombie, stored) = test.unsafeRunSync()
+    // the zombie's replay landed nothing durable: the key is still deleted after its release
+    assertEquals(clue(afterZombie), None)
+    // no pre-delete event survived any recovery; the durable state is exactly the post-delete fold
+    assertEquals(clue(stored), Some("n1,n2,n3"))
+  }
+
+  private def allocateEventsFlow(
+    storage: PersistenceModule[IO, String],
+    appId: String,
+    groupId: String,
+    tp: TopicPartition,
+    fold: FoldOption[IO, KafkaSnapshot[String], ConsumerRecord[String, ByteVector]],
+  ): IO[(PartitionFlow[IO], IO[Unit])] = {
+    val flow = for {
+      timersOf      <- Resource.eval(TimersOf.memory[IO, KafkaKey])
+      keysOf        <- Resource.eval(storage.keys.toKeysOf)
+      persistenceOf <- storage.restoreEvents
+      keyStateOf = KeyStateOf.eagerRecovery[IO, KafkaSnapshot[String]](
+        applicationId = appId,
+        groupId       = groupId,
+        keysOf        = keysOf,
+        timersOf      = timersOf,
+        persistenceOf = persistenceOf,
+        timerFlowOf = TimerFlowOf.persistPeriodically[IO](
+          fireEvery     = 1.hour,
+          persistEvery  = 1.hour,
+          flushOnRevoke = true,
+        ),
+        fold     = fold,
+        tick     = TickOption.id[IO, KafkaSnapshot[String]],
+        registry = EntityRegistry.empty[IO, KafkaKey, KafkaSnapshot[String]],
+      )
+      partitionFlowOf = PartitionFlowOf(keyStateOf, PartitionFlowConfig(commitOnRevoke = true))
+      flow <- partitionFlowOf(
+        PartitionAssignment(tp, Offset.min, IO.pure(none[ConsumerGroupMetadata])),
+        ScheduleCommit.empty[IO],
+      )
+    } yield flow
+    flow.allocated
+  }
 
   private def allocateStaleFlow(
     storage: PersistenceModule[IO, String],

--- a/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/FlowSpec.scala
+++ b/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/FlowSpec.scala
@@ -3,14 +3,17 @@ package com.evolutiongaming.kafka.flow
 import cats.data.NonEmptyList
 import cats.effect.unsafe.IORuntime
 import cats.effect.{IO, Ref, Resource}
+import cats.syntax.all.*
 import com.evolutiongaming.catshelper.LogOf
 import com.evolutiongaming.kafka.flow.cassandra.{CassandraPersistence, ConsistencyOverrides}
-import com.evolutiongaming.kafka.flow.kafka.Consumer
+import com.evolutiongaming.kafka.flow.kafka.{Consumer, ScheduleCommit}
 import com.evolutiongaming.kafka.flow.key.CassandraKeys
+import com.evolutiongaming.kafka.flow.persistence.PersistenceModule
 import com.evolutiongaming.kafka.flow.registry.EntityRegistry
 import com.evolutiongaming.kafka.flow.snapshot.KafkaSnapshot
 import com.evolutiongaming.kafka.flow.timer.{TimerFlowOf, TimersOf}
 import com.evolutiongaming.retry.Retry
+import com.evolutiongaming.skafka.consumer.ConsumerGroupMetadata
 import com.evolutiongaming.skafka.consumer.{ConsumerRecord, ConsumerRecords, WithSize}
 import com.evolutiongaming.skafka.{Offset, TopicPartition}
 import scodec.bits.ByteVector
@@ -81,6 +84,133 @@ class FlowSpec extends CassandraSpec {
     val test: IO[Unit] = flow.use(join => join.attempt.map(result => assert(clue(result.isLeft))))
 
     test.unsafeRunSync()
+  }
+
+  // Reproduces the #732 stale-writer corruption through the real kafka-flow machinery (PartitionFlow, eager recovery,
+  // fold, buffered snapshots, flush-on-revoke). The ownership overlap is simulated by two PartitionFlows over one
+  // partition: a real overlap is indistinguishable from the second flow being created while the first is still alive.
+  test("issue #732 reproduction: stale flush-on-revoke overwrites the newer snapshot (last-write-wins)") {
+    val (staleFlush, stored) = staleFlushScenario(compareAndSet = false).unsafeRunSync()
+    assertEquals(clue(staleFlush), Right(()))
+    // recovery now returns the STALE snapshot (events e6..e10 are lost although the new owner persisted them):
+    // this assertion documents the corruption of issue #732, prevented in the paired test below
+    assertEquals(clue(stored.map(_.value)), Some("e1,e2,e3,e4,e5"))
+  }
+
+  test("issue #732 prevention: stale flush-on-revoke is rejected (compareAndSet)") {
+    val (staleFlush, stored) = staleFlushScenario(compareAndSet = true).unsafeRunSync()
+    // the release itself succeeds: the rejected write surfaces as a logged-and-swallowed cache entry release error
+    // ("scache: failed to release cache entry: ... SnapshotWriteConflict"), which is the desired outcome for a
+    // partition that is being given away anyway
+    assertEquals(clue(staleFlush), Right(()))
+    // the protection: the stale write did not land, the new owner's snapshot survived
+    assertEquals(clue(stored.map(_.value)), Some((1 to 10).map(i => s"e$i").mkString(",")))
+  }
+
+  /** The #732 scenario: the previous owner (flow A) folds events e1..e5 without flushing; the new owner (flow B)
+    * recovers (nothing was persisted or committed by A), folds events e1..e10, and flushes on release; then A - unaware
+    * of the handover - flushes its stale state on revoke.
+    *
+    * Returns (result of A's release, stored snapshot after A's release).
+    */
+  private def staleFlushScenario(
+    compareAndSet: Boolean
+  ): IO[(Either[Throwable, Unit], Option[KafkaSnapshot[String]])] = {
+    val appId   = if (compareAndSet) "FlowSpec-732-cas" else "FlowSpec-732-lww"
+    val groupId = "integration-tests-1"
+    val tp      = TopicPartition.empty
+    val key     = "key-732"
+
+    val eventsA = (1 to 5).toList.map(i => s"e$i")
+    val eventsB = (1 to 10).toList.map(i => s"e$i")
+
+    for {
+      storage <- CassandraPersistence.withSchema[IO, String](
+        cassandra().session,
+        cassandra().sync,
+        ConsistencyOverrides.none,
+        CassandraKeys.DefaultSegments,
+        snapshotCompareAndSet = compareAndSet,
+      )
+      // the previous owner: folds events, snapshots stay buffered in memory
+      flowA             <- allocateStaleFlow(storage, appId, groupId, tp)
+      (flowA_, releaseA) = flowA
+      _                 <- flowA_(staleFlowRecords(eventsA, key, tp))
+      // the new owner: eagerly recovers (finds nothing), folds all events, flushes on release
+      flowB             <- allocateStaleFlow(storage, appId, groupId, tp)
+      (flowB_, releaseB) = flowB
+      _                 <- flowB_(staleFlowRecords(eventsB, key, tp))
+      _                 <- releaseB
+      newOwnerWrote     <- storage.snapshots.get(KafkaKey(appId, groupId, tp, key))
+      _                  = assertEquals(clue(newOwnerWrote.map(_.value)), Some(eventsB.mkString(",")))
+      // the previous owner flushes its stale state on revoke
+      staleFlush <- releaseA.attempt
+      stored     <- storage.snapshots.get(KafkaKey(appId, groupId, tp, key))
+    } yield (staleFlush, stored)
+  }
+
+  // state is the comma-joined list of folded events; the snapshot offset is the offset of the folded record
+  private val staleFlowFold: FoldOption[IO, KafkaSnapshot[String], ConsumerRecord[String, ByteVector]] =
+    FoldOption.of { (state, record) =>
+      IO {
+        val event = record.value.flatMap(_.value.decodeUtf8.toOption).getOrElse(sys.error("event payload missing"))
+        val value = state.fold(event)(s => s"${s.value},$event")
+        KafkaSnapshot(offset = record.offset, value = value).some
+      }
+    }
+
+  private def staleFlowRecords(
+    events: List[String],
+    key: String,
+    tp: TopicPartition,
+  ): List[ConsumerRecord[String, ByteVector]] =
+    events.zipWithIndex.map {
+      case (event, offset) =>
+        ConsumerRecord[String, ByteVector](
+          topicPartition   = tp,
+          offset           = Offset.unsafe(offset.toLong),
+          timestampAndType = None,
+          key              = Some(WithSize(key)),
+          value            = Some(WithSize(ByteVector.encodeUtf8(event).toOption.get)),
+        )
+    }
+
+  private def allocateStaleFlow(
+    storage: PersistenceModule[IO, String],
+    appId: String,
+    groupId: String,
+    tp: TopicPartition,
+    fold: FoldOption[IO, KafkaSnapshot[String], ConsumerRecord[String, ByteVector]] = staleFlowFold,
+  ): IO[(PartitionFlow[IO], IO[Unit])] = {
+    val flow = for {
+      timersOf      <- Resource.eval(TimersOf.memory[IO, KafkaKey])
+      keysOf        <- Resource.eval(storage.keys.toKeysOf)
+      persistenceOf <- Resource.eval(storage.snapshotsOnly)
+      keyStateOf = KeyStateOf.eagerRecovery[IO, KafkaSnapshot[String]](
+        applicationId = appId,
+        groupId       = groupId,
+        keysOf        = keysOf,
+        timersOf      = timersOf,
+        persistenceOf = persistenceOf,
+        // snapshots are flushed only when the flow is released (flush-on-revoke), never periodically -
+        // so the moment of the stale write is controlled by the test
+        timerFlowOf = TimerFlowOf.persistPeriodically[IO](
+          fireEvery     = 1.hour,
+          persistEvery  = 1.hour,
+          flushOnRevoke = true,
+        ),
+        fold     = fold,
+        tick     = TickOption.id[IO, KafkaSnapshot[String]],
+        registry = EntityRegistry.empty[IO, KafkaKey, KafkaSnapshot[String]],
+      )
+      partitionFlowOf = PartitionFlowOf(keyStateOf, PartitionFlowConfig(commitOnRevoke = true))
+      // no consumer drives this flow: the group-metadata reader is None (the Cassandra fence does not use it)
+      flow <- partitionFlowOf(
+        PartitionAssignment(tp, Offset.min, IO.pure(none[ConsumerGroupMetadata])),
+        ScheduleCommit.empty[IO],
+      )
+    } yield flow
+    flow.allocated
   }
 
   implicit val log: LogOf[IO] = LogOf.slf4j[IO].unsafeRunSync()(IORuntime.global)

--- a/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/FlowSpec.scala
+++ b/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/FlowSpec.scala
@@ -10,7 +10,7 @@ import com.evolutiongaming.kafka.flow.kafka.{Consumer, ScheduleCommit}
 import com.evolutiongaming.kafka.flow.key.CassandraKeys
 import com.evolutiongaming.kafka.flow.persistence.PersistenceModule
 import com.evolutiongaming.kafka.flow.registry.EntityRegistry
-import com.evolutiongaming.kafka.flow.snapshot.KafkaSnapshot
+import com.evolutiongaming.kafka.flow.snapshot.{CassandraSnapshots, KafkaSnapshot}
 import com.evolutiongaming.kafka.flow.timer.{TimerFlowOf, TimersOf}
 import com.evolutiongaming.retry.Retry
 import com.evolutiongaming.skafka.consumer.{ConsumerRecord, ConsumerRecords, WithSize}
@@ -173,6 +173,66 @@ class FlowSpec extends CassandraSpec {
           value            = Some(WithSize(ByteVector.encodeUtf8(event).toOption.get)),
         )
     }
+
+  // a fold that deletes the key (returns None) on a "DELETE" event, otherwise behaves like staleFlowFold
+  private val deleteOnMarkerFold: FoldOption[IO, KafkaSnapshot[String], ConsumerRecord[String, ByteVector]] =
+    FoldOption.of { (state, record) =>
+      IO {
+        val event = record.value.flatMap(_.value.decodeUtf8.toOption).getOrElse(sys.error("event payload missing"))
+        if (event == "DELETE") none[KafkaSnapshot[String]]
+        else KafkaSnapshot(offset = record.offset, value = state.fold(event)(s => s"${s.value},$event")).some
+      }
+    }
+
+  // Real-Cassandra counterpart of the (timer-driven) core SnapshotReplayFencingSpec: it covers the flow -> real
+  // CassandraSnapshots delete seam for the replay-window fix. TestControl cannot drive the real driver's async I/O, so
+  // the delete is triggered deterministically (no sleep) by a fold returning None on a replayed-offset record - the
+  // same Snapshots.delete fence path the tick would hit. A delete whose processing offset (2) trails the key's
+  // recovered snapshot offset (5) must be fenced on the high-water (5) and apply against real Cassandra, not be
+  // rejected as stale.
+  test(
+    "compare-and-set: a delete during replay below the recovered snapshot offset applies (fenced on the high-water)"
+  ) {
+    val appId            = "FlowSpec-cas-replay-delete"
+    val groupId          = "integration-tests-1"
+    val tp               = TopicPartition.empty
+    val key              = "key-replay-delete"
+    val events           = (1 to 6).toList.map(i => s"e$i") // land at offsets 0..5
+    val recoveredAt      = Offset.unsafe(5) // the recovered snapshot's high-water offset (the last event)
+    val replayedDeleteAt = Offset.unsafe(2) // a replayed DELETE that trails the recovered offset (2 < 5)
+
+    val test: IO[(Either[Throwable, Unit], Option[KafkaSnapshot[String]])] = for {
+      storage <- CassandraPersistence.withSchema[IO, String](
+        cassandra().session,
+        cassandra().sync,
+        ConsistencyOverrides.none,
+        CassandraKeys.DefaultSegments,
+        snapshotCompareAndSet = true,
+      )
+      // an owner persists the key's snapshot at offset 5 and registers the key
+      flowA             <- allocateStaleFlow(storage, appId, groupId, tp)
+      (flowA_, releaseA) = flowA
+      _                 <- flowA_(staleFlowRecords(events, key, tp))
+      _                 <- releaseA
+      stored            <- storage.snapshots.get(KafkaKey(appId, groupId, tp, key))
+      _                  = assertEquals(clue(stored.map(_.offset)), Some(recoveredAt))
+      // a new flow recovers the key (snapshot offset 5) at assignedAt = 0; the replayed "DELETE" makes the fold
+      // return None -> delete at the replayed offset, which must be fenced on the high-water (recoveredAt)
+      flowB             <- allocateStaleFlow(storage, appId, groupId, tp, deleteOnMarkerFold)
+      (flowB_, releaseB) = flowB
+      deleteResult <- flowB_(staleFlowRecords(List("DELETE"), key, tp).map(_.copy(offset = replayedDeleteAt))).attempt
+      _            <- releaseB.attempt
+      afterDelete  <- storage.snapshots.get(KafkaKey(appId, groupId, tp, key))
+    } yield (deleteResult, afterDelete)
+
+    val (deleteResult, afterDelete) = test.unsafeRunSync()
+    deleteResult match {
+      case Left(conflict: CassandraSnapshots.SnapshotWriteConflict) =>
+        fail(s"the replay-window delete was rejected by CAS instead of being fenced on the high-water: $conflict")
+      case Left(e)  => fail(s"unexpected error: $e")
+      case Right(_) => assert(clue(afterDelete.isEmpty)) // deleted; the tombstone reads back as None
+    }
+  }
 
   private def allocateStaleFlow(
     storage: PersistenceModule[IO, String],

--- a/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/FlowSpec.scala
+++ b/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/FlowSpec.scala
@@ -140,11 +140,11 @@ class FlowSpec extends CassandraSpec {
       (flowB_, releaseB) = flowB
       _                 <- flowB_(staleFlowRecords(eventsB, key, tp))
       _                 <- releaseB
-      newOwnerWrote     <- storage.snapshots.get(KafkaKey(appId, groupId, tp, key))
+      newOwnerWrote     <- storage.snapshots.read(KafkaKey(appId, groupId, tp, key)).map(_.flatMap(_.value))
       _                  = assertEquals(clue(newOwnerWrote.map(_.value)), Some(eventsB.mkString(",")))
       // the previous owner flushes its stale state on revoke
       staleFlush <- releaseA.attempt
-      stored     <- storage.snapshots.get(KafkaKey(appId, groupId, tp, key))
+      stored     <- storage.snapshots.read(KafkaKey(appId, groupId, tp, key)).map(_.flatMap(_.value))
     } yield (staleFlush, stored)
   }
 
@@ -214,7 +214,7 @@ class FlowSpec extends CassandraSpec {
       (flowA_, releaseA) = flowA
       _                 <- flowA_(staleFlowRecords(events, key, tp))
       _                 <- releaseA
-      stored            <- storage.snapshots.get(KafkaKey(appId, groupId, tp, key))
+      stored            <- storage.snapshots.read(KafkaKey(appId, groupId, tp, key)).map(_.flatMap(_.value))
       _                  = assertEquals(clue(stored.map(_.offset)), Some(recoveredAt))
       // a new flow recovers the key (snapshot offset 5) at assignedAt = 0; the replayed "DELETE" makes the fold
       // return None -> delete at the replayed offset, which must be fenced on the high-water (recoveredAt)
@@ -222,7 +222,7 @@ class FlowSpec extends CassandraSpec {
       (flowB_, releaseB) = flowB
       deleteResult <- flowB_(staleFlowRecords(List("DELETE"), key, tp).map(_.copy(offset = replayedDeleteAt))).attempt
       _            <- releaseB.attempt
-      afterDelete  <- storage.snapshots.get(KafkaKey(appId, groupId, tp, key))
+      afterDelete  <- storage.snapshots.read(KafkaKey(appId, groupId, tp, key)).map(_.flatMap(_.value))
     } yield (deleteResult, afterDelete)
 
     val (deleteResult, afterDelete) = test.unsafeRunSync()

--- a/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/FlowSpec.scala
+++ b/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/FlowSpec.scala
@@ -3,10 +3,12 @@ package com.evolutiongaming.kafka.flow
 import cats.data.NonEmptyList
 import cats.effect.unsafe.IORuntime
 import cats.effect.{IO, Ref, Resource}
+import cats.syntax.all.*
 import com.evolutiongaming.catshelper.LogOf
 import com.evolutiongaming.kafka.flow.cassandra.{CassandraPersistence, ConsistencyOverrides}
-import com.evolutiongaming.kafka.flow.kafka.Consumer
+import com.evolutiongaming.kafka.flow.kafka.{Consumer, ScheduleCommit}
 import com.evolutiongaming.kafka.flow.key.CassandraKeys
+import com.evolutiongaming.kafka.flow.persistence.PersistenceModule
 import com.evolutiongaming.kafka.flow.registry.EntityRegistry
 import com.evolutiongaming.kafka.flow.snapshot.KafkaSnapshot
 import com.evolutiongaming.kafka.flow.timer.{TimerFlowOf, TimersOf}
@@ -81,6 +83,129 @@ class FlowSpec extends CassandraSpec {
     val test: IO[Unit] = flow.use(join => join.attempt.map(result => assert(clue(result.isLeft))))
 
     test.unsafeRunSync()
+  }
+
+  // Reproduces the #732 stale-writer corruption through the real kafka-flow machinery (PartitionFlow, eager recovery,
+  // fold, buffered snapshots, flush-on-revoke). The ownership overlap is simulated by two PartitionFlows over one
+  // partition: a real overlap is indistinguishable from the second flow being created while the first is still alive.
+  test("issue #732 reproduction: stale flush-on-revoke overwrites the newer snapshot (last-write-wins)") {
+    val (staleFlush, stored) = staleFlushScenario(compareAndSet = false).unsafeRunSync()
+    assertEquals(clue(staleFlush), Right(()))
+    // recovery now returns the STALE snapshot (events e6..e10 are lost although the new owner persisted them):
+    // this assertion documents the corruption of issue #732, prevented in the paired test below
+    assertEquals(clue(stored.map(_.value)), Some("e1,e2,e3,e4,e5"))
+  }
+
+  test("issue #732 prevention: stale flush-on-revoke is rejected (compareAndSet)") {
+    val (staleFlush, stored) = staleFlushScenario(compareAndSet = true).unsafeRunSync()
+    // the release itself succeeds: the rejected write surfaces as a logged-and-swallowed cache entry release error
+    // ("scache: failed to release cache entry: ... SnapshotWriteConflict"), which is the desired outcome for a
+    // partition that is being given away anyway
+    assertEquals(clue(staleFlush), Right(()))
+    // the protection: the stale write did not land, the new owner's snapshot survived
+    assertEquals(clue(stored.map(_.value)), Some((1 to 10).map(i => s"e$i").mkString(",")))
+  }
+
+  /** The #732 scenario: the previous owner (flow A) folds events e1..e5 without flushing; the new owner (flow B)
+    * recovers (nothing was persisted or committed by A), folds events e1..e10, and flushes on release; then A - unaware
+    * of the handover - flushes its stale state on revoke.
+    *
+    * Returns (result of A's release, stored snapshot after A's release).
+    */
+  private def staleFlushScenario(
+    compareAndSet: Boolean
+  ): IO[(Either[Throwable, Unit], Option[KafkaSnapshot[String]])] = {
+    val appId   = if (compareAndSet) "FlowSpec-732-cas" else "FlowSpec-732-lww"
+    val groupId = "integration-tests-1"
+    val tp      = TopicPartition.empty
+    val key     = "key-732"
+
+    val eventsA = (1 to 5).toList.map(i => s"e$i")
+    val eventsB = (1 to 10).toList.map(i => s"e$i")
+
+    for {
+      storage <- CassandraPersistence.withSchema[IO, String](
+        cassandra().session,
+        cassandra().sync,
+        ConsistencyOverrides.none,
+        CassandraKeys.DefaultSegments,
+        snapshotCompareAndSet = compareAndSet,
+      )
+      // the previous owner: folds events, snapshots stay buffered in memory
+      flowA             <- allocateStaleFlow(storage, appId, groupId, tp)
+      (flowA_, releaseA) = flowA
+      _                 <- flowA_(staleFlowRecords(eventsA, key, tp))
+      // the new owner: eagerly recovers (finds nothing), folds all events, flushes on release
+      flowB             <- allocateStaleFlow(storage, appId, groupId, tp)
+      (flowB_, releaseB) = flowB
+      _                 <- flowB_(staleFlowRecords(eventsB, key, tp))
+      _                 <- releaseB
+      newOwnerWrote     <- storage.snapshots.get(KafkaKey(appId, groupId, tp, key))
+      _                  = assertEquals(clue(newOwnerWrote.map(_.value)), Some(eventsB.mkString(",")))
+      // the previous owner flushes its stale state on revoke
+      staleFlush <- releaseA.attempt
+      stored     <- storage.snapshots.get(KafkaKey(appId, groupId, tp, key))
+    } yield (staleFlush, stored)
+  }
+
+  // state is the comma-joined list of folded events; the snapshot offset is the offset of the folded record
+  private val staleFlowFold: FoldOption[IO, KafkaSnapshot[String], ConsumerRecord[String, ByteVector]] =
+    FoldOption.of { (state, record) =>
+      IO {
+        val event = record.value.flatMap(_.value.decodeUtf8.toOption).getOrElse(sys.error("event payload missing"))
+        val value = state.fold(event)(s => s"${s.value},$event")
+        KafkaSnapshot(offset = record.offset, value = value).some
+      }
+    }
+
+  private def staleFlowRecords(
+    events: List[String],
+    key: String,
+    tp: TopicPartition,
+  ): List[ConsumerRecord[String, ByteVector]] =
+    events.zipWithIndex.map {
+      case (event, offset) =>
+        ConsumerRecord[String, ByteVector](
+          topicPartition   = tp,
+          offset           = Offset.unsafe(offset.toLong),
+          timestampAndType = None,
+          key              = Some(WithSize(key)),
+          value            = Some(WithSize(ByteVector.encodeUtf8(event).toOption.get)),
+        )
+    }
+
+  private def allocateStaleFlow(
+    storage: PersistenceModule[IO, String],
+    appId: String,
+    groupId: String,
+    tp: TopicPartition,
+    fold: FoldOption[IO, KafkaSnapshot[String], ConsumerRecord[String, ByteVector]] = staleFlowFold,
+  ): IO[(PartitionFlow[IO], IO[Unit])] = {
+    val flow = for {
+      timersOf      <- Resource.eval(TimersOf.memory[IO, KafkaKey])
+      keysOf        <- Resource.eval(storage.keys.toKeysOf)
+      persistenceOf <- Resource.eval(storage.snapshotsOnly)
+      keyStateOf = KeyStateOf.eagerRecovery[IO, KafkaSnapshot[String]](
+        applicationId = appId,
+        groupId       = groupId,
+        keysOf        = keysOf,
+        timersOf      = timersOf,
+        persistenceOf = persistenceOf,
+        // snapshots are flushed only when the flow is released (flush-on-revoke), never periodically -
+        // so the moment of the stale write is controlled by the test
+        timerFlowOf = TimerFlowOf.persistPeriodically[IO](
+          fireEvery     = 1.hour,
+          persistEvery  = 1.hour,
+          flushOnRevoke = true,
+        ),
+        fold     = fold,
+        tick     = TickOption.id[IO, KafkaSnapshot[String]],
+        registry = EntityRegistry.empty[IO, KafkaKey, KafkaSnapshot[String]],
+      )
+      partitionFlowOf = PartitionFlowOf(keyStateOf, PartitionFlowConfig(commitOnRevoke = true))
+      flow           <- partitionFlowOf(tp, Offset.min, ScheduleCommit.empty[IO])
+    } yield flow
+    flow.allocated
   }
 
   implicit val log: LogOf[IO] = LogOf.slf4j[IO].unsafeRunSync()(IORuntime.global)

--- a/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/cassandra/CassandraPersistenceWiringSpec.scala
+++ b/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/cassandra/CassandraPersistenceWiringSpec.scala
@@ -1,0 +1,44 @@
+package com.evolutiongaming.kafka.flow.cassandra
+
+import cats.effect.IO
+import com.evolutiongaming.catshelper.LogOf
+import com.evolutiongaming.kafka.flow.key.KeySegments
+import com.evolutiongaming.kafka.flow.{CassandraSpec, KafkaKey}
+import com.evolutiongaming.skafka.TopicPartition
+
+/** The offset fence must follow the write mode, not the snapshot type: a last-write-wins store never gates a write on
+  * the offset and never returns a tombstone floor, so its module must keep the unfenced buffer - otherwise
+  * `compareAndSet = false` users would inherit the fenced buffering semantics and, in events-recovery, a per-key floor
+  * read that can never find anything (a cost regression against the pre-compare-and-set behaviour). See
+  * `PersistenceModule.snapshotsOf`.
+  */
+class CassandraPersistenceWiringSpec extends CassandraSpec {
+
+  test("compare-and-set module wires a fenced buffer; last-write-wins module stays unfenced") {
+    implicit val logOf: LogOf[IO] = LogOf.empty[IO]
+    val key = KafkaKey("CassandraPersistenceWiringSpec", "integration-tests-1", TopicPartition.empty, "wiring")
+    val test: IO[Unit] = for {
+      lww <- CassandraPersistence.withSchemaF[IO, String](
+        cassandra().session,
+        cassandra().sync,
+        ConsistencyOverrides.none,
+        KeySegments.default,
+        snapshotCompareAndSet = false,
+      )
+      cas <- CassandraPersistence.withSchemaF[IO, String](
+        cassandra().session,
+        cassandra().sync,
+        ConsistencyOverrides.none,
+        KeySegments.default,
+        snapshotCompareAndSet = true,
+      )
+      lwwSnapshots <- lww.snapshotsOf.flatMap(_.apply(key))
+      casSnapshots <- cas.snapshotsOf.flatMap(_.apply(key))
+    } yield {
+      assert(!lwwSnapshots.fenced, "last-write-wins must keep the unfenced buffer")
+      assert(casSnapshots.fenced, "compare-and-set must fence the buffer on KafkaSnapshot.offset")
+    }
+
+    test.unsafeRunSync()
+  }
+}

--- a/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotSpec.scala
+++ b/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotSpec.scala
@@ -20,7 +20,7 @@ class SnapshotSpec extends CassandraSpec {
       _                    <- snapshots.persist(key, snapshot)
       snapshotAfterPersist <- snapshots.get(key)
       ttls                 <- getTtls(key)
-      _                    <- snapshots.delete(key)
+      _                    <- snapshots.delete(key, snapshot.offset)
       snapshotAfterDelete  <- snapshots.get(key)
     } yield {
       assert(clue(snapshotBeforeTest.isEmpty))
@@ -82,40 +82,13 @@ class SnapshotSpec extends CassandraSpec {
     test.unsafeRunSync()
   }
 
-  test("compare-and-set: a delete is unguarded, so a lower-offset write resurrects a deleted key (persist-only gap)") {
-    // Pins the accepted persist-only residual gap (see docs/cassandra-single-writer-design.md, "Scope:
-    // persist-only"): a delete is a plain last-write-wins DELETE, so it removes the row and its offset
-    // guard. A lagging zombie's lower-offset write then finds an absent row, takes the
-    // `INSERT ... IF NOT EXISTS` first-write path, and resurrects the key below the deleted offset. This
-    // is the one residual #732 case the persist fence does not cover; if a future mode offset-gates
-    // deletes, this assertion should flip (the resurrection becomes a SnapshotWriteConflict).
-    val key = KafkaKey("SnapshotSpec", "integration-tests-1", TopicPartition.empty, "cas-delete-resurrect")
-    val test: IO[Unit] = for {
-      snapshots <- CassandraSnapshots.withSchema[IO, String](
-        cassandra().session,
-        cassandra().sync,
-        compareAndSet = true
-      )
-      _           <- snapshots.persist(key, KafkaSnapshot(offset = Offset.unsafe(10), value = "state-10"))
-      _           <- snapshots.delete(key)
-      deleted     <- snapshots.get(key)
-      _           <- snapshots.persist(key, KafkaSnapshot(offset = Offset.unsafe(7), value = "state-7-stale"))
-      resurrected <- snapshots.get(key)
-    } yield {
-      assert(clue(deleted.isEmpty))
-      // the unguarded delete let the lower offset (7) win, resurrecting the key below the delete
-      assertEquals(clue(resurrected), Some(KafkaSnapshot(offset = Offset.unsafe(7), value = "state-7-stale")))
-    }
-
-    test.unsafeRunSync()
-  }
-
   test("compare-and-set: concurrent first-writers race on a fresh key; the highest offset wins, no corruption") {
     // Exercises persistCompareAndSet's first-write compound under real contention: every writer hits
     // UPDATE-absent then `INSERT ... IF NOT EXISTS` for the same new key; one INSERT wins and the losers
-    // take the retry-`UPDATE` path (the single-threaded tests never reach it). The offset guard keeps it
-    // safe -- the durable snapshot ends at the highest offset, never clobbered by a lower one, and any
-    // rejected writer fails cleanly with SnapshotWriteConflict.
+    // take the retry-`UPDATE` path (the branch single-threaded tests never reach). The offset guard keeps
+    // it safe -- the durable snapshot ends at the highest offset, never clobbered by a lower one, and any
+    // rejected writer fails cleanly with SnapshotWriteConflict. (Exhaustive interleaving coverage, plus
+    // the TTL-reap spurious-conflict edge this test can't force, is the CasFirstWrite model.)
     val key     = KafkaKey("SnapshotSpec", "integration-tests-1", TopicPartition.empty, "cas-first-write-race")
     val offsets = (1 to 8).toList
     val test: IO[Unit] = for {
@@ -134,6 +107,146 @@ class SnapshotSpec extends CassandraSpec {
         case _: CassandraSnapshots.SnapshotWriteConflict => ()
         case other                                       => fail(s"unexpected failure (not a conflict): $other")
       }
+    }
+
+    test.unsafeRunSync()
+  }
+
+  test("compare-and-set: a legitimate re-creation after a delete uses a higher offset") {
+    val key = KafkaKey("SnapshotSpec", "integration-tests-1", TopicPartition.empty, "cas-delete")
+    val test: IO[Unit] = for {
+      snapshots <- CassandraSnapshots.withSchema[IO, String](
+        cassandra().session,
+        cassandra().sync,
+        compareAndSet = true
+      )
+      _           <- snapshots.persist(key, KafkaSnapshot(offset = Offset.unsafe(10), value = "state-10"))
+      _           <- snapshots.delete(key, Offset.unsafe(10))
+      afterDelete <- snapshots.get(key)
+      // the key was deleted at offset 10; a legitimate re-creation arrives at a higher offset and applies
+      _         <- snapshots.persist(key, KafkaSnapshot(offset = Offset.unsafe(20), value = "state-20"))
+      recreated <- snapshots.get(key)
+    } yield {
+      assert(clue(afterDelete.isEmpty)) // tombstone reads back as absent
+      assertEquals(clue(recreated.map(_.value)), Some("state-20"))
+    }
+
+    test.unsafeRunSync()
+  }
+
+  test("compare-and-set: stale delete is rejected and leaves the newer snapshot") {
+    val key = KafkaKey("SnapshotSpec", "integration-tests-1", TopicPartition.empty, "cas-stale-delete")
+    val test: IO[Unit] = for {
+      snapshots <- CassandraSnapshots.withSchema[IO, String](
+        cassandra().session,
+        cassandra().sync,
+        compareAndSet = true
+      )
+      _ <- snapshots.persist(key, KafkaSnapshot(offset = Offset.unsafe(10), value = "state-10"))
+      // a stale writer (lower offset) tries to delete: it must not erase the newer owner's snapshot
+      result <- snapshots.delete(key, Offset.unsafe(7)).attempt
+      stored <- snapshots.get(key)
+    } yield {
+      result match {
+        case Left(conflict: CassandraSnapshots.SnapshotWriteConflict) =>
+          assertEquals(clue(conflict.key), key)
+          assertEquals(clue(conflict.attemptedOffset), Offset.unsafe(7))
+          assertEquals(clue(conflict.persistedOffset), Some(Offset.unsafe(10)))
+        case other => fail(s"expected SnapshotWriteConflict, got $other")
+      }
+      assertEquals(clue(stored.map(_.value)), Some("state-10"))
+    }
+
+    test.unsafeRunSync()
+  }
+
+  test("compare-and-set: deleting an absent key is an idempotent no-op") {
+    val key = KafkaKey("SnapshotSpec", "integration-tests-1", TopicPartition.empty, "cas-idempotent-delete")
+    val test: IO[Unit] = for {
+      snapshots <- CassandraSnapshots.withSchema[IO, String](
+        cassandra().session,
+        cassandra().sync,
+        compareAndSet = true
+      )
+      _ <- snapshots.persist(key, KafkaSnapshot(offset = Offset.unsafe(10), value = "state-10"))
+      _ <- snapshots.delete(key, Offset.unsafe(10))
+      // re-issuing the delete (e.g. an at-least-once replay after a crash before the offset commit) must not fail
+      result <- snapshots.delete(key, Offset.unsafe(10)).attempt
+      stored <- snapshots.get(key)
+    } yield {
+      assert(clue(result.isRight))
+      assert(clue(stored.isEmpty))
+    }
+
+    test.unsafeRunSync()
+  }
+
+  test("compare-and-set: a stale lower-offset write after a delete is rejected (no resurrection)") {
+    val key = KafkaKey("SnapshotSpec", "integration-tests-1", TopicPartition.empty, "cas-no-resurrection")
+    val test: IO[Unit] = for {
+      snapshots <- CassandraSnapshots.withSchema[IO, String](
+        cassandra().session,
+        cassandra().sync,
+        compareAndSet = true
+      )
+      _ <- snapshots.persist(key, KafkaSnapshot(offset = Offset.unsafe(10), value = "state-10"))
+      _ <- snapshots.delete(key, Offset.unsafe(10))
+      // the delete leaves an offset-carrying tombstone (offset 10); a stale lower-offset write must NOT resurrect the
+      // key, otherwise a later recovery would fold new events onto the stale state
+      result <- snapshots.persist(key, KafkaSnapshot(offset = Offset.unsafe(3), value = "state-3")).attempt
+      stored <- snapshots.get(key)
+    } yield {
+      result match {
+        case Left(conflict: CassandraSnapshots.SnapshotWriteConflict) =>
+          assertEquals(clue(conflict.attemptedOffset), Offset.unsafe(3))
+          assertEquals(clue(conflict.persistedOffset), Some(Offset.unsafe(10)))
+        case other => fail(s"expected SnapshotWriteConflict, got $other")
+      }
+      assert(clue(stored.isEmpty)) // still deleted, not resurrected
+    }
+
+    test.unsafeRunSync()
+  }
+
+  test("compare-and-set: an equal-offset delete applies") {
+    val key = KafkaKey("SnapshotSpec", "integration-tests-1", TopicPartition.empty, "cas-equal-offset-delete")
+    val test: IO[Unit] = for {
+      snapshots <- CassandraSnapshots.withSchema[IO, String](
+        cassandra().session,
+        cassandra().sync,
+        compareAndSet = true
+      )
+      _      <- snapshots.persist(key, KafkaSnapshot(offset = Offset.unsafe(10), value = "state-10"))
+      _      <- snapshots.delete(key, Offset.unsafe(10))
+      stored <- snapshots.get(key)
+    } yield assert(clue(stored.isEmpty))
+
+    test.unsafeRunSync()
+  }
+
+  test("compare-and-set: a replayed stale delete cannot remove a newer snapshot") {
+    val key = KafkaKey("SnapshotSpec", "integration-tests-1", TopicPartition.empty, "cas-replayed-stale-delete")
+    val test: IO[Unit] = for {
+      snapshots <- CassandraSnapshots.withSchema[IO, String](
+        cassandra().session,
+        cassandra().sync,
+        compareAndSet = true
+      )
+      _ <- snapshots.persist(key, KafkaSnapshot(offset = Offset.unsafe(10), value = "state-10"))
+      _ <- snapshots.delete(key, Offset.unsafe(10))
+      _ <- snapshots.persist(key, KafkaSnapshot(offset = Offset.unsafe(20), value = "state-20"))
+      // an at-least-once replay of the OLD delete (offset 10) must not erase the newer snapshot (offset 20)
+      result <- snapshots.delete(key, Offset.unsafe(10)).attempt
+      stored <- snapshots.get(key)
+    } yield {
+      result match {
+        case Left(conflict: CassandraSnapshots.SnapshotWriteConflict) =>
+          assertEquals(clue(conflict.key), key)
+          assertEquals(clue(conflict.attemptedOffset), Offset.unsafe(10))
+          assertEquals(clue(conflict.persistedOffset), Some(Offset.unsafe(20)))
+        case other => fail(s"expected SnapshotWriteConflict, got $other")
+      }
+      assertEquals(clue(stored.map(_.value)), Some("state-20"))
     }
 
     test.unsafeRunSync()

--- a/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotSpec.scala
+++ b/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotSpec.scala
@@ -11,6 +11,17 @@ import scala.jdk.CollectionConverters.*
 
 class SnapshotSpec extends CassandraSpec {
 
+  // The store now exposes the unified read/write over Stored; these adapters keep the store-level cases speaking the
+  // persist/delete/get vocabulary, so they still pin the exact compare-and-set / tombstone semantics unchanged.
+  private implicit class SnapshotStoreOps(val db: SnapshotDatabase[IO, KafkaKey, KafkaSnapshot[String]]) {
+    def persist(key: KafkaKey, snapshot: KafkaSnapshot[String]): IO[Unit] =
+      db.write(key, Stored.Live(snapshot, snapshot.offset.some))
+    def delete(key: KafkaKey, offset: Offset): IO[Unit] =
+      db.write(key, Stored.Tombstone(offset))
+    def get(key: KafkaKey): IO[Option[KafkaSnapshot[String]]] =
+      db.read(key).map(_.flatMap(_.value))
+  }
+
   test("queries") {
     val key      = KafkaKey("SnapshotSpec", "integration-tests-1", TopicPartition.empty, "queries")
     val snapshot = KafkaSnapshot(offset = Offset.min, value = "snapshot-contents")

--- a/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotSpec.scala
+++ b/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotSpec.scala
@@ -32,6 +32,136 @@ class SnapshotSpec extends CassandraSpec {
     test.unsafeRunSync()
   }
 
+  test("compare-and-set: writes with monotonically increasing offsets are applied") {
+    val key = KafkaKey("SnapshotSpec", "integration-tests-1", TopicPartition.empty, "cas-monotonic")
+    val test: IO[Unit] = for {
+      snapshots <- CassandraSnapshots.withSchema[IO, String](
+        cassandra().session,
+        cassandra().sync,
+        compareAndSet = true
+      )
+      // first write of a key goes through the `INSERT ... IF NOT EXISTS` path
+      _    <- snapshots.persist(key, KafkaSnapshot(offset = Offset.unsafe(5), value = "state-5"))
+      five <- snapshots.get(key)
+      _    <- snapshots.persist(key, KafkaSnapshot(offset = Offset.unsafe(10), value = "state-10"))
+      ten  <- snapshots.get(key)
+      // a snapshot can be replaced at the same offset, e.g. when state was changed by a timer
+      _     <- snapshots.persist(key, KafkaSnapshot(offset = Offset.unsafe(10), value = "state-10-updated"))
+      tenUp <- snapshots.get(key)
+    } yield {
+      assertEquals(clue(five.map(_.value)), Some("state-5"))
+      assertEquals(clue(ten.map(_.value)), Some("state-10"))
+      assertEquals(clue(tenUp.map(_.value)), Some("state-10-updated"))
+    }
+
+    test.unsafeRunSync()
+  }
+
+  test("compare-and-set: stale write is rejected") {
+    val key = KafkaKey("SnapshotSpec", "integration-tests-1", TopicPartition.empty, "cas-stale")
+    val test: IO[Unit] = for {
+      snapshots <- CassandraSnapshots.withSchema[IO, String](
+        cassandra().session,
+        cassandra().sync,
+        compareAndSet = true
+      )
+      _      <- snapshots.persist(key, KafkaSnapshot(offset = Offset.unsafe(10), value = "state-10"))
+      result <- snapshots.persist(key, KafkaSnapshot(offset = Offset.unsafe(7), value = "state-7-stale")).attempt
+      stored <- snapshots.get(key)
+    } yield {
+      result match {
+        case Left(conflict: CassandraSnapshots.SnapshotWriteConflict) =>
+          assertEquals(clue(conflict.key), key)
+          assertEquals(clue(conflict.attemptedOffset), Offset.unsafe(7))
+          assertEquals(clue(conflict.persistedOffset), Some(Offset.unsafe(10)))
+        case other => fail(s"expected SnapshotWriteConflict, got $other")
+      }
+      assertEquals(clue(stored.map(_.value)), Some("state-10"))
+    }
+
+    test.unsafeRunSync()
+  }
+
+  test("compare-and-set: a delete is unguarded, so a lower-offset write resurrects a deleted key (persist-only gap)") {
+    // Pins the accepted persist-only residual gap (see docs/cassandra-single-writer-design.md, "Scope:
+    // deletes are not fenced"): a delete is a plain last-write-wins DELETE, so it removes the row and its offset
+    // guard. A lagging zombie's lower-offset write then finds an absent row, takes the
+    // `INSERT ... IF NOT EXISTS` first-write path, and resurrects the key below the deleted offset. This
+    // is the one residual #732 case the persist fence does not cover; if a future mode offset-gates
+    // deletes, this assertion should flip (the resurrection becomes a SnapshotWriteConflict).
+    val key = KafkaKey("SnapshotSpec", "integration-tests-1", TopicPartition.empty, "cas-delete-resurrect")
+    val test: IO[Unit] = for {
+      snapshots <- CassandraSnapshots.withSchema[IO, String](
+        cassandra().session,
+        cassandra().sync,
+        compareAndSet = true
+      )
+      _           <- snapshots.persist(key, KafkaSnapshot(offset = Offset.unsafe(10), value = "state-10"))
+      _           <- snapshots.delete(key)
+      deleted     <- snapshots.get(key)
+      _           <- snapshots.persist(key, KafkaSnapshot(offset = Offset.unsafe(7), value = "state-7-stale"))
+      resurrected <- snapshots.get(key)
+    } yield {
+      assert(clue(deleted.isEmpty))
+      // the unguarded delete let the lower offset (7) win, resurrecting the key below the delete
+      assertEquals(clue(resurrected), Some(KafkaSnapshot(offset = Offset.unsafe(7), value = "state-7-stale")))
+    }
+
+    test.unsafeRunSync()
+  }
+
+  test("compare-and-set: concurrent first-writers race on a fresh key; the highest offset wins, no corruption") {
+    // Exercises persistCompareAndSet's first-write compound under real contention: every writer hits
+    // UPDATE-absent then `INSERT ... IF NOT EXISTS` for the same new key; one INSERT wins and the losers
+    // take the retry-`UPDATE` path (the single-threaded tests never reach it). The offset guard keeps it
+    // safe -- the durable snapshot ends at the highest offset, never clobbered by a lower one, and any
+    // rejected writer fails cleanly with SnapshotWriteConflict.
+    val key     = KafkaKey("SnapshotSpec", "integration-tests-1", TopicPartition.empty, "cas-first-write-race")
+    val offsets = (1 to 8).toList
+    val test: IO[Unit] = for {
+      snapshots <- CassandraSnapshots.withSchema[IO, String](
+        cassandra().session,
+        cassandra().sync,
+        compareAndSet = true
+      )
+      results <- offsets.parTraverse(o =>
+        snapshots.persist(key, KafkaSnapshot(offset = Offset.unsafe(o.toLong), value = s"state-$o")).attempt
+      )
+      stored <- snapshots.get(key)
+    } yield {
+      assertEquals(clue(stored.map(_.value)), Some(s"state-${offsets.max}")) // highest wins, no stale overwrite
+      results.collect { case Left(e) => e }.foreach {
+        case _: CassandraSnapshots.SnapshotWriteConflict => ()
+        case other                                       => fail(s"unexpected failure (not a conflict): $other")
+      }
+    }
+
+    test.unsafeRunSync()
+  }
+
+  test("compare-and-set: ttl is set on both insert and update paths") {
+    val key = KafkaKey("SnapshotSpec", "integration-tests-1", TopicPartition.empty, "cas-ttl")
+    val test: IO[Unit] = for {
+      snapshots <- CassandraSnapshots.withSchema[IO, String](
+        cassandra().session,
+        cassandra().sync,
+        ttl           = 1.hour.some,
+        compareAndSet = true,
+      )
+      _          <- snapshots.persist(key, KafkaSnapshot(offset = Offset.unsafe(5), value = "state-5"))
+      insertTtls <- getTtls(key)
+      _          <- snapshots.persist(key, KafkaSnapshot(offset = Offset.unsafe(10), value = "state-10"))
+      updateTtls <- getTtls(key)
+    } yield {
+      assertEquals(clue(insertTtls.size), 1)
+      assert(clue(insertTtls.head.isDefined))
+      assertEquals(clue(updateTtls.size), 1)
+      assert(clue(updateTtls.head.isDefined))
+    }
+
+    test.unsafeRunSync()
+  }
+
   test("failures") {
     val key = KafkaKey("SnapshotSpec", "integration-tests-1", TopicPartition.empty, "queries")
     val test: IO[Unit] = for {

--- a/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotSpec.scala
+++ b/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotSpec.scala
@@ -32,6 +32,136 @@ class SnapshotSpec extends CassandraSpec {
     test.unsafeRunSync()
   }
 
+  test("compare-and-set: writes with monotonically increasing offsets are applied") {
+    val key = KafkaKey("SnapshotSpec", "integration-tests-1", TopicPartition.empty, "cas-monotonic")
+    val test: IO[Unit] = for {
+      snapshots <- CassandraSnapshots.withSchema[IO, String](
+        cassandra().session,
+        cassandra().sync,
+        compareAndSet = true
+      )
+      // first write of a key goes through the `INSERT ... IF NOT EXISTS` path
+      _    <- snapshots.persist(key, KafkaSnapshot(offset = Offset.unsafe(5), value = "state-5"))
+      five <- snapshots.get(key)
+      _    <- snapshots.persist(key, KafkaSnapshot(offset = Offset.unsafe(10), value = "state-10"))
+      ten  <- snapshots.get(key)
+      // a snapshot can be replaced at the same offset, e.g. when state was changed by a timer
+      _     <- snapshots.persist(key, KafkaSnapshot(offset = Offset.unsafe(10), value = "state-10-updated"))
+      tenUp <- snapshots.get(key)
+    } yield {
+      assertEquals(clue(five.map(_.value)), Some("state-5"))
+      assertEquals(clue(ten.map(_.value)), Some("state-10"))
+      assertEquals(clue(tenUp.map(_.value)), Some("state-10-updated"))
+    }
+
+    test.unsafeRunSync()
+  }
+
+  test("compare-and-set: stale write is rejected") {
+    val key = KafkaKey("SnapshotSpec", "integration-tests-1", TopicPartition.empty, "cas-stale")
+    val test: IO[Unit] = for {
+      snapshots <- CassandraSnapshots.withSchema[IO, String](
+        cassandra().session,
+        cassandra().sync,
+        compareAndSet = true
+      )
+      _      <- snapshots.persist(key, KafkaSnapshot(offset = Offset.unsafe(10), value = "state-10"))
+      result <- snapshots.persist(key, KafkaSnapshot(offset = Offset.unsafe(7), value = "state-7-stale")).attempt
+      stored <- snapshots.get(key)
+    } yield {
+      result match {
+        case Left(conflict: CassandraSnapshots.SnapshotWriteConflict) =>
+          assertEquals(clue(conflict.key), key)
+          assertEquals(clue(conflict.attemptedOffset), Offset.unsafe(7))
+          assertEquals(clue(conflict.persistedOffset), Some(Offset.unsafe(10)))
+        case other => fail(s"expected SnapshotWriteConflict, got $other")
+      }
+      assertEquals(clue(stored.map(_.value)), Some("state-10"))
+    }
+
+    test.unsafeRunSync()
+  }
+
+  test("compare-and-set: a delete is unguarded, so a lower-offset write resurrects a deleted key (persist-only gap)") {
+    // Pins the accepted persist-only residual gap (see docs/cassandra-single-writer-design.md, "Scope:
+    // persist-only"): a delete is a plain last-write-wins DELETE, so it removes the row and its offset
+    // guard. A lagging zombie's lower-offset write then finds an absent row, takes the
+    // `INSERT ... IF NOT EXISTS` first-write path, and resurrects the key below the deleted offset. This
+    // is the one residual #732 case the persist fence does not cover; if a future mode offset-gates
+    // deletes, this assertion should flip (the resurrection becomes a SnapshotWriteConflict).
+    val key = KafkaKey("SnapshotSpec", "integration-tests-1", TopicPartition.empty, "cas-delete-resurrect")
+    val test: IO[Unit] = for {
+      snapshots <- CassandraSnapshots.withSchema[IO, String](
+        cassandra().session,
+        cassandra().sync,
+        compareAndSet = true
+      )
+      _           <- snapshots.persist(key, KafkaSnapshot(offset = Offset.unsafe(10), value = "state-10"))
+      _           <- snapshots.delete(key)
+      deleted     <- snapshots.get(key)
+      _           <- snapshots.persist(key, KafkaSnapshot(offset = Offset.unsafe(7), value = "state-7-stale"))
+      resurrected <- snapshots.get(key)
+    } yield {
+      assert(clue(deleted.isEmpty))
+      // the unguarded delete let the lower offset (7) win, resurrecting the key below the delete
+      assertEquals(clue(resurrected), Some(KafkaSnapshot(offset = Offset.unsafe(7), value = "state-7-stale")))
+    }
+
+    test.unsafeRunSync()
+  }
+
+  test("compare-and-set: concurrent first-writers race on a fresh key; the highest offset wins, no corruption") {
+    // Exercises persistCompareAndSet's first-write compound under real contention: every writer hits
+    // UPDATE-absent then `INSERT ... IF NOT EXISTS` for the same new key; one INSERT wins and the losers
+    // take the retry-`UPDATE` path (the single-threaded tests never reach it). The offset guard keeps it
+    // safe -- the durable snapshot ends at the highest offset, never clobbered by a lower one, and any
+    // rejected writer fails cleanly with SnapshotWriteConflict.
+    val key     = KafkaKey("SnapshotSpec", "integration-tests-1", TopicPartition.empty, "cas-first-write-race")
+    val offsets = (1 to 8).toList
+    val test: IO[Unit] = for {
+      snapshots <- CassandraSnapshots.withSchema[IO, String](
+        cassandra().session,
+        cassandra().sync,
+        compareAndSet = true
+      )
+      results <- offsets.parTraverse(o =>
+        snapshots.persist(key, KafkaSnapshot(offset = Offset.unsafe(o.toLong), value = s"state-$o")).attempt
+      )
+      stored <- snapshots.get(key)
+    } yield {
+      assertEquals(clue(stored.map(_.value)), Some(s"state-${offsets.max}")) // highest wins, no stale overwrite
+      results.collect { case Left(e) => e }.foreach {
+        case _: CassandraSnapshots.SnapshotWriteConflict => ()
+        case other                                       => fail(s"unexpected failure (not a conflict): $other")
+      }
+    }
+
+    test.unsafeRunSync()
+  }
+
+  test("compare-and-set: ttl is set on both insert and update paths") {
+    val key = KafkaKey("SnapshotSpec", "integration-tests-1", TopicPartition.empty, "cas-ttl")
+    val test: IO[Unit] = for {
+      snapshots <- CassandraSnapshots.withSchema[IO, String](
+        cassandra().session,
+        cassandra().sync,
+        ttl           = 1.hour.some,
+        compareAndSet = true,
+      )
+      _          <- snapshots.persist(key, KafkaSnapshot(offset = Offset.unsafe(5), value = "state-5"))
+      insertTtls <- getTtls(key)
+      _          <- snapshots.persist(key, KafkaSnapshot(offset = Offset.unsafe(10), value = "state-10"))
+      updateTtls <- getTtls(key)
+    } yield {
+      assertEquals(clue(insertTtls.size), 1)
+      assert(clue(insertTtls.head.isDefined))
+      assertEquals(clue(updateTtls.size), 1)
+      assert(clue(updateTtls.head.isDefined))
+    }
+
+    test.unsafeRunSync()
+  }
+
   test("failures") {
     val key = KafkaKey("SnapshotSpec", "integration-tests-1", TopicPartition.empty, "queries")
     val test: IO[Unit] = for {

--- a/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotSpec.scala
+++ b/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotSpec.scala
@@ -98,8 +98,9 @@ class SnapshotSpec extends CassandraSpec {
     // UPDATE-absent then `INSERT ... IF NOT EXISTS` for the same new key; one INSERT wins and the losers
     // take the retry-`UPDATE` path (the branch single-threaded tests never reach). The offset guard keeps
     // it safe -- the durable snapshot ends at the highest offset, never clobbered by a lower one, and any
-    // rejected writer fails cleanly with SnapshotWriteConflict. (Exhaustive interleaving coverage, plus
-    // the TTL-reap spurious-conflict edge this test can't force, is the CasFirstWrite model.)
+    // rejected writer fails cleanly with SnapshotWriteConflict. The compound is intrinsically coupled to real
+    // Cassandra lightweight-transaction results, so it has no in-memory unit double; the one path not forced here
+    // is the (effectively unreachable) TTL-reap spurious conflict on the retry-`UPDATE` (see persistCompareAndSet).
     val key     = KafkaKey("SnapshotSpec", "integration-tests-1", TopicPartition.empty, "cas-first-write-race")
     val offsets = (1 to 8).toList
     val test: IO[Unit] = for {

--- a/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotSpec.scala
+++ b/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotSpec.scala
@@ -11,6 +11,17 @@ import scala.jdk.CollectionConverters.*
 
 class SnapshotSpec extends CassandraSpec {
 
+  // The store now exposes the unified read/write over Stored; these adapters keep the store-level cases speaking the
+  // persist/delete/get vocabulary, so they still pin the exact compare-and-set / tombstone semantics unchanged.
+  private implicit class SnapshotStoreOps(val db: SnapshotDatabase[IO, KafkaKey, KafkaSnapshot[String]]) {
+    def persist(key: KafkaKey, snapshot: KafkaSnapshot[String]): IO[Unit] =
+      db.write(key, Stored.Live(snapshot, snapshot.offset.some))
+    def delete(key: KafkaKey, offset: Offset): IO[Unit] =
+      db.write(key, Stored.Tombstone(offset))
+    def get(key: KafkaKey): IO[Option[KafkaSnapshot[String]]] =
+      db.read(key).map(_.flatMap(_.value))
+  }
+
   test("queries") {
     val key      = KafkaKey("SnapshotSpec", "integration-tests-1", TopicPartition.empty, "queries")
     val snapshot = KafkaSnapshot(offset = Offset.min, value = "snapshot-contents")
@@ -20,7 +31,7 @@ class SnapshotSpec extends CassandraSpec {
       _                    <- snapshots.persist(key, snapshot)
       snapshotAfterPersist <- snapshots.get(key)
       ttls                 <- getTtls(key)
-      _                    <- snapshots.delete(key)
+      _                    <- snapshots.delete(key, snapshot.offset)
       snapshotAfterDelete  <- snapshots.get(key)
     } yield {
       assert(clue(snapshotBeforeTest.isEmpty))
@@ -82,40 +93,14 @@ class SnapshotSpec extends CassandraSpec {
     test.unsafeRunSync()
   }
 
-  test("compare-and-set: a delete is unguarded, so a lower-offset write resurrects a deleted key (persist-only gap)") {
-    // Pins the accepted persist-only residual gap (see docs/cassandra-single-writer-design.md, "Scope:
-    // deletes are not fenced"): a delete is a plain last-write-wins DELETE, so it removes the row and its offset
-    // guard. A lagging zombie's lower-offset write then finds an absent row, takes the
-    // `INSERT ... IF NOT EXISTS` first-write path, and resurrects the key below the deleted offset. This
-    // is the one residual #732 case the persist fence does not cover; if a future mode offset-gates
-    // deletes, this assertion should flip (the resurrection becomes a SnapshotWriteConflict).
-    val key = KafkaKey("SnapshotSpec", "integration-tests-1", TopicPartition.empty, "cas-delete-resurrect")
-    val test: IO[Unit] = for {
-      snapshots <- CassandraSnapshots.withSchema[IO, String](
-        cassandra().session,
-        cassandra().sync,
-        compareAndSet = true
-      )
-      _           <- snapshots.persist(key, KafkaSnapshot(offset = Offset.unsafe(10), value = "state-10"))
-      _           <- snapshots.delete(key)
-      deleted     <- snapshots.get(key)
-      _           <- snapshots.persist(key, KafkaSnapshot(offset = Offset.unsafe(7), value = "state-7-stale"))
-      resurrected <- snapshots.get(key)
-    } yield {
-      assert(clue(deleted.isEmpty))
-      // the unguarded delete let the lower offset (7) win, resurrecting the key below the delete
-      assertEquals(clue(resurrected), Some(KafkaSnapshot(offset = Offset.unsafe(7), value = "state-7-stale")))
-    }
-
-    test.unsafeRunSync()
-  }
-
   test("compare-and-set: concurrent first-writers race on a fresh key; the highest offset wins, no corruption") {
     // Exercises persistCompareAndSet's first-write compound under real contention: every writer hits
     // UPDATE-absent then `INSERT ... IF NOT EXISTS` for the same new key; one INSERT wins and the losers
-    // take the retry-`UPDATE` path (the single-threaded tests never reach it). The offset guard keeps it
-    // safe -- the durable snapshot ends at the highest offset, never clobbered by a lower one, and any
-    // rejected writer fails cleanly with SnapshotWriteConflict.
+    // take the retry-`UPDATE` path (the branch single-threaded tests never reach). The offset guard keeps
+    // it safe -- the durable snapshot ends at the highest offset, never clobbered by a lower one, and any
+    // rejected writer fails cleanly with SnapshotWriteConflict. The compound is intrinsically coupled to real
+    // Cassandra lightweight-transaction results, so it has no in-memory unit double; the one path not forced here
+    // is the (effectively unreachable) TTL-reap spurious conflict on the retry-`UPDATE` (see persistCompareAndSet).
     val key     = KafkaKey("SnapshotSpec", "integration-tests-1", TopicPartition.empty, "cas-first-write-race")
     val offsets = (1 to 8).toList
     val test: IO[Unit] = for {
@@ -134,6 +119,303 @@ class SnapshotSpec extends CassandraSpec {
         case _: CassandraSnapshots.SnapshotWriteConflict => ()
         case other                                       => fail(s"unexpected failure (not a conflict): $other")
       }
+    }
+
+    test.unsafeRunSync()
+  }
+
+  test("compare-and-set: a legitimate re-creation after a delete uses a higher offset") {
+    val key = KafkaKey("SnapshotSpec", "integration-tests-1", TopicPartition.empty, "cas-delete")
+    val test: IO[Unit] = for {
+      snapshots <- CassandraSnapshots.withSchema[IO, String](
+        cassandra().session,
+        cassandra().sync,
+        compareAndSet = true
+      )
+      _           <- snapshots.persist(key, KafkaSnapshot(offset = Offset.unsafe(10), value = "state-10"))
+      _           <- snapshots.delete(key, Offset.unsafe(10))
+      afterDelete <- snapshots.get(key)
+      // the raw read must surface the tombstone's offset (the replay-window floor) - not collapse it to
+      // "nothing there"; the deleted-key livelock prevention hangs on exactly this read
+      tombstone <- snapshots.read(key)
+      // the key was deleted at offset 10; a legitimate re-creation arrives at a higher offset and applies
+      _         <- snapshots.persist(key, KafkaSnapshot(offset = Offset.unsafe(20), value = "state-20"))
+      recreated <- snapshots.get(key)
+    } yield {
+      assert(clue(afterDelete.isEmpty)) // tombstone reads back as absent
+      assertEquals(clue(tombstone), Some(Stored.Tombstone(Offset.unsafe(10))): Option[Stored[KafkaSnapshot[String]]])
+      assertEquals(clue(recreated.map(_.value)), Some("state-20"))
+    }
+
+    test.unsafeRunSync()
+  }
+
+  test("compare-and-set: stale delete is rejected and leaves the newer snapshot") {
+    val key = KafkaKey("SnapshotSpec", "integration-tests-1", TopicPartition.empty, "cas-stale-delete")
+    val test: IO[Unit] = for {
+      snapshots <- CassandraSnapshots.withSchema[IO, String](
+        cassandra().session,
+        cassandra().sync,
+        compareAndSet = true
+      )
+      _ <- snapshots.persist(key, KafkaSnapshot(offset = Offset.unsafe(10), value = "state-10"))
+      // a stale writer (lower offset) tries to delete: it must not erase the newer owner's snapshot
+      result <- snapshots.delete(key, Offset.unsafe(7)).attempt
+      stored <- snapshots.get(key)
+    } yield {
+      result match {
+        case Left(conflict: CassandraSnapshots.SnapshotWriteConflict) =>
+          assertEquals(clue(conflict.key), key)
+          assertEquals(clue(conflict.attemptedOffset), Offset.unsafe(7))
+          assertEquals(clue(conflict.persistedOffset), Some(Offset.unsafe(10)))
+        case other => fail(s"expected SnapshotWriteConflict, got $other")
+      }
+      assertEquals(clue(stored.map(_.value)), Some("state-10"))
+    }
+
+    test.unsafeRunSync()
+  }
+
+  test("compare-and-set: deleting a never-persisted key writes the tombstone so a zombie cannot resurrect it") {
+    val key = KafkaKey("SnapshotSpec", "integration-tests-1", TopicPartition.empty, "cas-delete-never-written")
+    val test: IO[Unit] = for {
+      snapshots <- CassandraSnapshots.withSchema[IO, String](
+        cassandra().session,
+        cassandra().sync,
+        compareAndSet = true
+      )
+      // A key created and deleted before it was ever durably persisted: the conditional UPDATE finds no row,
+      // so the delete takes the row-absent branch (resolveConditional's onAbsent) and INSERTs the
+      // offset-carrying tombstone `IF NOT EXISTS`. Skipping the write (the old no-op) would leave no fence.
+      result    <- snapshots.delete(key, Offset.unsafe(10)).attempt
+      tombstone <- snapshots.read(key)
+      absent    <- snapshots.get(key)
+      // A revoked zombie still holding the never-persisted key's buffered pre-delete snapshot flushes it at a
+      // lower offset. The tombstone (offset 10) must reject it -- otherwise the deleted key is resurrected
+      // durably while the consumer offset has already committed past the delete.
+      zombie <- snapshots.persist(key, KafkaSnapshot(offset = Offset.unsafe(3), value = "zombie-3")).attempt
+      stored <- snapshots.get(key)
+    } yield {
+      assert(clue(result.isRight))
+      // the delete left an offset-carrying tombstone at 10 (the fence), reading back as absent
+      assertEquals(clue(tombstone), Some(Stored.Tombstone(Offset.unsafe(10))): Option[Stored[KafkaSnapshot[String]]])
+      assert(clue(absent.isEmpty))
+      zombie match {
+        case Left(conflict: CassandraSnapshots.SnapshotWriteConflict) =>
+          assertEquals(clue(conflict.attemptedOffset), Offset.unsafe(3))
+          assertEquals(clue(conflict.persistedOffset), Some(Offset.unsafe(10)))
+        case other => fail(s"expected SnapshotWriteConflict, got $other")
+      }
+      assert(clue(stored.isEmpty)) // still deleted, not resurrected
+    }
+
+    test.unsafeRunSync()
+  }
+
+  test("compare-and-set: re-deleting a never-persisted, already-tombstoned key is idempotent") {
+    val key = KafkaKey("SnapshotSpec", "integration-tests-1", TopicPartition.empty, "cas-delete-never-written-idem")
+    val test: IO[Unit] = for {
+      snapshots <- CassandraSnapshots.withSchema[IO, String](
+        cassandra().session,
+        cassandra().sync,
+        compareAndSet = true
+      )
+      _ <- snapshots.delete(key, Offset.unsafe(10)) // INSERTs the tombstone (first delete of a fresh key)
+      // an at-least-once replay of the same delete now finds the tombstone row and applies the equal-offset
+      // UPDATE (a no-op), rather than taking the INSERT path again
+      result    <- snapshots.delete(key, Offset.unsafe(10)).attempt
+      tombstone <- snapshots.read(key)
+    } yield {
+      assert(clue(result.isRight))
+      assertEquals(clue(tombstone), Some(Stored.Tombstone(Offset.unsafe(10))): Option[Stored[KafkaSnapshot[String]]])
+    }
+
+    test.unsafeRunSync()
+  }
+
+  test("compare-and-set: the delete tombstone carries the ttl (it is reaped, not immortal)") {
+    val key = KafkaKey("SnapshotSpec", "integration-tests-1", TopicPartition.empty, "cas-tombstone-ttl")
+    val test: IO[Unit] = for {
+      snapshots <- CassandraSnapshots.withSchema[IO, String](
+        cassandra().session,
+        cassandra().sync,
+        ttl           = 1.hour.some,
+        compareAndSet = true
+      )
+      _ <- snapshots.persist(key, KafkaSnapshot(offset = Offset.unsafe(10), value = "state-10"))
+      _ <- snapshots.delete(key, Offset.unsafe(11))
+      // the tombstone's guard cell must carry the TTL - without it a deleted key's row lives forever
+      offsetTtls <- getTtls(key, column = "offset")
+    } yield {
+      assertEquals(clue(offsetTtls.size), 1)
+      assert(clue(offsetTtls.head.isDefined))
+    }
+
+    test.unsafeRunSync()
+  }
+
+  test("compare-and-set: deleting an absent key is an idempotent no-op") {
+    val key = KafkaKey("SnapshotSpec", "integration-tests-1", TopicPartition.empty, "cas-idempotent-delete")
+    val test: IO[Unit] = for {
+      snapshots <- CassandraSnapshots.withSchema[IO, String](
+        cassandra().session,
+        cassandra().sync,
+        compareAndSet = true
+      )
+      _ <- snapshots.persist(key, KafkaSnapshot(offset = Offset.unsafe(10), value = "state-10"))
+      _ <- snapshots.delete(key, Offset.unsafe(10))
+      // re-issuing the delete (e.g. an at-least-once replay after a crash before the offset commit) must not fail
+      result <- snapshots.delete(key, Offset.unsafe(10)).attempt
+      stored <- snapshots.get(key)
+    } yield {
+      assert(clue(result.isRight))
+      assert(clue(stored.isEmpty))
+    }
+
+    test.unsafeRunSync()
+  }
+
+  test("compare-and-set: a stale lower-offset write after a delete is rejected (no resurrection)") {
+    val key = KafkaKey("SnapshotSpec", "integration-tests-1", TopicPartition.empty, "cas-no-resurrection")
+    val test: IO[Unit] = for {
+      snapshots <- CassandraSnapshots.withSchema[IO, String](
+        cassandra().session,
+        cassandra().sync,
+        compareAndSet = true
+      )
+      _ <- snapshots.persist(key, KafkaSnapshot(offset = Offset.unsafe(10), value = "state-10"))
+      _ <- snapshots.delete(key, Offset.unsafe(10))
+      // the delete leaves an offset-carrying tombstone (offset 10); a stale lower-offset write must NOT resurrect the
+      // key, otherwise a later recovery would fold new events onto the stale state
+      result <- snapshots.persist(key, KafkaSnapshot(offset = Offset.unsafe(3), value = "state-3")).attempt
+      stored <- snapshots.get(key)
+    } yield {
+      result match {
+        case Left(conflict: CassandraSnapshots.SnapshotWriteConflict) =>
+          assertEquals(clue(conflict.attemptedOffset), Offset.unsafe(3))
+          assertEquals(clue(conflict.persistedOffset), Some(Offset.unsafe(10)))
+        case other => fail(s"expected SnapshotWriteConflict, got $other")
+      }
+      assert(clue(stored.isEmpty)) // still deleted, not resurrected
+    }
+
+    test.unsafeRunSync()
+  }
+
+  test("compare-and-set: an equal-offset delete applies") {
+    val key = KafkaKey("SnapshotSpec", "integration-tests-1", TopicPartition.empty, "cas-equal-offset-delete")
+    val test: IO[Unit] = for {
+      snapshots <- CassandraSnapshots.withSchema[IO, String](
+        cassandra().session,
+        cassandra().sync,
+        compareAndSet = true
+      )
+      _      <- snapshots.persist(key, KafkaSnapshot(offset = Offset.unsafe(10), value = "state-10"))
+      _      <- snapshots.delete(key, Offset.unsafe(10))
+      stored <- snapshots.get(key)
+    } yield assert(clue(stored.isEmpty))
+
+    test.unsafeRunSync()
+  }
+
+  test("compare-and-set: a replayed stale delete cannot remove a newer snapshot") {
+    val key = KafkaKey("SnapshotSpec", "integration-tests-1", TopicPartition.empty, "cas-replayed-stale-delete")
+    val test: IO[Unit] = for {
+      snapshots <- CassandraSnapshots.withSchema[IO, String](
+        cassandra().session,
+        cassandra().sync,
+        compareAndSet = true
+      )
+      _ <- snapshots.persist(key, KafkaSnapshot(offset = Offset.unsafe(10), value = "state-10"))
+      _ <- snapshots.delete(key, Offset.unsafe(10))
+      _ <- snapshots.persist(key, KafkaSnapshot(offset = Offset.unsafe(20), value = "state-20"))
+      // an at-least-once replay of the OLD delete (offset 10) must not erase the newer snapshot (offset 20)
+      result <- snapshots.delete(key, Offset.unsafe(10)).attempt
+      stored <- snapshots.get(key)
+    } yield {
+      result match {
+        case Left(conflict: CassandraSnapshots.SnapshotWriteConflict) =>
+          assertEquals(clue(conflict.key), key)
+          assertEquals(clue(conflict.attemptedOffset), Offset.unsafe(10))
+          assertEquals(clue(conflict.persistedOffset), Some(Offset.unsafe(20)))
+        case other => fail(s"expected SnapshotWriteConflict, got $other")
+      }
+      assertEquals(clue(stored.map(_.value)), Some("state-20"))
+    }
+
+    test.unsafeRunSync()
+  }
+
+  test(
+    "compare-and-set: replaying a delete after its tombstone was TTL-reaped re-creates the fence, " +
+      "neither fencing a legitimate higher write nor admitting a stale lower one"
+  ) {
+    // Deleting a never-persisted key hits the row-absent branch, INSERTing an offset-carrying tombstone
+    // `IF NOT EXISTS`. A short ttl lets that tombstone reap; after it does, replaying the same at-least-once
+    // delete re-INSERTs the tombstone at the OLD offset. Claim: the re-created old tombstone (offset 10) is a
+    // bound, not a hazard --
+    //   - it does NOT admit a stale lower-offset write (persist at 3 rejected: 10 <= 3 is false), and
+    //   - it does NOT fence a legitimate higher write (persist at 20 applies: 10 <= 20 holds).
+    val key = KafkaKey("SnapshotSpec", "integration-tests-1", TopicPartition.empty, "cas-reaped-tombstone-replay")
+    // Two instances on one table: `reaping` writes with a short ttl so the FIRST tombstone reaps within the test
+    // (sleep past it; 1s TTL granularity + read-time filtering, so 5s/7s is generous against jitter). `durable`
+    // writes with NO ttl, used from the replay on: the re-created fence and the writes tested against it must not
+    // reap mid-test -- the fence semantics under test are independent of the tombstone's ttl, and reusing the
+    // short ttl here would leave the later assertions racing a 5s clock with no margin.
+    val ttl   = 5.seconds
+    val sleep = 7.seconds
+    val test: IO[Unit] = for {
+      reaping <- CassandraSnapshots.withSchema[IO, String](
+        cassandra().session,
+        cassandra().sync,
+        ttl           = ttl.some,
+        compareAndSet = true
+      )
+      durable <- CassandraSnapshots.withSchema[IO, String](
+        cassandra().session,
+        cassandra().sync,
+        ttl           = None,
+        compareAndSet = true
+      )
+      // (1) delete a never-persisted key at offset 10 -> INSERTs the offset-carrying tombstone (row-absent branch)
+      _              <- reaping.delete(key, Offset.unsafe(10))
+      tombstoneFresh <- reaping.read(key)
+      // (2) sleep past the ttl -> the whole tombstone row reaps (INSERT ... USING TTL ttls the row marker + cells)
+      _         <- IO.sleep(sleep)
+      afterReap <- reaping.read(key)
+      // (3) replay the SAME delete at offset 10 after the reap -> re-INSERTs the tombstone, now permanent (no ttl)
+      replay         <- durable.delete(key, Offset.unsafe(10)).attempt
+      tombstoneAgain <- durable.read(key)
+      // (4) the re-created old tombstone (offset 10) must NOT admit a stale lower-offset write
+      staleLower      <- durable.persist(key, KafkaSnapshot(offset = Offset.unsafe(3), value = "stale-3")).attempt
+      stillTombstoned <- durable.get(key)
+      // (5) and it must NOT fence a legitimate higher write (10 <= 20 holds)
+      _         <- durable.persist(key, KafkaSnapshot(offset = Offset.unsafe(20), value = "state-20"))
+      recreated <- durable.get(key)
+    } yield {
+      // (1) the fresh delete left an offset-carrying tombstone at 10, reading back as a tombstone (value absent)
+      assertEquals(
+        clue(tombstoneFresh),
+        Some(Stored.Tombstone(Offset.unsafe(10))): Option[Stored[KafkaSnapshot[String]]]
+      )
+      // (2) after the ttl the row is fully gone -- read returns None, not a stale tombstone
+      assertEquals(clue(afterReap), None: Option[Stored[KafkaSnapshot[String]]])
+      // (3) the replayed delete succeeds and re-creates the tombstone at the old offset 10
+      assert(clue(replay.isRight))
+      assertEquals(
+        clue(tombstoneAgain),
+        Some(Stored.Tombstone(Offset.unsafe(10))): Option[Stored[KafkaSnapshot[String]]]
+      )
+      // (4) a stale lower-offset write is still rejected by the re-created tombstone (fence intact, no resurrection)
+      staleLower match {
+        case Left(conflict: CassandraSnapshots.SnapshotWriteConflict) =>
+          assertEquals(clue(conflict.attemptedOffset), Offset.unsafe(3))
+          assertEquals(clue(conflict.persistedOffset), Some(Offset.unsafe(10)))
+        case other => fail(s"expected SnapshotWriteConflict, got $other")
+      }
+      assert(clue(stillTombstoned.isEmpty)) // still deleted, not resurrected by the stale writer
+      // (5) a legitimate higher write still applies -- the re-created old tombstone does NOT fence it
+      assertEquals(clue(recreated.map(_.value)), Some("state-20"))
     }
 
     test.unsafeRunSync()
@@ -192,11 +474,11 @@ class SnapshotSpec extends CassandraSpec {
     test.unsafeRunSync()
   }
 
-  private def getTtls(key: KafkaKey): IO[List[Option[Int]]] = {
+  private def getTtls(key: KafkaKey, column: String = "value"): IO[List[Option[Int]]] = {
     val session = cassandra().session
     for {
       prepared <- session.prepare(
-        s"""SELECT TTL(value) FROM ${CassandraSnapshots.DefaultTableName} WHERE
+        s"""SELECT TTL($column) FROM ${CassandraSnapshots.DefaultTableName} WHERE
            |  application_id = :application_id
            |  AND group_id = :group_id
            |  AND topic = :topic

--- a/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotTtlEdgeSpec.scala
+++ b/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotTtlEdgeSpec.scala
@@ -13,23 +13,25 @@ import scala.jdk.CollectionConverters.*
 
 /** The guard-expired ("poison") row: a TTL reconfiguration artefact, and its repair.
   *
-  * Cassandra TTLs are per cell, and a row stays visible while any live cell - or the first write's `INSERT` row marker,
-  * which nothing can remove - survives. A no-TTL deployment's first write of a key leaves that immortal marker; enable
-  * the `ttl` and let the key's TTL'd cells expire, and the row stays visible with every column null: `offset = null`,
-  * so nothing fences it. `get` already reads it as absent (the `value` cell is expired), but without a repair path no
-  * persist could ever claim it again: the null guard fails `IF offset <= :offset`, the not-applied result was mistaken
-  * for "row absent", `INSERT ... IF NOT EXISTS` lost to the still-visible row, and the retry conflicted - every write
-  * of the key raising `SnapshotWriteConflict`, forever (established empirically against real Cassandra).
+  * Cassandra TTLs are per cell: a statement stamps its TTL only onto the cells it writes, and a row stays visible while
+  * any live cell (or the first write's `INSERT` row marker, which nothing can remove) survives. Every persist rewrites
+  * all four cells with one TTL, but the compare-and-set delete writes only `value = null` and `offset` - so enabling
+  * (or shortening) the `ttl` between a key's persist and its delete produces a visible row whose `offset` guard expires
+  * while older cells keep it alive: `value = null`, `offset = null`. Nothing fences that row, and before the repair
+  * statement existed nothing could claim it either: `read` silently decoded the null offset as 0 (the tombstone floor
+  * collapsed to `Offset.min` - the deleted-key replay fence lost its floor), and a persist conflicted forever (the null
+  * guard fails `IF offset <= :offset`; the result was mistaken for "row absent"; `INSERT ... IF NOT EXISTS` lost to the
+  * still-visible row; the retry conflicted). Established empirically against real Cassandra.
   *
-  * The fix: the not-applied result distinguishes "row present, guard null" (Cassandra returns the condition column,
-  * null, exactly when the row exists) from "row absent", and a persist claims the guard-expired row through the
-  * Paxos-safe `IF offset = null` repair write, which also reinstates the guard.
+  * The fix: `read` reports a guard-expired row as absent (a guard that is gone fences nothing - exactly a reaped row),
+  * a delete on it is an idempotent no-op, and a persist claims it through the Paxos-safe `IF offset = null` repair
+  * write, which also reinstates the guard.
   */
 class SnapshotTtlEdgeSpec extends CassandraSpec {
 
   private val table = "snapshots_ttl_edge"
 
-  test("a guard-expired row reads as absent and is repaired by the next persist") {
+  test("a guard-expired row reads as absent, deletes as a no-op, and is repaired by the next persist") {
     val key = KafkaKey("SnapshotTtlEdgeSpec", "integration-tests-1", TopicPartition.empty, "poison")
     val test: IO[Unit] = for {
       // two deployments over one table: before and after `ttl` was enabled
@@ -43,33 +45,56 @@ class SnapshotTtlEdgeSpec extends CassandraSpec {
         cassandra().session,
         cassandra().sync,
         tableName     = table,
-        ttl           = 1.second.some,
+        ttl           = 5.seconds.some,
         compareAndSet = true,
       )
-      // 1. the no-TTL deployment's first write: an INSERT, so the row marker is immortal
-      _ <- noTtl.persist(key, KafkaSnapshot(offset = Offset.unsafe(10), value = "v10"))
-      // 2. the TTL-enabled deployment re-persists: all four cells rewritten with TTL 1s (the marker keeps none)
-      _ <- withTtl.persist(key, KafkaSnapshot(offset = Offset.unsafe(11), value = "v11"))
-      // 3. the cells expire; the immortal marker keeps the row visible with every column null
-      _   <- IO.sleep(3.seconds)
+      // 1. the no-TTL deployment persists the key: the first write is an INSERT, so the row marker and
+      //    all four cells are immortal
+      _ <- noTtl.write(
+        key,
+        Stored.Live(KafkaSnapshot(offset = Offset.unsafe(10), value = "v10"), Offset.unsafe(10).some)
+      )
+      // 2. the TTL-enabled deployment deletes it: the tombstone writes value = null plus offset with
+      //    TTL 1s; created/metadata (and the row marker) keep no TTL
+      _         <- withTtl.write(key, Stored.Tombstone(Offset.unsafe(11)))
+      tombstone <- noTtl.read(key)
+      // 3. the offset cell expires; the row stays visible through the immortal marker/cells
+      _   <- IO.sleep(7.seconds)
       row <- selectRaw(key)
-      // 4. the guard is gone, so the row fences nothing - and reads as absent
-      readPoison <- noTtl.get(key)
+      // 4. the guard is gone, so the row fences nothing: it reads back as absent (not as a tombstone
+      //    with a silently-zero floor), and a replayed delete is an idempotent no-op that writes nothing
+      readPoison   <- noTtl.read(key)
+      deletePoison <- noTtl.write(key, Stored.Tombstone(Offset.unsafe(11))).attempt
+      rowAfterOps  <- selectRaw(key)
       // 5. a legitimate re-creation claims the row through the `IF offset = null` repair write
-      _           <- noTtl.persist(key, KafkaSnapshot(offset = Offset.unsafe(12), value = "v12"))
-      afterRepair <- noTtl.get(key)
+      _ <- noTtl.write(
+        key,
+        Stored.Live(KafkaSnapshot(offset = Offset.unsafe(12), value = "v12"), Offset.unsafe(12).some)
+      )
+      afterRepair <- noTtl.read(key)
       // 6. the repair reinstated the guard: a stale write is fenced again
-      staleAfterRepair <- noTtl.persist(key, KafkaSnapshot(offset = Offset.unsafe(5), value = "v5-stale")).attempt
+      staleAfterRepair <- noTtl
+        .write(key, Stored.Live(KafkaSnapshot(offset = Offset.unsafe(5), value = "v5-stale"), Offset.unsafe(5).some))
+        .attempt
     } yield {
+      assertEquals(clue(tombstone), Some(Stored.Tombstone(Offset.unsafe(11))): Option[Stored[KafkaSnapshot[String]]])
       row match {
-        case Some((value, offset)) =>
-          assertEquals(clue(value), None: Option[ByteVector]) // expired
+        case Some((value, offset, metadata)) =>
+          assertEquals(clue(value), None: Option[ByteVector]) // tombstoned
           assertEquals(clue(offset), None: Option[Offset]) // expired: the guard is gone
+          assert(clue(metadata).isDefined, "an immortal pre-TTL cell keeps the row visible")
         case None =>
-          fail("expected the poison row to stay visible via the immortal row marker")
+          fail("expected the poison row to stay visible after the offset cell expired")
       }
-      assertEquals(clue(readPoison), None: Option[KafkaSnapshot[String]])
-      assertEquals(clue(afterRepair.map(_.value)), Some("v12"))
+      assertEquals(clue(readPoison), None: Option[Stored[KafkaSnapshot[String]]])
+      assert(clue(deletePoison).isRight)
+      assertEquals(clue(rowAfterOps.flatMap(_._2)), None: Option[Offset]) // the no-op delete wrote nothing
+      assertEquals(
+        clue(afterRepair),
+        Some(Stored.Live(KafkaSnapshot(offset = Offset.unsafe(12), value = "v12"), Offset.unsafe(12).some)): Option[
+          Stored[KafkaSnapshot[String]]
+        ],
+      )
       staleAfterRepair match {
         case Left(conflict: CassandraSnapshots.SnapshotWriteConflict) =>
           assertEquals(clue(conflict.persistedOffset), Some(Offset.unsafe(12)))
@@ -80,11 +105,66 @@ class SnapshotTtlEdgeSpec extends CassandraSpec {
     test.unsafeRunSync()
   }
 
-  private def selectRaw(key: KafkaKey): IO[Option[(Option[ByteVector], Option[Offset])]] = {
+  test("a marker-kept row with all cells expired (no delete involved) reads as absent and is repaired") {
+    val key = KafkaKey("SnapshotTtlEdgeSpec", "integration-tests-1", TopicPartition.empty, "poison-marker")
+    val test: IO[Unit] = for {
+      noTtl <- CassandraSnapshots.withSchema[IO, String](
+        cassandra().session,
+        cassandra().sync,
+        tableName     = table,
+        compareAndSet = true,
+      )
+      withTtl <- CassandraSnapshots.withSchema[IO, String](
+        cassandra().session,
+        cassandra().sync,
+        tableName     = table,
+        ttl           = 5.seconds.some,
+        compareAndSet = true,
+      )
+      // the persist-only variant of the same state: a no-TTL first write leaves the immortal INSERT row
+      // marker; a TTL'd re-persist rewrites all four cells; when they expire the marker alone keeps the
+      // row visible with every column null - no delete involved
+      _ <- noTtl.write(
+        key,
+        Stored.Live(KafkaSnapshot(offset = Offset.unsafe(10), value = "v10"), Offset.unsafe(10).some)
+      )
+      _ <- withTtl.write(
+        key,
+        Stored.Live(KafkaSnapshot(offset = Offset.unsafe(11), value = "v11"), Offset.unsafe(11).some)
+      )
+      _          <- IO.sleep(7.seconds)
+      row        <- selectRaw(key)
+      readPoison <- noTtl.read(key)
+      _ <- noTtl.write(
+        key,
+        Stored.Live(KafkaSnapshot(offset = Offset.unsafe(12), value = "v12"), Offset.unsafe(12).some)
+      )
+      afterRepair <- noTtl.read(key)
+    } yield {
+      row match {
+        case Some((value, offset, _)) =>
+          assertEquals(clue(value), None: Option[ByteVector]) // expired
+          assertEquals(clue(offset), None: Option[Offset]) // expired: the guard is gone
+        case None =>
+          fail("expected the poison row to stay visible via the immortal row marker")
+      }
+      assertEquals(clue(readPoison), None: Option[Stored[KafkaSnapshot[String]]])
+      assertEquals(
+        clue(afterRepair),
+        Some(Stored.Live(KafkaSnapshot(offset = Offset.unsafe(12), value = "v12"), Offset.unsafe(12).some)): Option[
+          Stored[KafkaSnapshot[String]]
+        ],
+      )
+    }
+
+    test.unsafeRunSync()
+  }
+
+  private def selectRaw(key: KafkaKey): IO[Option[(Option[ByteVector], Option[Offset], Option[String])]] = {
     val session = cassandra().session
     for {
       prepared <- session.prepare(
-        s"""SELECT value, offset FROM $table WHERE
+        s"""SELECT value, offset, metadata FROM $table WHERE
            |  application_id = :application_id
            |  AND group_id = :group_id
            |  AND topic = :topic
@@ -100,7 +180,11 @@ class SnapshotTtlEdgeSpec extends CassandraSpec {
         .encode("key", key.key)
       rows <- session.execute(bound)
     } yield rows.all().asScala.headOption.map { row =>
-      (row.decode[Option[ByteVector]]("value"), row.decode[Option[Offset]]("offset"))
+      (
+        row.decode[Option[ByteVector]]("value"),
+        row.decode[Option[Offset]]("offset"),
+        row.decode[Option[String]]("metadata")
+      )
     }
   }
 }

--- a/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotTtlEdgeSpec.scala
+++ b/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/snapshot/SnapshotTtlEdgeSpec.scala
@@ -1,0 +1,106 @@
+package com.evolutiongaming.kafka.flow.snapshot
+
+import cats.effect.IO
+import cats.syntax.all.*
+import com.evolutiongaming.kafka.flow.cassandra.CassandraCodecs.*
+import com.evolutiongaming.kafka.flow.{CassandraSpec, KafkaKey}
+import com.evolutiongaming.scassandra.syntax.*
+import com.evolutiongaming.skafka.{Offset, TopicPartition}
+import scodec.bits.ByteVector
+
+import scala.concurrent.duration.*
+import scala.jdk.CollectionConverters.*
+
+/** The guard-expired ("poison") row: a TTL reconfiguration artefact, and its repair.
+  *
+  * Cassandra TTLs are per cell, and a row stays visible while any live cell - or the first write's `INSERT` row marker,
+  * which nothing can remove - survives. A no-TTL deployment's first write of a key leaves that immortal marker; enable
+  * the `ttl` and let the key's TTL'd cells expire, and the row stays visible with every column null: `offset = null`,
+  * so nothing fences it. `get` already reads it as absent (the `value` cell is expired), but without a repair path no
+  * persist could ever claim it again: the null guard fails `IF offset <= :offset`, the not-applied result was mistaken
+  * for "row absent", `INSERT ... IF NOT EXISTS` lost to the still-visible row, and the retry conflicted - every write
+  * of the key raising `SnapshotWriteConflict`, forever (established empirically against real Cassandra).
+  *
+  * The fix: the not-applied result distinguishes "row present, guard null" (Cassandra returns the condition column,
+  * null, exactly when the row exists) from "row absent", and a persist claims the guard-expired row through the
+  * Paxos-safe `IF offset = null` repair write, which also reinstates the guard.
+  */
+class SnapshotTtlEdgeSpec extends CassandraSpec {
+
+  private val table = "snapshots_ttl_edge"
+
+  test("a guard-expired row reads as absent and is repaired by the next persist") {
+    val key = KafkaKey("SnapshotTtlEdgeSpec", "integration-tests-1", TopicPartition.empty, "poison")
+    val test: IO[Unit] = for {
+      // two deployments over one table: before and after `ttl` was enabled
+      noTtl <- CassandraSnapshots.withSchema[IO, String](
+        cassandra().session,
+        cassandra().sync,
+        tableName     = table,
+        compareAndSet = true,
+      )
+      withTtl <- CassandraSnapshots.withSchema[IO, String](
+        cassandra().session,
+        cassandra().sync,
+        tableName     = table,
+        ttl           = 1.second.some,
+        compareAndSet = true,
+      )
+      // 1. the no-TTL deployment's first write: an INSERT, so the row marker is immortal
+      _ <- noTtl.persist(key, KafkaSnapshot(offset = Offset.unsafe(10), value = "v10"))
+      // 2. the TTL-enabled deployment re-persists: all four cells rewritten with TTL 1s (the marker keeps none)
+      _ <- withTtl.persist(key, KafkaSnapshot(offset = Offset.unsafe(11), value = "v11"))
+      // 3. the cells expire; the immortal marker keeps the row visible with every column null
+      _   <- IO.sleep(3.seconds)
+      row <- selectRaw(key)
+      // 4. the guard is gone, so the row fences nothing - and reads as absent
+      readPoison <- noTtl.get(key)
+      // 5. a legitimate re-creation claims the row through the `IF offset = null` repair write
+      _           <- noTtl.persist(key, KafkaSnapshot(offset = Offset.unsafe(12), value = "v12"))
+      afterRepair <- noTtl.get(key)
+      // 6. the repair reinstated the guard: a stale write is fenced again
+      staleAfterRepair <- noTtl.persist(key, KafkaSnapshot(offset = Offset.unsafe(5), value = "v5-stale")).attempt
+    } yield {
+      row match {
+        case Some((value, offset)) =>
+          assertEquals(clue(value), None: Option[ByteVector]) // expired
+          assertEquals(clue(offset), None: Option[Offset]) // expired: the guard is gone
+        case None =>
+          fail("expected the poison row to stay visible via the immortal row marker")
+      }
+      assertEquals(clue(readPoison), None: Option[KafkaSnapshot[String]])
+      assertEquals(clue(afterRepair.map(_.value)), Some("v12"))
+      staleAfterRepair match {
+        case Left(conflict: CassandraSnapshots.SnapshotWriteConflict) =>
+          assertEquals(clue(conflict.persistedOffset), Some(Offset.unsafe(12)))
+        case other => fail(s"expected SnapshotWriteConflict after the repair reinstated the guard, got $other")
+      }
+    }
+
+    test.unsafeRunSync()
+  }
+
+  private def selectRaw(key: KafkaKey): IO[Option[(Option[ByteVector], Option[Offset])]] = {
+    val session = cassandra().session
+    for {
+      prepared <- session.prepare(
+        s"""SELECT value, offset FROM $table WHERE
+           |  application_id = :application_id
+           |  AND group_id = :group_id
+           |  AND topic = :topic
+           |  AND partition = :partition
+           |  AND key = :key""".stripMargin
+      )
+      bound = prepared
+        .bind()
+        .encode("application_id", key.applicationId)
+        .encode("group_id", key.groupId)
+        .encode("topic", key.topicPartition.topic)
+        .encode("partition", key.topicPartition.partition.value)
+        .encode("key", key.key)
+      rows <- session.execute(bound)
+    } yield rows.all().asScala.headOption.map { row =>
+      (row.decode[Option[ByteVector]]("value"), row.decode[Option[Offset]]("offset"))
+    }
+  }
+}

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/CassandraPersistence.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/CassandraPersistence.scala
@@ -21,6 +21,10 @@ object CassandraPersistence {
     *   - for keys see [[com.evolutiongaming.kafka.flow.key.CassandraKeys.DefaultTableName]]
     *   - for snapshots see [[com.evolutiongaming.kafka.flow.snapshot.CassandraSnapshots.DefaultTableName]]
     *   - for journals see [[com.evolutiongaming.kafka.flow.journal.CassandraJournals.DefaultTableName]]
+    *
+    * @param snapshotCompareAndSet
+    *   enables conditional snapshot writes protecting from stale writers overwriting newer snapshots during partition
+    *   ownership transitions, see [[com.evolutiongaming.kafka.flow.snapshot.CassandraSnapshots.withSchema]]
     */
   def withSchemaF[F[_]: Async, S](
     session: scassandra.CassandraSession[F],
@@ -28,6 +32,7 @@ object CassandraPersistence {
     consistencyOverrides: ConsistencyOverrides,
     keysSegments: KeySegments,
     recordExpiration: RecordExpiration = RecordExpiration.default,
+    snapshotCompareAndSet: Boolean     = false,
   )(implicit fromBytes: skafka.FromBytes[F, S], toBytes: skafka.ToBytes[F, S]): F[PersistenceModule[F, S]] = for {
     _keys <- CassandraKeys.withSchema(session, sync, consistencyOverrides, keysSegments, ttl = recordExpiration.keys)
     _journals <- CassandraJournals.withSchema(session, sync, consistencyOverrides, ttl = recordExpiration.journals)
@@ -35,7 +40,8 @@ object CassandraPersistence {
       session,
       sync,
       consistencyOverrides,
-      ttl = recordExpiration.snapshots
+      ttl           = recordExpiration.snapshots,
+      compareAndSet = snapshotCompareAndSet,
     )
   } yield new CassandraPersistence[F, S] {
     def keys      = _keys
@@ -50,7 +56,7 @@ object CassandraPersistence {
     *
     * This method uses the same `JsonCodec[Try]` as `JournalParser` does to simplify defining the basic application. if
     * \@consistencyConfig is present then applies ConsistencyConfig.Read for all read queries and
-    * ConsistencyConfig.Write for all the mutations
+    * ConsistencyConfig.Write for all the mutations. For `snapshotCompareAndSet` see `withSchemaF`.
     */
   def withSchema[F[_]: Async, S](
     session: scassandra.CassandraSession[F],
@@ -58,11 +64,12 @@ object CassandraPersistence {
     consistencyOverrides: ConsistencyOverrides,
     keysSegments: KeySegments,
     recordExpiration: RecordExpiration = RecordExpiration.default,
+    snapshotCompareAndSet: Boolean     = false,
   )(implicit fromBytes: skafka.FromBytes[Try, S], toBytes: skafka.ToBytes[Try, S]): F[PersistenceModule[F, S]] = {
     val fromTry                              = FunctionK.liftFunction[Try, F](MonadThrow[F].fromTry)
     implicit val _fromBytes: FromBytes[F, S] = fromBytes mapK fromTry
     implicit val _toBytes: ToBytes[F, S]     = toBytes mapK fromTry
-    withSchemaF(session, sync, consistencyOverrides, keysSegments, recordExpiration)
+    withSchemaF(session, sync, consistencyOverrides, keysSegments, recordExpiration, snapshotCompareAndSet)
   }
 
   // This exists for the sake of binary compatibility, to be removed in next major version

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/CassandraPersistence.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/CassandraPersistence.scala
@@ -1,13 +1,16 @@
 package com.evolutiongaming.kafka.flow.cassandra
 
 import cats.arrow.FunctionK
-import cats.effect.Async
+import cats.effect.{Async, Sync}
 import cats.syntax.all.*
 import cats.{Monad, MonadThrow}
 import com.evolutiongaming.cassandra.sync.CassandraSync
 import com.evolutiongaming.kafka.flow.journal.CassandraJournals
 import com.evolutiongaming.kafka.flow.key.{CassandraKeys, KeySegments}
+import com.evolutiongaming.catshelper.LogOf
+import com.evolutiongaming.kafka.flow.KafkaKey
 import com.evolutiongaming.kafka.flow.persistence.PersistenceModule
+import com.evolutiongaming.kafka.flow.snapshot.{KafkaSnapshot, SnapshotsOf}
 import com.evolutiongaming.kafka.flow.snapshot.CassandraSnapshots
 import com.evolutiongaming.skafka.{FromBytes, ToBytes}
 import com.evolutiongaming.{scassandra, skafka}
@@ -47,6 +50,16 @@ object CassandraPersistence {
     def keys      = _keys
     def journals  = _journals
     def snapshots = _snapshots
+
+    // the offset fence belongs to the compare-and-set mode only: a last-write-wins store never gates a
+    // write on the offset and never returns a tombstone floor, so it keeps the unfenced buffer (and
+    // events-recovery skips the per-key floor read) - exactly the pre-compare-and-set behaviour
+    override def snapshotsOf(
+      implicit F: Sync[F],
+      logOf: LogOf[F]
+    ): F[SnapshotsOf[F, KafkaKey, KafkaSnapshot[S]]] =
+      if (snapshotCompareAndSet) super.snapshotsOf
+      else logOf(CassandraPersistence.getClass).map(implicit log => SnapshotsOf.backedBy(_snapshots))
   }
 
   /** Creates schema in Cassandra if not there yet. Uses default names for all Cassandra tables:

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/CassandraSnapshots.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/CassandraSnapshots.scala
@@ -13,7 +13,7 @@ import com.evolutiongaming.kafka.flow.cassandra.StatementHelper.StatementOps
 import com.evolutiongaming.scassandra.CassandraSession
 import com.evolutiongaming.scassandra.StreamingCassandraSession.*
 import com.evolutiongaming.scassandra.syntax.*
-import com.evolutiongaming.skafka.{Bytes, FromBytes, Offset, ToBytes}
+import com.evolutiongaming.skafka.{Bytes, FromBytes, Offset, ToBytes, Topic}
 import scodec.bits.ByteVector
 import CassandraSnapshots.*
 
@@ -36,8 +36,8 @@ class CassandraSnapshots[F[_]: Async, T](
 )(implicit fromBytes: FromBytes[F, T], toBytes: ToBytes[F, T])
     extends SnapshotDatabase[F, KafkaKey, KafkaSnapshot[T]] {
 
-  /** Routes a [[Stored]] write: a present value persists a snapshot, an absent value writes a tombstone (delete). A
-    * compare-and-set store gates both on `stored.offset` (always set on the fenced buffer path); see [[Snapshots]].
+  /** Routes a `Stored` write: a present value persists a snapshot, an absent value writes a tombstone (delete). A
+    * compare-and-set store gates both on `stored.offset` (always set on the fenced buffer path); see `Snapshots`.
     */
   def write(key: KafkaKey, stored: Stored[KafkaSnapshot[T]]): F[Unit] =
     stored match {
@@ -82,8 +82,10 @@ class CassandraSnapshots[F[_]: Async, T](
           else
             // lost the insert race to a concurrent writer: retry the conditional update once
             executeWrite(bind(persistStatement)).flatMap { retryRow =>
-              // a row deleted between the insert and the retry surfaces as a (spurious) conflict; the flow
-              // recovers from it on the next flush
+              // a row deleted between the insert and the retry surfaces as a (spurious) conflict that fails this
+              // flow; the partition's next owner re-recovers and the write succeeds once the row is observed again.
+              // Effectively unreachable in pure compare-and-set mode, where a delete keeps the row as a tombstone -
+              // only a whole-row TTL reap in this narrow window removes it.
               resolveConditional(key, retryRow, snapshot.offset)(
                 SnapshotWriteConflict(key, snapshot.offset, none).raiseError[F, Unit]
               )
@@ -114,10 +116,10 @@ class CassandraSnapshots[F[_]: Async, T](
     else none
 
   /** Recovers the stored unit, surfacing a tombstone's offset as the replay-window floor. A present row reads back as
-    * `Some(Stored(Some(snapshot), _))`; a tombstone (null `value`, kept by [[deleteCompareAndSet]]) as
-    * `Some(Stored(None, offset))` carrying the stored offset even though the value is absent; no row as `None`. Without
-    * the tombstone's offset a deleted key recovers with no floor and a legitimate owner re-persisting below it
-    * self-fences (a livelock); see `docs/cassandra-single-writer-design.md`.
+    * `Some(Stored(Some(snapshot), _))`; a tombstone (null `value`, kept by `deleteCompareAndSet`) as `Some(Stored(None,
+    * offset))` carrying the stored offset even though the value is absent; no row as `None`. Without the tombstone's
+    * offset a deleted key recovers with no floor and a legitimate owner re-persisting below it self-fences (a
+    * livelock); see `docs/cassandra-single-writer-design.md`.
     */
   def read(key: KafkaKey): F[Option[Stored[KafkaSnapshot[T]]]] = {
     val boundStatement =
@@ -126,7 +128,7 @@ class CassandraSnapshots[F[_]: Async, T](
     session.executeStream(boundStatement).first.flatMap {
       case None => none[Stored[KafkaSnapshot[T]]].pure[F]
       case Some(row) =>
-        decode(row).map {
+        decode(row, key.topicPartition.topic).map {
           case Some(snapshot) => Stored.Live(snapshot, snapshot.offset.some).some
           case None           => Stored.Tombstone(row.decode[Offset]("offset")).some
         }
@@ -287,11 +289,14 @@ object CassandraSnapshots {
   // we cannot use DecodeRow here because Code[T].decode is effectful.
   // A null `value` is a logical tombstone (a compare-and-set delete, see Statements.prepareDelete): the row is kept so
   // its `offset` keeps guarding against a stale lower-offset writer, but the key reads back as absent.
-  protected def decode[F[_]: Monad, T](row: Row)(implicit fromBytes: FromBytes[F, T]): F[Option[KafkaSnapshot[T]]] =
+  protected def decode[F[_]: Monad, T](row: Row, topic: Topic)(
+    implicit fromBytes: FromBytes[F, T]
+  ): F[Option[KafkaSnapshot[T]]] =
     row.decode[Option[ByteVector]]("value") match {
-      case None => none[KafkaSnapshot[T]].pure[F]
+      case None        => none[KafkaSnapshot[T]].pure[F]
       case Some(value) =>
-        fromBytes.apply(value.toArray, "").map { value =>
+        // deserialize with the snapshot's topic, symmetric with `persist`/`bindPersist` which serialize with it
+        fromBytes.apply(value.toArray, topic).map { value =>
           KafkaSnapshot[T](
             offset   = row.decode[Offset]("offset"),
             metadata = row.decode[String]("metadata"),

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/CassandraSnapshots.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/CassandraSnapshots.scala
@@ -87,8 +87,8 @@ class CassandraSnapshots[F[_]: Async, T](
     session.execute(boundStatement.withConsistencyLevel(consistencyOverrides.write)).map(_.one())
 
   /** Interprets a conditional-write (lightweight transaction) result: unit if it applied, [[SnapshotWriteConflict]] if
-    * a newer stored offset rejected it, or runs `onAbsent` when the row is absent (no `offset` in the result) - the
-    * first-write path inserts there, and its retry treats a still-absent row as a (spurious) conflict.
+    * a newer stored offset rejected it, or `onAbsent` when the row is absent (no `offset` in the result) - the only
+    * branch that differs between persist (first-write insert, then retry) and delete (idempotent no-op).
     */
   private def resolveConditional(key: KafkaKey, row: Row, attemptedOffset: Offset)(onAbsent: => F[Unit]): F[Unit] =
     if (row.getBool("[applied]")) ().pure[F]
@@ -108,18 +108,31 @@ class CassandraSnapshots[F[_]: Async, T](
     val boundStatement =
       Statements.bindGet(getStatement, key).withConsistencyLevel(consistencyOverrides.read)
 
-    for {
-      row      <- session.executeStream(boundStatement).first
-      snapshot <- row.map(row => decode(row)).sequence
-    } yield snapshot
+    session.executeStream(boundStatement).first.flatMap(_.flatTraverse(row => decode(row)))
   }
 
-  // persist-only mode: a delete is an ordinary last-write-wins DELETE (the offset guard protects persists, not
-  // deletes). Gating deletes on an offset is out of scope here (it would need a delete(key, offset) signature).
-  def delete(key: KafkaKey): F[Unit] = {
+  def delete(key: KafkaKey, offset: Offset): F[Unit] =
+    writeMode match {
+      case WriteMode.LastWriteWins    => deleteUnconditional(key)
+      case WriteMode.CompareAndSet(_) => deleteCompareAndSet(key, offset)
+    }
+
+  private def deleteUnconditional(key: KafkaKey): F[Unit] = {
     val boundStatement = Statements.bindDelete(deleteStatement, key).withConsistencyLevel(consistencyOverrides.write)
     session.execute(boundStatement).void
   }
+
+  /** Deletes via an offset-gated logical tombstone (see [[Statements.prepareDelete]]); `get` reads it back as `None`.
+    *
+    * A not-applied result is a benign no-op when the row is absent (an at-least-once replay, or a key never persisted)
+    * and is reported as success; a not-applied result with a higher stored offset means a newer writer owns the key,
+    * raised as [[SnapshotWriteConflict]] as in [[persistCompareAndSet]].
+    */
+  private def deleteCompareAndSet(key: KafkaKey, offset: Offset): F[Unit] =
+    executeWrite(Statements.bindDelete(deleteStatement, key, offset)).flatMap { row =>
+      // an absent row means an earlier delete (possibly this one, replayed) already removed it: idempotent no-op
+      resolveConditional(key, row, offset)(().pure[F])
+    }
 
 }
 
@@ -164,10 +177,11 @@ object CassandraSnapshots {
     * @param ttl
     *   optional TTL to set on inserted records
     * @param compareAndSet
-    *   if `true`, each snapshot *persist* is a Cassandra lightweight transaction asserting the stored offset is not
-    *   greater than the new one, protecting from stale writers; a rejected write fails with [[SnapshotWriteConflict]].
-    *   Deletes remain ordinary last-write-wins (gating deletes on an offset is out of scope for this mode). See the
-    *   persistence docs' "Protecting against stale snapshot writes" for limitations and costs. Default `false`.
+    *   if `true`, each snapshot write is a Cassandra lightweight transaction asserting the stored offset is not greater
+    *   than the new one, protecting from stale writers; a rejected write fails with [[SnapshotWriteConflict]]. In this
+    *   mode a delete keeps the row as an offset-carrying logical tombstone (see [[Statements.prepareDelete]]) reaped
+    *   only by `ttl`, so set `ttl` to bound the table and Paxos partition growth. See the persistence docs' "Protecting
+    *   against stale snapshot writes" for limitations and costs. Default `false` (last write wins).
     * @param fromBytes
     *   deserializer function to convert array of bytes to the snapshot type T
     * @param toBytes
@@ -228,7 +242,7 @@ object CassandraSnapshots {
       _                <- snapshotSchema.create
       getStatement     <- Statements.prepareGet(session, tableName)
       persistStatement <- Statements.preparePersist(session, tableName, ttl, compareAndSet)
-      deleteStatement  <- Statements.prepareDelete(session, tableName)
+      deleteStatement  <- Statements.prepareDelete(session, tableName, ttl, compareAndSet = compareAndSet)
       writeMode <-
         if (compareAndSet)
           Statements.prepareInsertIfNotExists(session, tableName, ttl).map(WriteMode.CompareAndSet(_): WriteMode)
@@ -248,17 +262,21 @@ object CassandraSnapshots {
     tableName: String = DefaultTableName,
   ): F[Unit] = SnapshotSchema.of(session, sync, tableName).truncate
 
-  // we cannot use DecodeRow here because Code[T].decode is effectful
-  protected def decode[F[_]: Monad, T](row: Row)(implicit fromBytes: FromBytes[F, T]): F[KafkaSnapshot[T]] = {
-    val value = row.decode[ByteVector]("value")
-    fromBytes.apply(value.toArray, "").map { value =>
-      KafkaSnapshot[T](
-        offset   = row.decode[Offset]("offset"),
-        metadata = row.decode[String]("metadata"),
-        value    = value
-      )
+  // we cannot use DecodeRow here because Code[T].decode is effectful.
+  // A null `value` is a logical tombstone (a compare-and-set delete, see Statements.prepareDelete): the row is kept so
+  // its `offset` keeps guarding against a stale lower-offset writer, but the key reads back as absent.
+  protected def decode[F[_]: Monad, T](row: Row)(implicit fromBytes: FromBytes[F, T]): F[Option[KafkaSnapshot[T]]] =
+    row.decode[Option[ByteVector]]("value") match {
+      case None => none[KafkaSnapshot[T]].pure[F]
+      case Some(value) =>
+        fromBytes.apply(value.toArray, "").map { value =>
+          KafkaSnapshot[T](
+            offset   = row.decode[Offset]("offset"),
+            metadata = row.decode[String]("metadata"),
+            value    = value
+          ).some
+        }
     }
-  }
 
   protected object Statements {
 
@@ -381,9 +399,36 @@ object CassandraSnapshots {
         .encode("partition", key.topicPartition.partition)
         .encode("key", key.key)
 
-    def prepareDelete[F[_]](session: CassandraSession[F], tableName: String): F[PreparedStatement] =
-      session
-        .prepare(
+    /** In compare-and-set mode the delete is an offset-carrying logical tombstone: `UPDATE ... SET value = null`
+      * keeping the row's `offset`, gated by `IF offset <= :offset`. Keeping the row preserves the `offset` guard across
+      * the delete (so a stale writer cannot resurrect the key at a lower offset) and forces the delete through the
+      * Paxos path (mixing lightweight transactions and regular mutations on the same row is not safe in Cassandra). The
+      * tombstone is reaped by the TTL, if configured. In last-write-wins mode the delete is an ordinary `DELETE`.
+      */
+    def prepareDelete[F[_]](
+      session: CassandraSession[F],
+      tableName: String,
+      ttl: Option[FiniteDuration],
+      compareAndSet: Boolean = false,
+    ): F[PreparedStatement] =
+      session.prepare(
+        if (compareAndSet)
+          s"""
+             |UPDATE
+             |  $tableName
+             |  ${StatementHelper.ttlFragment(ttl)}
+             |SET
+             |  value = null,
+             |  offset = :offset
+             |WHERE
+             |  application_id = :application_id
+             |  AND group_id = :group_id
+             |  AND topic = :topic
+             |  AND partition = :partition
+             |  AND key = :key
+             |  IF offset <= :offset
+          """.stripMargin
+        else
           s"""
              |DELETE FROM
              |  $tableName
@@ -393,8 +438,8 @@ object CassandraSnapshots {
              |  AND topic = :topic
              |  AND partition = :partition
              |  AND key = :key
-        """.stripMargin
-        )
+          """.stripMargin
+      )
 
     def bindDelete(statement: PreparedStatement, key: KafkaKey): BoundStatement =
       statement
@@ -404,5 +449,9 @@ object CassandraSnapshots {
         .encode("topic", key.topicPartition.topic)
         .encode("partition", key.topicPartition.partition)
         .encode("key", key.key)
+
+    /** Binds the delete for compare-and-set mode, adding the `:offset` the `IF offset <= :offset` guard checks. */
+    def bindDelete(statement: PreparedStatement, key: KafkaKey, offset: Offset): BoundStatement =
+      bindDelete(statement, key).encode("offset", offset)
   }
 }

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/CassandraSnapshots.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/CassandraSnapshots.scala
@@ -13,27 +13,112 @@ import com.evolutiongaming.kafka.flow.cassandra.StatementHelper.StatementOps
 import com.evolutiongaming.scassandra.CassandraSession
 import com.evolutiongaming.scassandra.StreamingCassandraSession.*
 import com.evolutiongaming.scassandra.syntax.*
-import com.evolutiongaming.skafka.{FromBytes, Offset, ToBytes}
+import com.evolutiongaming.skafka.{Bytes, FromBytes, Offset, ToBytes}
 import scodec.bits.ByteVector
 import CassandraSnapshots.*
 
+import java.time.Instant
 import scala.concurrent.duration.FiniteDuration
+import scala.util.control.NoStackTrace
 
+/** Cassandra-backed implementation of `SnapshotDatabase`.
+  *
+  * In `WriteMode.CompareAndSet` mode a snapshot is persisted only if the stored snapshot's offset is not greater than
+  * the offset of the new snapshot. See [[CassandraSnapshots.withSchema]] for details.
+  */
 class CassandraSnapshots[F[_]: Async, T](
   session: CassandraSession[F],
   getStatement: PreparedStatement,
   persistStatement: PreparedStatement,
   deleteStatement: PreparedStatement,
   consistencyOverrides: ConsistencyOverrides = ConsistencyOverrides.none,
+  writeMode: WriteMode                       = WriteMode.LastWriteWins,
 )(implicit fromBytes: FromBytes[F, T], toBytes: ToBytes[F, T])
     extends SnapshotDatabase[F, KafkaKey, KafkaSnapshot[T]] {
 
   def persist(key: KafkaKey, snapshot: KafkaSnapshot[T]): F[Unit] =
+    writeMode match {
+      case WriteMode.LastWriteWins                 => persistUnconditional(key, snapshot)
+      case WriteMode.CompareAndSet(insert, repair) => persistCompareAndSet(insert, repair, key, snapshot)
+    }
+
+  private def persistUnconditional(key: KafkaKey, snapshot: KafkaSnapshot[T]): F[Unit] =
     for {
       boundStatement <- Statements.bindPersist(persistStatement, key, snapshot)
       statement       = boundStatement.withConsistencyLevel(consistencyOverrides.write)
       _              <- session.execute(statement).void
     } yield ()
+
+  /** Persists the snapshot only if the stored one is not newer.
+    *
+    * The conditional update is not applied when the stored row has a higher offset (a concurrent writer persisted a
+    * newer snapshot) or when the row does not exist yet. The latter is retried as `INSERT ... IF NOT EXISTS`; if that
+    * loses to a concurrent insert, the conditional update is retried once, so the writer with the newest snapshot wins
+    * a first-write race. A row whose `offset` guard cell has expired (a TTL reconfiguration artefact, see
+    * `Statements.prepareRepairPersist`) is repaired through an `IF offset = null` write - without it the key would
+    * conflict forever: the null guard fails the conditional update, and `INSERT ... IF NOT EXISTS` loses to the
+    * still-visible row.
+    */
+  private def persistCompareAndSet(
+    insertStatement: PreparedStatement,
+    repairStatement: PreparedStatement,
+    key: KafkaKey,
+    snapshot: KafkaSnapshot[T],
+  ): F[Unit] =
+    for {
+      created <- Clock[F].instant
+      value   <- toBytes.apply(snapshot.value, key.topicPartition.topic)
+      bind     = (statement: PreparedStatement) => Statements.bindPersist(statement, key, snapshot, created, value)
+      // claims a guard-expired row (null `offset`): applies only while the guard is still gone, so a raced
+      // repair serializes via Paxos - the loser resolves to a plain conflict and the flow recovers as usual
+      repair = executeWrite(bind(repairStatement)).flatMap { repairRow =>
+        val conflict = SnapshotWriteConflict(key, snapshot.offset, none).raiseError[F, Unit]
+        resolveConditional(key, repairRow, snapshot.offset)(onAbsent = conflict, onGuardExpired = conflict)
+      }
+      updateRow <- executeWrite(bind(persistStatement))
+      _ <- resolveConditional(key, updateRow, snapshot.offset)(
+        // the row does not exist yet: first write for the key
+        onAbsent = executeWrite(bind(insertStatement)).flatMap { insertRow =>
+          if (insertRow.getBool("[applied]")) ().pure[F]
+          else
+            // lost the insert race to a concurrent writer: retry the conditional update once
+            executeWrite(bind(persistStatement)).flatMap { retryRow =>
+              // a row deleted between the insert and the retry surfaces as a (spurious) conflict; the flow
+              // recovers from it on the next flush
+              resolveConditional(key, retryRow, snapshot.offset)(
+                onAbsent       = SnapshotWriteConflict(key, snapshot.offset, none).raiseError[F, Unit],
+                onGuardExpired = repair,
+              )
+            }
+        },
+        onGuardExpired = repair,
+      )
+    } yield ()
+
+  private def executeWrite(boundStatement: BoundStatement): F[Row] =
+    session.execute(boundStatement.withConsistencyLevel(consistencyOverrides.write)).map(_.one())
+
+  /** Interprets a conditional-write (lightweight transaction) result: unit if it applied, [[SnapshotWriteConflict]] if
+    * a newer stored offset rejected it, `onGuardExpired` when the row exists but its `offset` guard cell is null
+    * (Cassandra returns the condition column - with a null value - exactly when the row exists; an absent row's result
+    * carries no such column), or `onAbsent` when the row is absent - the first-write path inserts there, and its retry
+    * treats a still-absent row as a (spurious) conflict.
+    */
+  private def resolveConditional(
+    key: KafkaKey,
+    row: Row,
+    attemptedOffset: Offset,
+  )(onAbsent: => F[Unit], onGuardExpired: => F[Unit]): F[Unit] =
+    if (row.getBool("[applied]")) ().pure[F]
+    else if (row.getColumnDefinitions.contains("offset"))
+      row.decode[Option[Offset]]("offset") match {
+        // the stored snapshot is newer: this writer is stale
+        case Some(persistedOffset) =>
+          SnapshotWriteConflict(key, attemptedOffset, persistedOffset.some).raiseError[F, Unit]
+        // the row exists but its offset cell expired (a TTL reconfiguration artefact): the guard is gone
+        case None => onGuardExpired
+      }
+    else onAbsent
 
   def get(key: KafkaKey): F[Option[KafkaSnapshot[T]]] = {
     val boundStatement =
@@ -41,10 +126,12 @@ class CassandraSnapshots[F[_]: Async, T](
 
     for {
       row      <- session.executeStream(boundStatement).first
-      snapshot <- row.map(row => decode(row)).sequence
+      snapshot <- row.flatTraverse(row => decode(row))
     } yield snapshot
   }
 
+  // persist-only mode: a delete is an ordinary last-write-wins DELETE (the offset guard protects persists, not
+  // deletes). Gating deletes on an offset is out of scope here (it would need a delete(key, offset) signature).
   def delete(key: KafkaKey): F[Unit] = {
     val boundStatement = Statements.bindDelete(deleteStatement, key).withConsistencyLevel(consistencyOverrides.write)
     session.execute(boundStatement).void
@@ -55,6 +142,32 @@ class CassandraSnapshots[F[_]: Async, T](
 object CassandraSnapshots {
 
   val DefaultTableName = "snapshots_v2"
+
+  /** How a snapshot write is performed. `WriteMode.CompareAndSet` carries the extra statements used for the first write
+    * of a key and for repairing an expired guard, so they exist exactly when the database is in compare-and-set of a
+    * key, so the insert statement exists exactly when the database is in compare-and-set mode.
+    */
+  sealed trait WriteMode
+  object WriteMode {
+    case object LastWriteWins extends WriteMode
+    final case class CompareAndSet(insertStatement: PreparedStatement, repairStatement: PreparedStatement)
+        extends WriteMode
+  }
+
+  /** Raised in compare-and-set mode (see [[CassandraSnapshots.withSchema]]) when the store already contains a newer
+    * snapshot for the key - another writer (likely the new partition owner after a rebalance) persisted in parallel, so
+    * this writer is stale. `persistedOffset` is the stored offset, if it could be determined.
+    */
+  final case class SnapshotWriteConflict(
+    key: KafkaKey,
+    attemptedOffset: Offset,
+    persistedOffset: Option[Offset],
+  ) extends RuntimeException(
+        s"snapshot write conflict for key $key: attempted to write with offset $attemptedOffset " +
+          s"while the store contains offset ${persistedOffset.fold("unknown")(_.toString)}, " +
+          "another writer is likely owning the key now"
+      )
+      with NoStackTrace
 
   /** Create table for storing snapshots. If table already exists it will not be recreated.
     *
@@ -68,6 +181,11 @@ object CassandraSnapshots {
     *   name of the table to create. The default value is "snapshots_v2"
     * @param ttl
     *   optional TTL to set on inserted records
+    * @param compareAndSet
+    *   if `true`, each snapshot *persist* is a Cassandra lightweight transaction asserting the stored offset is not
+    *   greater than the new one, protecting from stale writers; a rejected write fails with [[SnapshotWriteConflict]].
+    *   Deletes remain ordinary last-write-wins (gating deletes on an offset is out of scope for this mode). See the
+    *   persistence docs' "Protecting against stale snapshot writes" for limitations and costs. Default `false`.
     * @param fromBytes
     *   deserializer function to convert array of bytes to the snapshot type T
     * @param toBytes
@@ -79,11 +197,19 @@ object CassandraSnapshots {
     consistencyOverrides: ConsistencyOverrides = ConsistencyOverrides.none,
     tableName: String                          = DefaultTableName,
     ttl: Option[FiniteDuration]                = None,
+    compareAndSet: Boolean                     = false,
   )(
     implicit fromBytes: FromBytes[F, T],
     toBytes: ToBytes[F, T]
   ): F[SnapshotDatabase[F, KafkaKey, KafkaSnapshot[T]]] =
-    withCustomSchema(SnapshotSchema.of(session, sync, tableName), session, consistencyOverrides, tableName, ttl)
+    withCustomSchema(
+      SnapshotSchema.of(session, sync, tableName),
+      session,
+      consistencyOverrides,
+      tableName,
+      ttl,
+      compareAndSet
+    )
 
   /** Create table with a user defined schema for storing snapshots. If table already exists it will not be recreated.
     * Note that the table schema must be compatible with predefined queries for storing and retrieving snapshots data.
@@ -98,6 +224,8 @@ object CassandraSnapshots {
     *   name of the table to create. The default value is "snapshots_v2"
     * @param ttl
     *   optional TTL to set on inserted records
+    * @param compareAndSet
+    *   enables conditional writes protecting from stale writers, see [[CassandraSnapshots.withSchema]]
     * @param fromBytes
     *   deserializer function to convert array of bytes to the snapshot type T
     * @param toBytes
@@ -109,6 +237,7 @@ object CassandraSnapshots {
     consistencyOverrides: ConsistencyOverrides = ConsistencyOverrides.none,
     tableName: String                          = DefaultTableName,
     ttl: Option[FiniteDuration]                = None,
+    compareAndSet: Boolean                     = false,
   )(
     implicit fromBytes: FromBytes[F, T],
     toBytes: ToBytes[F, T]
@@ -116,14 +245,22 @@ object CassandraSnapshots {
     for {
       _                <- snapshotSchema.create
       getStatement     <- Statements.prepareGet(session, tableName)
-      persistStatement <- Statements.preparePersist(session, tableName, ttl)
+      persistStatement <- Statements.preparePersist(session, tableName, ttl, compareAndSet)
       deleteStatement  <- Statements.prepareDelete(session, tableName)
+      writeMode <-
+        if (compareAndSet)
+          for {
+            insert <- Statements.prepareInsertIfNotExists(session, tableName, ttl)
+            repair <- Statements.prepareRepairPersist(session, tableName, ttl)
+          } yield WriteMode.CompareAndSet(insert, repair): WriteMode
+        else (WriteMode.LastWriteWins: WriteMode).pure[F]
     } yield new CassandraSnapshots(
       session              = session,
       getStatement         = getStatement,
       persistStatement     = persistStatement,
       deleteStatement      = deleteStatement,
       consistencyOverrides = consistencyOverrides,
+      writeMode            = writeMode,
     )
 
   def truncate[F[_]: Monad](
@@ -133,16 +270,21 @@ object CassandraSnapshots {
   ): F[Unit] = SnapshotSchema.of(session, sync, tableName).truncate
 
   // we cannot use DecodeRow here because Code[T].decode is effectful
-  protected def decode[F[_]: Monad, T](row: Row)(implicit fromBytes: FromBytes[F, T]): F[KafkaSnapshot[T]] = {
-    val value = row.decode[ByteVector]("value")
-    fromBytes.apply(value.toArray, "").map { value =>
-      KafkaSnapshot[T](
-        offset   = row.decode[Offset]("offset"),
-        metadata = row.decode[String]("metadata"),
-        value    = value
-      )
+  // a visible row can carry a null `value`: its cell expired while older cells or the first write's row marker keep
+  // the row alive (the guard-expired row, see Statements.prepareRepairPersist). Nothing distinguishes it from a
+  // reaped key, so it reads as absent - decoding it non-optionally would instead fail every recovery of the key.
+  protected def decode[F[_]: Monad, T](row: Row)(implicit fromBytes: FromBytes[F, T]): F[Option[KafkaSnapshot[T]]] =
+    row.decode[Option[ByteVector]]("value") match {
+      case None => none[KafkaSnapshot[T]].pure[F]
+      case Some(value) =>
+        fromBytes.apply(value.toArray, "").map { value =>
+          KafkaSnapshot[T](
+            offset   = row.decode[Offset]("offset"),
+            metadata = row.decode[String]("metadata"),
+            value    = value
+          ).some
+        }
     }
-  }
 
   protected object Statements {
 
@@ -150,23 +292,82 @@ object CassandraSnapshots {
       session: CassandraSession[F],
       tableName: String,
       ttl: Option[FiniteDuration],
+      compareAndSet: Boolean = false,
+    ): F[PreparedStatement] =
+      session.prepare(persistCql(tableName, ttl, condition = if (compareAndSet) "IF offset <= :offset" else ""))
+
+    /** Used in compare-and-set mode to repair a row whose `offset` guard cell has expired while other cells (or the
+      * first write's `INSERT` row marker, immortal only when that first write ran without a `ttl` and the table has no
+      * `default_time_to_live`) keep the row visible. Cassandra TTLs are per cell, so the state arises when the `ttl` is
+      * enabled or shortened between writes of a key - e.g. a no-TTL deployment's first write (immortal row marker)
+      * followed by TTL'd persists that have since expired. Such a row fences nothing, and the regular conditional write
+      * can never claim it (the null guard fails `IF offset <= :offset`, and `INSERT ... IF NOT EXISTS` loses to the
+      * still-visible row - without this statement the key would conflict forever). `IF offset = null` claims exactly
+      * that state through Paxos: racing writers serialize, the loser sees a live offset and conflicts. The repair
+      * re-arms the guard but (being an `UPDATE`) cannot remove an immortal marker, so such a row re-poisons after each
+      * `ttl` until an owner deletes/reaps it - palliative, not curative. (`get` already reads such a row as absent -
+      * its `value` cell is expired - and a plain delete removes it entirely, so the read and delete paths need no
+      * counterpart.)
+      */
+    def prepareRepairPersist[F[_]](
+      session: CassandraSession[F],
+      tableName: String,
+      ttl: Option[FiniteDuration],
+    ): F[PreparedStatement] =
+      session.prepare(persistCql(tableName, ttl, condition = "IF offset = null"))
+
+    private def persistCql(tableName: String, ttl: Option[FiniteDuration], condition: String): String =
+      s"""
+         |UPDATE
+         |  $tableName
+         |  ${StatementHelper.ttlFragment(ttl)}
+         |SET
+         |  created = :created,
+         |  metadata = :metadata,
+         |  value = :value,
+         |  offset = :offset
+         |WHERE
+         |  application_id = :application_id
+         |  AND group_id = :group_id
+         |  AND topic = :topic
+         |  AND partition = :partition
+         |  AND key = :key
+         |  $condition
+        """.stripMargin
+
+    /** Used in compare-and-set mode for the first write of a key, when the conditional update of `preparePersist`
+      * cannot be applied because the row does not exist yet.
+      */
+    def prepareInsertIfNotExists[F[_]](
+      session: CassandraSession[F],
+      tableName: String,
+      ttl: Option[FiniteDuration],
     ): F[PreparedStatement] =
       session.prepare(
         s"""
-           |UPDATE
-           |  $tableName
-           |  ${StatementHelper.ttlFragment(ttl)}
-           |SET
-           |  created = :created,
-           |  metadata = :metadata,
-           |  value = :value,
-           |  offset = :offset
-           |WHERE
-           |  application_id = :application_id
-           |  AND group_id = :group_id
-           |  AND topic = :topic
-           |  AND partition = :partition
-           |  AND key = :key
+           |INSERT INTO $tableName (
+           |  application_id,
+           |  group_id,
+           |  topic,
+           |  partition,
+           |  key,
+           |  created,
+           |  metadata,
+           |  value,
+           |  offset
+           |) VALUES (
+           |  :application_id,
+           |  :group_id,
+           |  :topic,
+           |  :partition,
+           |  :key,
+           |  :created,
+           |  :metadata,
+           |  :value,
+           |  :offset
+           |)
+           |IF NOT EXISTS
+           |${StatementHelper.ttlFragment(ttl)}
         """.stripMargin
       )
 
@@ -178,19 +379,26 @@ object CassandraSnapshots {
       for {
         created <- Clock[F].instant
         value   <- toBytes.apply(snapshot.value, key.topicPartition.topic)
-      } yield {
-        statement
-          .bind()
-          .encode("application_id", key.applicationId)
-          .encode("group_id", key.groupId)
-          .encode("topic", key.topicPartition.topic)
-          .encode("partition", key.topicPartition.partition)
-          .encode("key", key.key)
-          .encode("offset", snapshot.offset)
-          .encode("created", created)
-          .encode("metadata", snapshot.metadata)
-          .encode("value", value)
-      }
+      } yield bindPersist(statement, key, snapshot, created, value)
+
+    def bindPersist[T](
+      statement: PreparedStatement,
+      key: KafkaKey,
+      snapshot: KafkaSnapshot[T],
+      created: Instant,
+      value: Bytes,
+    ): BoundStatement =
+      statement
+        .bind()
+        .encode("application_id", key.applicationId)
+        .encode("group_id", key.groupId)
+        .encode("topic", key.topicPartition.topic)
+        .encode("partition", key.topicPartition.partition)
+        .encode("key", key.key)
+        .encode("offset", snapshot.offset)
+        .encode("created", created)
+        .encode("metadata", snapshot.metadata)
+        .encode("value", value)
 
     def prepareGet[F[_]](session: CassandraSession[F], tableName: String): F[PreparedStatement] =
       session

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/CassandraSnapshots.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/CassandraSnapshots.scala
@@ -1,6 +1,6 @@
 package com.evolutiongaming.kafka.flow.snapshot
 
-import cats.Monad
+import cats.{Functor, Monad}
 import cats.effect.{Async, Clock}
 import cats.syntax.all.*
 import com.datastax.driver.core.{BoundStatement, PreparedStatement, Row}
@@ -109,6 +109,26 @@ class CassandraSnapshots[F[_]: Async, T](
       Statements.bindGet(getStatement, key).withConsistencyLevel(consistencyOverrides.read)
 
     session.executeStream(boundStatement).first.flatMap(_.flatTraverse(row => decode(row)))
+  }
+
+  /** Surfaces a tombstone's offset as the replay-window floor. A present row decodes to [[Recovered.Present]]; a
+    * tombstone (null `value`, kept by [[deleteCompareAndSet]]) decodes to [[Recovered.Deleted]] carrying the stored
+    * offset, even though [[get]] reads it back as absent; no row is [[Recovered.Absent]]. Without this a deleted key
+    * recovers with no floor and a legitimate owner re-persisting below the tombstone's offset self-fences (a livelock);
+    * see `docs/cassandra-single-writer-design.md`.
+    */
+  override def recover(key: KafkaKey)(implicit F: Functor[F]): F[Recovered[KafkaSnapshot[T]]] = {
+    val boundStatement =
+      Statements.bindGet(getStatement, key).withConsistencyLevel(consistencyOverrides.read)
+
+    session.executeStream(boundStatement).first.flatMap {
+      case None => (Recovered.Absent: Recovered[KafkaSnapshot[T]]).pure[F]
+      case Some(row) =>
+        decode(row).map {
+          case Some(snapshot) => Recovered.Present(snapshot)
+          case None           => Recovered.Deleted(row.decode[Offset]("offset"))
+        }
+    }
   }
 
   def delete(key: KafkaKey, offset: Offset): F[Unit] =

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/CassandraSnapshots.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/CassandraSnapshots.scala
@@ -13,7 +13,7 @@ import com.evolutiongaming.kafka.flow.cassandra.StatementHelper.StatementOps
 import com.evolutiongaming.scassandra.CassandraSession
 import com.evolutiongaming.scassandra.StreamingCassandraSession.*
 import com.evolutiongaming.scassandra.syntax.*
-import com.evolutiongaming.skafka.{Bytes, FromBytes, Offset, ToBytes}
+import com.evolutiongaming.skafka.{Bytes, FromBytes, Offset, ToBytes, Topic}
 import scodec.bits.ByteVector
 import CassandraSnapshots.*
 
@@ -36,10 +36,19 @@ class CassandraSnapshots[F[_]: Async, T](
 )(implicit fromBytes: FromBytes[F, T], toBytes: ToBytes[F, T])
     extends SnapshotDatabase[F, KafkaKey, KafkaSnapshot[T]] {
 
-  def persist(key: KafkaKey, snapshot: KafkaSnapshot[T]): F[Unit] =
+  /** Routes a `Stored` write: a present value persists a snapshot, an absent value writes a tombstone (delete). A
+    * compare-and-set store gates both on `stored.offset` (always set on the fenced buffer path); see `Snapshots`.
+    */
+  def write(key: KafkaKey, stored: Stored[KafkaSnapshot[T]]): F[Unit] =
+    stored match {
+      case Stored.Live(snapshot, _) => persist(key, snapshot)
+      case Stored.Tombstone(at)     => delete(key, at)
+    }
+
+  private def persist(key: KafkaKey, snapshot: KafkaSnapshot[T]): F[Unit] =
     writeMode match {
-      case WriteMode.LastWriteWins                 => persistUnconditional(key, snapshot)
-      case WriteMode.CompareAndSet(insert, repair) => persistCompareAndSet(insert, repair, key, snapshot)
+      case WriteMode.LastWriteWins                    => persistUnconditional(key, snapshot)
+      case WriteMode.CompareAndSet(insert, repair, _) => persistCompareAndSet(insert, repair, key, snapshot)
     }
 
   private def persistUnconditional(key: KafkaKey, snapshot: KafkaSnapshot[T]): F[Unit] =
@@ -83,8 +92,10 @@ class CassandraSnapshots[F[_]: Async, T](
           else
             // lost the insert race to a concurrent writer: retry the conditional update once
             executeWrite(bind(persistStatement)).flatMap { retryRow =>
-              // a row deleted between the insert and the retry surfaces as a (spurious) conflict; the flow
-              // recovers from it on the next flush
+              // a row deleted between the insert and the retry surfaces as a (spurious) conflict that fails this
+              // flow; the partition's next owner re-recovers and the write succeeds once the row is observed again.
+              // Effectively unreachable in pure compare-and-set mode, where a delete keeps the row as a tombstone -
+              // only a whole-row TTL reap in this narrow window removes it.
               resolveConditional(key, retryRow, snapshot.offset)(
                 onAbsent       = SnapshotWriteConflict(key, snapshot.offset, none).raiseError[F, Unit],
                 onGuardExpired = repair,
@@ -101,8 +112,8 @@ class CassandraSnapshots[F[_]: Async, T](
   /** Interprets a conditional-write (lightweight transaction) result: unit if it applied, [[SnapshotWriteConflict]] if
     * a newer stored offset rejected it, `onGuardExpired` when the row exists but its `offset` guard cell is null
     * (Cassandra returns the condition column - with a null value - exactly when the row exists; an absent row's result
-    * carries no such column), or `onAbsent` when the row is absent - the first-write path inserts there, and its retry
-    * treats a still-absent row as a (spurious) conflict.
+    * carries no such column), or `onAbsent` when the row is absent. The two callbacks are where persist (first-write
+    * insert / repair) and delete (idempotent no-ops) differ.
     */
   private def resolveConditional(
     key: KafkaKey,
@@ -120,22 +131,74 @@ class CassandraSnapshots[F[_]: Async, T](
       }
     else onAbsent
 
-  def get(key: KafkaKey): F[Option[KafkaSnapshot[T]]] = {
+  /** Recovers the stored unit, surfacing a tombstone's offset as the replay-window floor. A present row reads back as
+    * `Some(Stored.Live(snapshot, offset))`; a tombstone (null `value`, kept by `deleteCompareAndSet`) as
+    * `Some(Stored.Tombstone(offset))` carrying the stored offset even though the value is absent; no row as `None`.
+    * Without the tombstone's offset a deleted key recovers with no floor and a legitimate owner re-persisting below it
+    * self-fences (a livelock); see `docs/cassandra-single-writer-design.md`.
+    *
+    * A tombstone whose `offset` cell has itself expired (a TTL reconfiguration artefact, see
+    * `Statements.prepareRepairPersist`) carries no guard and no floor - it is reported as absent, exactly like a fully
+    * reaped row. (Decoding it as an offset would silently read the null as 0 - a floor of `Offset.min`, i.e. none,
+    * while implying one exists.) A *live* row cannot have a null `offset`: every persist rewrites all cells with one
+    * TTL; only the delete writes a subset.
+    */
+  def read(key: KafkaKey): F[Option[Stored[KafkaSnapshot[T]]]] = {
     val boundStatement =
       Statements.bindGet(getStatement, key).withConsistencyLevel(consistencyOverrides.read)
 
-    for {
-      row      <- session.executeStream(boundStatement).first
-      snapshot <- row.flatTraverse(row => decode(row))
-    } yield snapshot
+    session.executeStream(boundStatement).first.flatMap {
+      case None => none[Stored[KafkaSnapshot[T]]].pure[F]
+      case Some(row) =>
+        decode(row, key.topicPartition.topic).map {
+          case Some(snapshot) => Stored.Live(snapshot, snapshot.offset.some).some
+          case None           => row.decode[Option[Offset]]("offset").map(Stored.Tombstone(_))
+        }
+    }
   }
 
-  // persist-only mode: a delete is an ordinary last-write-wins DELETE (the offset guard protects persists, not
-  // deletes). Gating deletes on an offset is out of scope here (it would need a delete(key, offset) signature).
-  def delete(key: KafkaKey): F[Unit] = {
+  private def delete(key: KafkaKey, offset: Offset): F[Unit] =
+    writeMode match {
+      case WriteMode.LastWriteWins                        => deleteUnconditional(key)
+      case WriteMode.CompareAndSet(_, _, tombstoneInsert) => deleteCompareAndSet(tombstoneInsert, key, offset)
+    }
+
+  private def deleteUnconditional(key: KafkaKey): F[Unit] = {
     val boundStatement = Statements.bindDelete(deleteStatement, key).withConsistencyLevel(consistencyOverrides.write)
     session.execute(boundStatement).void
   }
+
+  /** Deletes via an offset-gated logical tombstone (see `Statements.prepareDelete`); `read` surfaces it as a
+    * [[Stored.Tombstone]] carrying the offset.
+    *
+    * When the row is ABSENT the delete does not no-op: it INSERTs the offset-carrying tombstone `IF NOT EXISTS`,
+    * mirroring the persist first-write compound. A key created and deleted before it was ever durably persisted would
+    * otherwise leave no row at all while the consumer offset commits past the delete, so a revoked owner (zombie) still
+    * holding the key's buffered pre-delete snapshot could `INSERT ... IF NOT EXISTS` it back at a lower offset - gated
+    * only by this store's compare-and-set, not the consumer generation - durably resurrecting the deleted key,
+    * permanently (recovery resumes past the delete). Writing the tombstone puts the fence in place so that resurrecting
+    * insert loses. If the tombstone insert itself loses a first-write race, the offset-gated update is retried once: a
+    * newer writer then conflicts, an equal/older one is tombstoned.
+    *
+    * A not-applied update with a higher stored offset means a newer writer owns the key, raised as
+    * [[SnapshotWriteConflict]] as in [[persistCompareAndSet]]. An expired guard (null offset cell) reads back as absent
+    * and fences nothing, so deleting it is a no-op.
+    */
+  private def deleteCompareAndSet(tombstoneInsertStatement: PreparedStatement, key: KafkaKey, offset: Offset): F[Unit] =
+    executeWrite(Statements.bindDelete(deleteStatement, key, offset)).flatMap { row =>
+      resolveConditional(key, row, offset)(
+        onAbsent =
+          executeWrite(Statements.bindTombstoneInsert(tombstoneInsertStatement, key, offset)).flatMap { insertRow =>
+            if (insertRow.getBool("[applied]")) ().pure[F]
+            else
+              // lost the insert race to a concurrent writer: retry the conditional (offset-gated) delete once
+              executeWrite(Statements.bindDelete(deleteStatement, key, offset)).flatMap { retryRow =>
+                resolveConditional(key, retryRow, offset)(onAbsent = ().pure[F], onGuardExpired = ().pure[F])
+              }
+          },
+        onGuardExpired = ().pure[F],
+      )
+    }
 
 }
 
@@ -144,14 +207,17 @@ object CassandraSnapshots {
   val DefaultTableName = "snapshots_v2"
 
   /** How a snapshot write is performed. `WriteMode.CompareAndSet` carries the extra statements used for the first write
-    * of a key and for repairing an expired guard, so they exist exactly when the database is in compare-and-set of a
-    * key, so the insert statement exists exactly when the database is in compare-and-set mode.
+    * of a key (the persist `INSERT`, and the tombstone `INSERT` for a delete of a never-persisted key) and for
+    * repairing an expired guard, so they exist exactly when the database is in compare-and-set mode.
     */
   sealed trait WriteMode
   object WriteMode {
     case object LastWriteWins extends WriteMode
-    final case class CompareAndSet(insertStatement: PreparedStatement, repairStatement: PreparedStatement)
-        extends WriteMode
+    final case class CompareAndSet(
+      insertStatement: PreparedStatement,
+      repairStatement: PreparedStatement,
+      tombstoneInsertStatement: PreparedStatement,
+    ) extends WriteMode
   }
 
   /** Raised in compare-and-set mode (see [[CassandraSnapshots.withSchema]]) when the store already contains a newer
@@ -182,10 +248,11 @@ object CassandraSnapshots {
     * @param ttl
     *   optional TTL to set on inserted records
     * @param compareAndSet
-    *   if `true`, each snapshot *persist* is a Cassandra lightweight transaction asserting the stored offset is not
-    *   greater than the new one, protecting from stale writers; a rejected write fails with [[SnapshotWriteConflict]].
-    *   Deletes remain ordinary last-write-wins (gating deletes on an offset is out of scope for this mode). See the
-    *   persistence docs' "Protecting against stale snapshot writes" for limitations and costs. Default `false`.
+    *   if `true`, each snapshot write is a Cassandra lightweight transaction asserting the stored offset is not greater
+    *   than the new one, protecting from stale writers; a rejected write fails with [[SnapshotWriteConflict]]. In this
+    *   mode a delete keeps the row as an offset-carrying logical tombstone (see `Statements.prepareDelete`) reaped only
+    *   by `ttl`, so set `ttl` to bound the table and Paxos partition growth. See the persistence docs' "Protecting
+    *   against stale snapshot writes" for limitations and costs. Default `false` (last write wins).
     * @param fromBytes
     *   deserializer function to convert array of bytes to the snapshot type T
     * @param toBytes
@@ -246,13 +313,14 @@ object CassandraSnapshots {
       _                <- snapshotSchema.create
       getStatement     <- Statements.prepareGet(session, tableName)
       persistStatement <- Statements.preparePersist(session, tableName, ttl, compareAndSet)
-      deleteStatement  <- Statements.prepareDelete(session, tableName)
+      deleteStatement  <- Statements.prepareDelete(session, tableName, ttl, compareAndSet = compareAndSet)
       writeMode <-
         if (compareAndSet)
           for {
-            insert <- Statements.prepareInsertIfNotExists(session, tableName, ttl)
-            repair <- Statements.prepareRepairPersist(session, tableName, ttl)
-          } yield WriteMode.CompareAndSet(insert, repair): WriteMode
+            insert          <- Statements.prepareInsertIfNotExists(session, tableName, ttl)
+            repair          <- Statements.prepareRepairPersist(session, tableName, ttl)
+            tombstoneInsert <- Statements.prepareTombstoneInsertIfNotExists(session, tableName, ttl)
+          } yield WriteMode.CompareAndSet(insert, repair, tombstoneInsert): WriteMode
         else (WriteMode.LastWriteWins: WriteMode).pure[F]
     } yield new CassandraSnapshots(
       session              = session,
@@ -269,15 +337,17 @@ object CassandraSnapshots {
     tableName: String = DefaultTableName,
   ): F[Unit] = SnapshotSchema.of(session, sync, tableName).truncate
 
-  // we cannot use DecodeRow here because Code[T].decode is effectful
-  // a visible row can carry a null `value`: its cell expired while older cells or the first write's row marker keep
-  // the row alive (the guard-expired row, see Statements.prepareRepairPersist). Nothing distinguishes it from a
-  // reaped key, so it reads as absent - decoding it non-optionally would instead fail every recovery of the key.
-  protected def decode[F[_]: Monad, T](row: Row)(implicit fromBytes: FromBytes[F, T]): F[Option[KafkaSnapshot[T]]] =
+  // we cannot use DecodeRow here because Code[T].decode is effectful.
+  // A null `value` is a logical tombstone (a compare-and-set delete, see Statements.prepareDelete): the row is kept so
+  // its `offset` keeps guarding against a stale lower-offset writer, but the key reads back as absent.
+  protected def decode[F[_]: Monad, T](row: Row, topic: Topic)(
+    implicit fromBytes: FromBytes[F, T]
+  ): F[Option[KafkaSnapshot[T]]] =
     row.decode[Option[ByteVector]]("value") match {
-      case None => none[KafkaSnapshot[T]].pure[F]
+      case None        => none[KafkaSnapshot[T]].pure[F]
       case Some(value) =>
-        fromBytes.apply(value.toArray, "").map { value =>
+        // deserialize with the snapshot's topic, symmetric with `persist`/`bindPersist` which serialize with it
+        fromBytes.apply(value.toArray, topic).map { value =>
           KafkaSnapshot[T](
             offset   = row.decode[Offset]("offset"),
             metadata = row.decode[String]("metadata"),
@@ -298,16 +368,14 @@ object CassandraSnapshots {
 
     /** Used in compare-and-set mode to repair a row whose `offset` guard cell has expired while other cells (or the
       * first write's `INSERT` row marker, immortal only when that first write ran without a `ttl` and the table has no
-      * `default_time_to_live`) keep the row visible. Cassandra TTLs are per cell, so the state arises when the `ttl` is
-      * enabled or shortened between writes of a key - e.g. a no-TTL deployment's first write (immortal row marker)
-      * followed by TTL'd persists that have since expired. Such a row fences nothing, and the regular conditional write
-      * can never claim it (the null guard fails `IF offset <= :offset`, and `INSERT ... IF NOT EXISTS` loses to the
-      * still-visible row - without this statement the key would conflict forever). `IF offset = null` claims exactly
-      * that state through Paxos: racing writers serialize, the loser sees a live offset and conflicts. The repair
-      * re-arms the guard but (being an `UPDATE`) cannot remove an immortal marker, so such a row re-poisons after each
-      * `ttl` until an owner deletes/reaps it - palliative, not curative. (`get` already reads such a row as absent -
-      * its `value` cell is expired - and a plain delete removes it entirely, so the read and delete paths need no
-      * counterpart.)
+      * `default_time_to_live`) keep the row visible. Cassandra TTLs are per cell, and only the delete writes a subset
+      * of the columns, so the state arises when the `ttl` is enabled or shortened between a key's persist and its
+      * delete. Such a row fences nothing, and the regular conditional write can never claim it (the null guard fails
+      * `IF offset <= :offset`, and `INSERT ... IF NOT EXISTS` loses to the still-visible row - without this statement
+      * the key would conflict forever). `IF offset = null` claims exactly that state through Paxos: racing writers
+      * serialize, the loser sees a live offset and conflicts. The repair re-arms the guard but (being an `UPDATE`)
+      * cannot remove an immortal marker, so such a row re-poisons after each `ttl` until an owner deletes/reaps it -
+      * palliative, not curative.
       */
     def prepareRepairPersist[F[_]](
       session: CassandraSession[F],
@@ -371,6 +439,49 @@ object CassandraSnapshots {
         """.stripMargin
       )
 
+    /** Used in compare-and-set mode for the first delete of a key that was never durably persisted: inserts the
+      * offset-carrying tombstone (a row with a null `value` and the `offset` set) `IF NOT EXISTS`, so an absent row
+      * still gets the fence a later stale writer's `INSERT ... IF NOT EXISTS` must lose to (see `deleteCompareAndSet`).
+      * `value`, `created` and `metadata` are left null - a tombstone carries only the offset, exactly as the
+      * `UPDATE`-based delete (`prepareDelete`) leaves them.
+      */
+    def prepareTombstoneInsertIfNotExists[F[_]](
+      session: CassandraSession[F],
+      tableName: String,
+      ttl: Option[FiniteDuration],
+    ): F[PreparedStatement] =
+      session.prepare(
+        s"""
+           |INSERT INTO $tableName (
+           |  application_id,
+           |  group_id,
+           |  topic,
+           |  partition,
+           |  key,
+           |  offset
+           |) VALUES (
+           |  :application_id,
+           |  :group_id,
+           |  :topic,
+           |  :partition,
+           |  :key,
+           |  :offset
+           |)
+           |IF NOT EXISTS
+           |${StatementHelper.ttlFragment(ttl)}
+        """.stripMargin
+      )
+
+    def bindTombstoneInsert(statement: PreparedStatement, key: KafkaKey, offset: Offset): BoundStatement =
+      statement
+        .bind()
+        .encode("application_id", key.applicationId)
+        .encode("group_id", key.groupId)
+        .encode("topic", key.topicPartition.topic)
+        .encode("partition", key.topicPartition.partition)
+        .encode("key", key.key)
+        .encode("offset", offset)
+
     def bindPersist[F[_]: Clock: Monad, T](
       statement: PreparedStatement,
       key: KafkaKey,
@@ -428,9 +539,36 @@ object CassandraSnapshots {
         .encode("partition", key.topicPartition.partition)
         .encode("key", key.key)
 
-    def prepareDelete[F[_]](session: CassandraSession[F], tableName: String): F[PreparedStatement] =
-      session
-        .prepare(
+    /** In compare-and-set mode the delete is an offset-carrying logical tombstone: `UPDATE ... SET value = null`
+      * keeping the row's `offset`, gated by `IF offset <= :offset`. Keeping the row preserves the `offset` guard across
+      * the delete (so a stale writer cannot resurrect the key at a lower offset) and forces the delete through the
+      * Paxos path (mixing lightweight transactions and regular mutations on the same row is not safe in Cassandra). The
+      * tombstone is reaped by the TTL, if configured. In last-write-wins mode the delete is an ordinary `DELETE`.
+      */
+    def prepareDelete[F[_]](
+      session: CassandraSession[F],
+      tableName: String,
+      ttl: Option[FiniteDuration],
+      compareAndSet: Boolean = false,
+    ): F[PreparedStatement] =
+      session.prepare(
+        if (compareAndSet)
+          s"""
+             |UPDATE
+             |  $tableName
+             |  ${StatementHelper.ttlFragment(ttl)}
+             |SET
+             |  value = null,
+             |  offset = :offset
+             |WHERE
+             |  application_id = :application_id
+             |  AND group_id = :group_id
+             |  AND topic = :topic
+             |  AND partition = :partition
+             |  AND key = :key
+             |  IF offset <= :offset
+          """.stripMargin
+        else
           s"""
              |DELETE FROM
              |  $tableName
@@ -440,8 +578,8 @@ object CassandraSnapshots {
              |  AND topic = :topic
              |  AND partition = :partition
              |  AND key = :key
-        """.stripMargin
-        )
+          """.stripMargin
+      )
 
     def bindDelete(statement: PreparedStatement, key: KafkaKey): BoundStatement =
       statement
@@ -451,5 +589,9 @@ object CassandraSnapshots {
         .encode("topic", key.topicPartition.topic)
         .encode("partition", key.topicPartition.partition)
         .encode("key", key.key)
+
+    /** Binds the delete for compare-and-set mode, adding the `:offset` the `IF offset <= :offset` guard checks. */
+    def bindDelete(statement: PreparedStatement, key: KafkaKey, offset: Offset): BoundStatement =
+      bindDelete(statement, key).encode("offset", offset)
   }
 }

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/CassandraSnapshots.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/CassandraSnapshots.scala
@@ -1,6 +1,6 @@
 package com.evolutiongaming.kafka.flow.snapshot
 
-import cats.{Functor, Monad}
+import cats.Monad
 import cats.effect.{Async, Clock}
 import cats.syntax.all.*
 import com.datastax.driver.core.{BoundStatement, PreparedStatement, Row}
@@ -36,7 +36,16 @@ class CassandraSnapshots[F[_]: Async, T](
 )(implicit fromBytes: FromBytes[F, T], toBytes: ToBytes[F, T])
     extends SnapshotDatabase[F, KafkaKey, KafkaSnapshot[T]] {
 
-  def persist(key: KafkaKey, snapshot: KafkaSnapshot[T]): F[Unit] =
+  /** Routes a [[Stored]] write: a present value persists a snapshot, an absent value writes a tombstone (delete). A
+    * compare-and-set store gates both on `stored.offset` (always set on the fenced buffer path); see [[Snapshots]].
+    */
+  def write(key: KafkaKey, stored: Stored[KafkaSnapshot[T]]): F[Unit] =
+    stored match {
+      case Stored.Live(snapshot, _) => persist(key, snapshot)
+      case Stored.Tombstone(at)     => delete(key, at)
+    }
+
+  private def persist(key: KafkaKey, snapshot: KafkaSnapshot[T]): F[Unit] =
     writeMode match {
       case WriteMode.LastWriteWins         => persistUnconditional(key, snapshot)
       case WriteMode.CompareAndSet(insert) => persistCompareAndSet(insert, key, snapshot)
@@ -104,34 +113,27 @@ class CassandraSnapshots[F[_]: Async, T](
     if (row.getColumnDefinitions.contains("offset")) row.decode[Option[Offset]]("offset")
     else none
 
-  def get(key: KafkaKey): F[Option[KafkaSnapshot[T]]] = {
-    val boundStatement =
-      Statements.bindGet(getStatement, key).withConsistencyLevel(consistencyOverrides.read)
-
-    session.executeStream(boundStatement).first.flatMap(_.flatTraverse(row => decode(row)))
-  }
-
-  /** Surfaces a tombstone's offset as the replay-window floor. A present row decodes to [[Recovered.Present]]; a
-    * tombstone (null `value`, kept by [[deleteCompareAndSet]]) decodes to [[Recovered.Deleted]] carrying the stored
-    * offset, even though [[get]] reads it back as absent; no row is [[Recovered.Absent]]. Without this a deleted key
-    * recovers with no floor and a legitimate owner re-persisting below the tombstone's offset self-fences (a livelock);
-    * see `docs/cassandra-single-writer-design.md`.
+  /** Recovers the stored unit, surfacing a tombstone's offset as the replay-window floor. A present row reads back as
+    * `Some(Stored(Some(snapshot), _))`; a tombstone (null `value`, kept by [[deleteCompareAndSet]]) as
+    * `Some(Stored(None, offset))` carrying the stored offset even though the value is absent; no row as `None`. Without
+    * the tombstone's offset a deleted key recovers with no floor and a legitimate owner re-persisting below it
+    * self-fences (a livelock); see `docs/cassandra-single-writer-design.md`.
     */
-  override def recover(key: KafkaKey)(implicit F: Functor[F]): F[Recovered[KafkaSnapshot[T]]] = {
+  def read(key: KafkaKey): F[Option[Stored[KafkaSnapshot[T]]]] = {
     val boundStatement =
       Statements.bindGet(getStatement, key).withConsistencyLevel(consistencyOverrides.read)
 
     session.executeStream(boundStatement).first.flatMap {
-      case None => (Recovered.Absent: Recovered[KafkaSnapshot[T]]).pure[F]
+      case None => none[Stored[KafkaSnapshot[T]]].pure[F]
       case Some(row) =>
         decode(row).map {
-          case Some(snapshot) => Recovered.Present(snapshot)
-          case None           => Recovered.Deleted(row.decode[Offset]("offset"))
+          case Some(snapshot) => Stored.Live(snapshot, snapshot.offset.some).some
+          case None           => Stored.Tombstone(row.decode[Offset]("offset")).some
         }
     }
   }
 
-  def delete(key: KafkaKey, offset: Offset): F[Unit] =
+  private def delete(key: KafkaKey, offset: Offset): F[Unit] =
     writeMode match {
       case WriteMode.LastWriteWins    => deleteUnconditional(key)
       case WriteMode.CompareAndSet(_) => deleteCompareAndSet(key, offset)

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/CassandraSnapshots.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/snapshot/CassandraSnapshots.scala
@@ -13,27 +13,96 @@ import com.evolutiongaming.kafka.flow.cassandra.StatementHelper.StatementOps
 import com.evolutiongaming.scassandra.CassandraSession
 import com.evolutiongaming.scassandra.StreamingCassandraSession.*
 import com.evolutiongaming.scassandra.syntax.*
-import com.evolutiongaming.skafka.{FromBytes, Offset, ToBytes}
+import com.evolutiongaming.skafka.{Bytes, FromBytes, Offset, ToBytes}
 import scodec.bits.ByteVector
 import CassandraSnapshots.*
 
+import java.time.Instant
 import scala.concurrent.duration.FiniteDuration
+import scala.util.control.NoStackTrace
 
+/** Cassandra-backed implementation of `SnapshotDatabase`.
+  *
+  * In `WriteMode.CompareAndSet` mode a snapshot is persisted only if the stored snapshot's offset is not greater than
+  * the offset of the new snapshot. See [[CassandraSnapshots.withSchema]] for details.
+  */
 class CassandraSnapshots[F[_]: Async, T](
   session: CassandraSession[F],
   getStatement: PreparedStatement,
   persistStatement: PreparedStatement,
   deleteStatement: PreparedStatement,
   consistencyOverrides: ConsistencyOverrides = ConsistencyOverrides.none,
+  writeMode: WriteMode                       = WriteMode.LastWriteWins,
 )(implicit fromBytes: FromBytes[F, T], toBytes: ToBytes[F, T])
     extends SnapshotDatabase[F, KafkaKey, KafkaSnapshot[T]] {
 
   def persist(key: KafkaKey, snapshot: KafkaSnapshot[T]): F[Unit] =
+    writeMode match {
+      case WriteMode.LastWriteWins         => persistUnconditional(key, snapshot)
+      case WriteMode.CompareAndSet(insert) => persistCompareAndSet(insert, key, snapshot)
+    }
+
+  private def persistUnconditional(key: KafkaKey, snapshot: KafkaSnapshot[T]): F[Unit] =
     for {
       boundStatement <- Statements.bindPersist(persistStatement, key, snapshot)
       statement       = boundStatement.withConsistencyLevel(consistencyOverrides.write)
       _              <- session.execute(statement).void
     } yield ()
+
+  /** Persists the snapshot only if the stored one is not newer.
+    *
+    * The conditional update is not applied when the stored row has a higher offset (a concurrent writer persisted a
+    * newer snapshot) or when the row does not exist yet. The latter is retried as `INSERT ... IF NOT EXISTS`; if that
+    * loses to a concurrent insert, the conditional update is retried once, so the writer with the newest snapshot wins
+    * a first-write race.
+    */
+  private def persistCompareAndSet(
+    insertStatement: PreparedStatement,
+    key: KafkaKey,
+    snapshot: KafkaSnapshot[T],
+  ): F[Unit] =
+    for {
+      created   <- Clock[F].instant
+      value     <- toBytes.apply(snapshot.value, key.topicPartition.topic)
+      bind       = (statement: PreparedStatement) => Statements.bindPersist(statement, key, snapshot, created, value)
+      updateRow <- executeWrite(bind(persistStatement))
+      _ <- resolveConditional(key, updateRow, snapshot.offset) {
+        // the row does not exist yet: first write for the key
+        executeWrite(bind(insertStatement)).flatMap { insertRow =>
+          if (insertRow.getBool("[applied]")) ().pure[F]
+          else
+            // lost the insert race to a concurrent writer: retry the conditional update once
+            executeWrite(bind(persistStatement)).flatMap { retryRow =>
+              // a row deleted between the insert and the retry surfaces as a (spurious) conflict; the flow
+              // recovers from it on the next flush
+              resolveConditional(key, retryRow, snapshot.offset)(
+                SnapshotWriteConflict(key, snapshot.offset, none).raiseError[F, Unit]
+              )
+            }
+        }
+      }
+    } yield ()
+
+  private def executeWrite(boundStatement: BoundStatement): F[Row] =
+    session.execute(boundStatement.withConsistencyLevel(consistencyOverrides.write)).map(_.one())
+
+  /** Interprets a conditional-write (lightweight transaction) result: unit if it applied, [[SnapshotWriteConflict]] if
+    * a newer stored offset rejected it, or runs `onAbsent` when the row is absent (no `offset` in the result) - the
+    * first-write path inserts there, and its retry treats a still-absent row as a (spurious) conflict.
+    */
+  private def resolveConditional(key: KafkaKey, row: Row, attemptedOffset: Offset)(onAbsent: => F[Unit]): F[Unit] =
+    if (row.getBool("[applied]")) ().pure[F]
+    else
+      persistedOffsetOf(row) match {
+        // the stored snapshot is newer: this writer is stale
+        case Some(persistedOffset) =>
+          SnapshotWriteConflict(key, attemptedOffset, persistedOffset.some).raiseError[F, Unit]
+        case None => onAbsent
+      }
+
+  private def persistedOffsetOf(row: Row): Option[Offset] =
+    if (row.getColumnDefinitions.contains("offset")) row.decode[Option[Offset]]("offset")
+    else none
 
   def get(key: KafkaKey): F[Option[KafkaSnapshot[T]]] = {
     val boundStatement =
@@ -45,6 +114,8 @@ class CassandraSnapshots[F[_]: Async, T](
     } yield snapshot
   }
 
+  // persist-only mode: a delete is an ordinary last-write-wins DELETE (the offset guard protects persists, not
+  // deletes). Gating deletes on an offset is out of scope here (it would need a delete(key, offset) signature).
   def delete(key: KafkaKey): F[Unit] = {
     val boundStatement = Statements.bindDelete(deleteStatement, key).withConsistencyLevel(consistencyOverrides.write)
     session.execute(boundStatement).void
@@ -55,6 +126,30 @@ class CassandraSnapshots[F[_]: Async, T](
 object CassandraSnapshots {
 
   val DefaultTableName = "snapshots_v2"
+
+  /** How a snapshot write is performed. `WriteMode.CompareAndSet` carries the extra statement used for the first write
+    * of a key, so the insert statement exists exactly when the database is in compare-and-set mode.
+    */
+  sealed trait WriteMode
+  object WriteMode {
+    case object LastWriteWins extends WriteMode
+    final case class CompareAndSet(insertStatement: PreparedStatement) extends WriteMode
+  }
+
+  /** Raised in compare-and-set mode (see [[CassandraSnapshots.withSchema]]) when the store already contains a newer
+    * snapshot for the key - another writer (likely the new partition owner after a rebalance) persisted in parallel, so
+    * this writer is stale. `persistedOffset` is the stored offset, if it could be determined.
+    */
+  final case class SnapshotWriteConflict(
+    key: KafkaKey,
+    attemptedOffset: Offset,
+    persistedOffset: Option[Offset],
+  ) extends RuntimeException(
+        s"snapshot write conflict for key $key: attempted to write with offset $attemptedOffset " +
+          s"while the store contains offset ${persistedOffset.fold("unknown")(_.toString)}, " +
+          "another writer is likely owning the key now"
+      )
+      with NoStackTrace
 
   /** Create table for storing snapshots. If table already exists it will not be recreated.
     *
@@ -68,6 +163,11 @@ object CassandraSnapshots {
     *   name of the table to create. The default value is "snapshots_v2"
     * @param ttl
     *   optional TTL to set on inserted records
+    * @param compareAndSet
+    *   if `true`, each snapshot *persist* is a Cassandra lightweight transaction asserting the stored offset is not
+    *   greater than the new one, protecting from stale writers; a rejected write fails with [[SnapshotWriteConflict]].
+    *   Deletes remain ordinary last-write-wins (gating deletes on an offset is out of scope for this mode). See the
+    *   persistence docs' "Protecting against stale snapshot writes" for limitations and costs. Default `false`.
     * @param fromBytes
     *   deserializer function to convert array of bytes to the snapshot type T
     * @param toBytes
@@ -79,11 +179,19 @@ object CassandraSnapshots {
     consistencyOverrides: ConsistencyOverrides = ConsistencyOverrides.none,
     tableName: String                          = DefaultTableName,
     ttl: Option[FiniteDuration]                = None,
+    compareAndSet: Boolean                     = false,
   )(
     implicit fromBytes: FromBytes[F, T],
     toBytes: ToBytes[F, T]
   ): F[SnapshotDatabase[F, KafkaKey, KafkaSnapshot[T]]] =
-    withCustomSchema(SnapshotSchema.of(session, sync, tableName), session, consistencyOverrides, tableName, ttl)
+    withCustomSchema(
+      SnapshotSchema.of(session, sync, tableName),
+      session,
+      consistencyOverrides,
+      tableName,
+      ttl,
+      compareAndSet
+    )
 
   /** Create table with a user defined schema for storing snapshots. If table already exists it will not be recreated.
     * Note that the table schema must be compatible with predefined queries for storing and retrieving snapshots data.
@@ -98,6 +206,8 @@ object CassandraSnapshots {
     *   name of the table to create. The default value is "snapshots_v2"
     * @param ttl
     *   optional TTL to set on inserted records
+    * @param compareAndSet
+    *   enables conditional writes protecting from stale writers, see [[CassandraSnapshots.withSchema]]
     * @param fromBytes
     *   deserializer function to convert array of bytes to the snapshot type T
     * @param toBytes
@@ -109,6 +219,7 @@ object CassandraSnapshots {
     consistencyOverrides: ConsistencyOverrides = ConsistencyOverrides.none,
     tableName: String                          = DefaultTableName,
     ttl: Option[FiniteDuration]                = None,
+    compareAndSet: Boolean                     = false,
   )(
     implicit fromBytes: FromBytes[F, T],
     toBytes: ToBytes[F, T]
@@ -116,14 +227,19 @@ object CassandraSnapshots {
     for {
       _                <- snapshotSchema.create
       getStatement     <- Statements.prepareGet(session, tableName)
-      persistStatement <- Statements.preparePersist(session, tableName, ttl)
+      persistStatement <- Statements.preparePersist(session, tableName, ttl, compareAndSet)
       deleteStatement  <- Statements.prepareDelete(session, tableName)
+      writeMode <-
+        if (compareAndSet)
+          Statements.prepareInsertIfNotExists(session, tableName, ttl).map(WriteMode.CompareAndSet(_): WriteMode)
+        else (WriteMode.LastWriteWins: WriteMode).pure[F]
     } yield new CassandraSnapshots(
       session              = session,
       getStatement         = getStatement,
       persistStatement     = persistStatement,
       deleteStatement      = deleteStatement,
       consistencyOverrides = consistencyOverrides,
+      writeMode            = writeMode,
     )
 
   def truncate[F[_]: Monad](
@@ -150,6 +266,7 @@ object CassandraSnapshots {
       session: CassandraSession[F],
       tableName: String,
       ttl: Option[FiniteDuration],
+      compareAndSet: Boolean = false,
     ): F[PreparedStatement] =
       session.prepare(
         s"""
@@ -167,6 +284,43 @@ object CassandraSnapshots {
            |  AND topic = :topic
            |  AND partition = :partition
            |  AND key = :key
+           |  ${if (compareAndSet) "IF offset <= :offset" else ""}
+        """.stripMargin
+      )
+
+    /** Used in compare-and-set mode for the first write of a key, when the conditional update of [[preparePersist]]
+      * cannot be applied because the row does not exist yet.
+      */
+    def prepareInsertIfNotExists[F[_]](
+      session: CassandraSession[F],
+      tableName: String,
+      ttl: Option[FiniteDuration],
+    ): F[PreparedStatement] =
+      session.prepare(
+        s"""
+           |INSERT INTO $tableName (
+           |  application_id,
+           |  group_id,
+           |  topic,
+           |  partition,
+           |  key,
+           |  created,
+           |  metadata,
+           |  value,
+           |  offset
+           |) VALUES (
+           |  :application_id,
+           |  :group_id,
+           |  :topic,
+           |  :partition,
+           |  :key,
+           |  :created,
+           |  :metadata,
+           |  :value,
+           |  :offset
+           |)
+           |IF NOT EXISTS
+           |${StatementHelper.ttlFragment(ttl)}
         """.stripMargin
       )
 
@@ -178,19 +332,26 @@ object CassandraSnapshots {
       for {
         created <- Clock[F].instant
         value   <- toBytes.apply(snapshot.value, key.topicPartition.topic)
-      } yield {
-        statement
-          .bind()
-          .encode("application_id", key.applicationId)
-          .encode("group_id", key.groupId)
-          .encode("topic", key.topicPartition.topic)
-          .encode("partition", key.topicPartition.partition)
-          .encode("key", key.key)
-          .encode("offset", snapshot.offset)
-          .encode("created", created)
-          .encode("metadata", snapshot.metadata)
-          .encode("value", value)
-      }
+      } yield bindPersist(statement, key, snapshot, created, value)
+
+    def bindPersist[T](
+      statement: PreparedStatement,
+      key: KafkaKey,
+      snapshot: KafkaSnapshot[T],
+      created: Instant,
+      value: Bytes,
+    ): BoundStatement =
+      statement
+        .bind()
+        .encode("application_id", key.applicationId)
+        .encode("group_id", key.groupId)
+        .encode("topic", key.topicPartition.topic)
+        .encode("partition", key.topicPartition.partition)
+        .encode("key", key.key)
+        .encode("offset", snapshot.offset)
+        .encode("created", created)
+        .encode("metadata", snapshot.metadata)
+        .encode("value", value)
 
     def prepareGet[F[_]](session: CassandraSession[F], tableName: String): F[PreparedStatement] =
       session

--- a/persistence-kafka-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/TransactionalKafkaPersistenceSpec.scala
+++ b/persistence-kafka-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/TransactionalKafkaPersistenceSpec.scala
@@ -7,7 +7,7 @@ import cats.syntax.all.*
 import com.evolutiongaming.catshelper.{FromTry, Log, LogOf}
 import com.evolutiongaming.kafka.flow.kafka.ScheduleCommit
 import com.evolutiongaming.kafka.flow.registry.EntityRegistry
-import com.evolutiongaming.kafka.flow.snapshot.SnapshotWriteDatabase
+import com.evolutiongaming.kafka.flow.snapshot.{SnapshotWriteDatabase, Stored}
 import com.evolutiongaming.kafka.flow.timer.{TimerFlowOf, TimersOf}
 import com.evolutiongaming.kafka.flow.{
   FoldOption,
@@ -42,6 +42,11 @@ import scala.concurrent.duration.*
   * first is still alive.
   */
 class TransactionalKafkaPersistenceSpec extends ForAllKafkaSuite {
+
+  // adapter: the unified write(Stored) keeps these cases speaking persist(key, value)
+  private implicit class WriteDbPersist(val db: SnapshotWriteDatabase[IO, KafkaKey, String]) {
+    def persist(key: KafkaKey, value: String): IO[Unit] = db.write(key, Stored.Live(value, none))
+  }
   implicit val ioRuntime: IORuntime = IORuntime.global
   implicit val logOf: LogOf[IO]     = LogOf.slf4j[IO].unsafeRunSync()
   implicit val log: Log[IO]         = logOf(this.getClass).unsafeRunSync()

--- a/persistence-kafka-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/TransactionalKafkaPersistenceSpec.scala
+++ b/persistence-kafka-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/TransactionalKafkaPersistenceSpec.scala
@@ -8,7 +8,7 @@ import com.evolutiongaming.catshelper.{FromTry, Log, LogOf}
 import com.evolutiongaming.kafka.flow.kafka.Codecs.*
 import com.evolutiongaming.kafka.flow.kafka.ScheduleCommit
 import com.evolutiongaming.kafka.flow.registry.EntityRegistry
-import com.evolutiongaming.kafka.flow.snapshot.SnapshotWriteDatabase
+import com.evolutiongaming.kafka.flow.snapshot.{SnapshotWriteDatabase, Stored}
 import com.evolutiongaming.kafka.flow.timer.{TimerFlowOf, TimersOf}
 import com.evolutiongaming.kafka.flow.{
   FoldOption,
@@ -50,6 +50,10 @@ class TransactionalKafkaPersistenceSpec extends ForAllKafkaSuite {
   // 45s stall deadline and 60s outer timeout - those fail first, with diagnostics
   override def munitTimeout: Duration = 3.minutes
 
+  // adapter: the unified write(Stored) keeps these cases speaking persist(key, value)
+  private implicit class WriteDbPersist(val db: SnapshotWriteDatabase[IO, KafkaKey, String]) {
+    def persist(key: KafkaKey, value: String): IO[Unit] = db.write(key, Stored.Live(value, none))
+  }
   implicit val ioRuntime: IORuntime = IORuntime.global
   implicit val logOf: LogOf[IO]     = LogOf.slf4j[IO].unsafeRunSync()
   implicit val log: Log[IO]         = logOf(this.getClass).unsafeRunSync()

--- a/persistence-kafka-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/TransactionalWriteThroughputSpec.scala
+++ b/persistence-kafka-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/TransactionalWriteThroughputSpec.scala
@@ -5,7 +5,7 @@ import cats.effect.IO
 import cats.effect.unsafe.IORuntime
 import cats.syntax.all.*
 import com.evolutiongaming.catshelper.{FromTry, Log, LogOf}
-import com.evolutiongaming.kafka.flow.snapshot.SnapshotWriteDatabase
+import com.evolutiongaming.kafka.flow.snapshot.{SnapshotWriteDatabase, Stored}
 import com.evolutiongaming.kafka.flow.{ForAllKafkaSuite, KafkaKey}
 import com.evolutiongaming.skafka.consumer.{
   AutoOffsetReset,
@@ -25,6 +25,11 @@ import scala.concurrent.duration.*
   * replication factor 1); the assertions are sanity-only.
   */
 class TransactionalWriteThroughputSpec extends ForAllKafkaSuite {
+
+  // adapter: the unified write(Stored) keeps these cases speaking persist(key, value)
+  private implicit class WriteDbPersist(val db: SnapshotWriteDatabase[IO, KafkaKey, String]) {
+    def persist(key: KafkaKey, value: String): IO[Unit] = db.write(key, Stored.Live(value, none))
+  }
 
   // Performance/rationale experiment, not a regression test: it adds no coverage beyond
   // TransactionalKafkaPersistenceSpec and is expensive, so it is excluded from the default test run.

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModule.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModule.scala
@@ -333,8 +333,8 @@ object KafkaPersistenceModule {
         KafkaSnapshotReadDatabase.of[F, S](snapshotTopicPartition.topic, getState = key => cache.remove(key).flatten)
 
       val snapshotDatabase = SnapshotDatabase(
-        read  = read,
-        write = writeDatabase
+        readDatabase  = read,
+        writeDatabase = writeDatabase
       ).withMetricsK(metrics.snapshotDatabaseMetrics)
 
       PersistenceOf.snapshotsOnly[F, KafkaKey, S, ConsumerRecord[String, ByteVector]](

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModule.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModule.scala
@@ -360,8 +360,8 @@ object KafkaPersistenceModule {
         KafkaSnapshotReadDatabase.of[F, S](snapshotTopicPartition.topic, getState = key => cache.remove(key).flatten)
 
       val snapshotDatabase = SnapshotDatabase(
-        read  = read,
-        write = writeDatabase
+        readDatabase  = read,
+        writeDatabase = writeDatabase
       ).withMetricsK(metrics.snapshotDatabaseMetrics)
 
       PersistenceOf.snapshotsOnly[F, KafkaKey, S, ConsumerRecord[String, ByteVector]](

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaSnapshotReadDatabase.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaSnapshotReadDatabase.scala
@@ -3,7 +3,7 @@ package com.evolutiongaming.kafka.flow.kafkapersistence
 import cats.Monad
 import cats.syntax.all.*
 import com.evolutiongaming.kafka.flow.KafkaKey
-import com.evolutiongaming.kafka.flow.snapshot.SnapshotReadDatabase
+import com.evolutiongaming.kafka.flow.snapshot.{SnapshotReadDatabase, Stored}
 import com.evolutiongaming.skafka.{FromBytes, Topic}
 import scodec.bits.ByteVector
 
@@ -16,5 +16,7 @@ object KafkaSnapshotReadDatabase {
       for {
         state      <- getState(key.key)
         maybeState <- state.traverse(bytes => FromBytes[F, S].apply(bytes.toArray, snapshotTopic))
-      } yield maybeState
+        // the compacted-topic backend tracks no per-snapshot offset; it is generation-fenced, so the buffer is
+        // unfenced (offset None) - see SnapshotsOf.backedBy without offsetOf
+      } yield maybeState.map(value => Stored.Live(value, none))
 }

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaSnapshotWriteDatabase.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaSnapshotWriteDatabase.scala
@@ -194,7 +194,8 @@ object KafkaSnapshotWriteDatabase {
   ): SnapshotWriteDatabase[F, KafkaKey, S] = new SnapshotWriteDatabase[F, KafkaKey, S] {
     override def persist(key: KafkaKey, snapshot: S): F[Unit] = produce(key, snapshot.some)
 
-    override def delete(key: KafkaKey): F[Unit] = produce(key, none)
+    // the Kafka path fences deletes by the producer's transactional generation, so the offset guard is not needed here
+    override def delete(key: KafkaKey, offset: Offset): F[Unit] = produce(key, none)
 
     private def produce(key: KafkaKey, snapshot: Option[S]): F[Unit] = {
       val targetPartition = partitionMapper.getStatePartition(key.topicPartition.partition)

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaSnapshotWriteDatabase.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaSnapshotWriteDatabase.scala
@@ -9,7 +9,7 @@ import cats.syntax.all.*
 import com.evolutiongaming.catshelper.FromTry
 import com.evolutiongaming.kafka.flow.KafkaKey
 import com.evolutiongaming.kafka.flow.kafka.ScheduleCommit
-import com.evolutiongaming.kafka.flow.snapshot.SnapshotWriteDatabase
+import com.evolutiongaming.kafka.flow.snapshot.{SnapshotWriteDatabase, Stored}
 import com.evolutiongaming.skafka.consumer.ConsumerGroupMetadata
 import com.evolutiongaming.skafka.producer.{Producer, ProducerRecord}
 import com.evolutiongaming.skafka.{Offset, OffsetAndMetadata, ToBytes, TopicPartition}
@@ -192,10 +192,9 @@ object KafkaSnapshotWriteDatabase {
     partitionMapper: KafkaPersistencePartitionMapper,
     send: ProducerRecord[String, S] => F[Unit],
   ): SnapshotWriteDatabase[F, KafkaKey, S] = new SnapshotWriteDatabase[F, KafkaKey, S] {
-    override def persist(key: KafkaKey, snapshot: S): F[Unit] = produce(key, snapshot.some)
-
-    // the Kafka path fences deletes by the producer's transactional generation, so the offset guard is not needed here
-    override def delete(key: KafkaKey, offset: Offset): F[Unit] = produce(key, none)
+    // a present value persists the snapshot, an absent value is a tombstone (delete); the Kafka path fences by the
+    // producer's transactional generation, so `stored.offset` is not needed here
+    override def write(key: KafkaKey, stored: Stored[S]): F[Unit] = produce(key, stored.value)
 
     private def produce(key: KafkaKey, snapshot: Option[S]): F[Unit] = {
       val targetPartition = partitionMapper.getStatePartition(key.topicPartition.partition)

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaSnapshotWriteDatabase.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaSnapshotWriteDatabase.scala
@@ -9,7 +9,7 @@ import cats.syntax.all.*
 import com.evolutiongaming.catshelper.FromTry
 import com.evolutiongaming.kafka.flow.KafkaKey
 import com.evolutiongaming.kafka.flow.kafka.ScheduleCommit
-import com.evolutiongaming.kafka.flow.snapshot.SnapshotWriteDatabase
+import com.evolutiongaming.kafka.flow.snapshot.{SnapshotWriteDatabase, Stored}
 import com.evolutiongaming.skafka.consumer.ConsumerGroupMetadata
 import com.evolutiongaming.skafka.producer.{Producer, ProducerRecord}
 import com.evolutiongaming.skafka.{Offset, OffsetAndMetadata, ToBytes, TopicPartition}
@@ -190,9 +190,9 @@ object KafkaSnapshotWriteDatabase {
     partitionMapper: KafkaPersistencePartitionMapper,
     send: ProducerRecord[String, S] => F[Unit],
   ): SnapshotWriteDatabase[F, KafkaKey, S] = new SnapshotWriteDatabase[F, KafkaKey, S] {
-    override def persist(key: KafkaKey, snapshot: S): F[Unit] = produce(key, snapshot.some)
-
-    override def delete(key: KafkaKey): F[Unit] = produce(key, none)
+    // a present value persists the snapshot, an absent value is a tombstone (delete); the Kafka path fences by the
+    // producer's transactional generation, so `stored.offset` is not needed here
+    override def write(key: KafkaKey, stored: Stored[S]): F[Unit] = produce(key, stored.value)
 
     private def produce(key: KafkaKey, snapshot: Option[S]): F[Unit] = {
       val targetPartition = partitionMapper.getStatePartition(key.topicPartition.partition)

--- a/persistence-kafka/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/GroupCommitSpec.scala
+++ b/persistence-kafka/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/GroupCommitSpec.scala
@@ -7,6 +7,7 @@ import cats.effect.{Deferred, IO, Ref}
 import cats.syntax.all.*
 import com.evolutiongaming.catshelper.FromTry
 import com.evolutiongaming.kafka.flow.KafkaKey
+import com.evolutiongaming.kafka.flow.snapshot.Stored
 import com.evolutiongaming.kafka.flow.kafkapersistence.GroupCommitSpec.*
 import com.evolutiongaming.skafka.consumer.ConsumerGroupMetadata
 import com.evolutiongaming.skafka.producer.{Producer, ProducerRecord, RecordMetadata}
@@ -70,7 +71,7 @@ class GroupCommitSpec extends FunSuite {
       val test = for {
         events  <- Ref.of[IO, Vector[Event]](Vector.empty)
         tx      <- buildTransactional(recordingProducer(events), ConsumerGroupMetadata.Empty.some, cap)
-        results <- keys.parTraverse(k => tx.writeDatabase.persist(kafkaKey(k), s"state-$k").attempt)
+        results <- keys.parTraverse(k => tx.writeDatabase.write(kafkaKey(k), Stored.Live((s"state-$k"), none)).attempt)
         log     <- events.get
       } yield {
         assert(results.forall(_.isRight), s"all writes complete: $results")
@@ -128,10 +129,15 @@ class GroupCommitSpec extends FunSuite {
         ConsumerGroupMetadata.Empty.some,
         maxWritesPerTransaction = cap,
       )
-      f0  <- tx.writeDatabase.persist(kafkaKey("w0"), "s0").start // opens and holds the first transaction
-      _   <- firstBegun.get
-      fm  <- tx.scheduleCommit.schedule(Offset.unsafe(9)).start // marker queued first, behind the held lock
-      fw  <- (1 to cap).toList.parTraverse(i => tx.writeDatabase.persist(kafkaKey(s"w$i"), s"s$i").start)
+      f0 <- tx
+        .writeDatabase
+        .write(kafkaKey("w0"), Stored.Live(("s0"), none))
+        .start // opens and holds the first transaction
+      _  <- firstBegun.get
+      fm <- tx.scheduleCommit.schedule(Offset.unsafe(9)).start // marker queued first, behind the held lock
+      fw <- (1 to cap)
+        .toList
+        .parTraverse(i => tx.writeDatabase.write(kafkaKey(s"w$i"), Stored.Live((s"s$i"), none)).start)
       _   <- IO.sleep(1.second) // virtual: lets the marker + writes enqueue and block on the lock before release
       _   <- release.complete(())
       _   <- (f0 :: fm :: fw).traverse_(_.joinWithNever)
@@ -154,7 +160,7 @@ class GroupCommitSpec extends FunSuite {
         maxWritesPerTransaction = 256,
         assignedOffset          = Offset.unsafe(3),
       )
-      _   <- tx.writeDatabase.persist(kafkaKey("key1"), "state-1")
+      _   <- tx.writeDatabase.write(kafkaKey("key1"), Stored.Live(("state-1"), none))
       log <- events.get
     } yield {
       assertEquals(offsetsCommitted(log), List(Offset.unsafe(3)))
@@ -172,7 +178,7 @@ class GroupCommitSpec extends FunSuite {
     val test = for {
       events <- Ref.of[IO, Vector[Event]](Vector.empty)
       tx <- buildTransactional(recordingProducer(events), ConsumerGroupMetadata.Empty.some, maxWritesPerTransaction = 1)
-      _  <- keys.parTraverse(k => tx.writeDatabase.persist(kafkaKey(k), s"state-$k"))
+      _  <- keys.parTraverse(k => tx.writeDatabase.write(kafkaKey(k), Stored.Live((s"state-$k"), none)))
       _  <- tx.scheduleCommit.schedule(Offset.unsafe(10))
       log <- events.get
     } yield {
@@ -189,7 +195,7 @@ class GroupCommitSpec extends FunSuite {
     val test = for {
       events <- Ref.of[IO, Vector[Event]](Vector.empty)
       tx     <- buildTransactional(recordingProducer(events), groupMetadata = none, maxWritesPerTransaction = 256)
-      result <- tx.writeDatabase.persist(kafkaKey("key1"), "state-1").attempt
+      result <- tx.writeDatabase.write(kafkaKey("key1"), Stored.Live(("state-1"), none)).attempt
       log    <- events.get
     } yield {
       assert(result.left.exists(_.isInstanceOf[IllegalStateException]), s"fail-loud: $result")
@@ -214,9 +220,11 @@ class GroupCommitSpec extends FunSuite {
         assignedOffset          = Offset.min,
         maxWritesPerTransaction = 256,
       )
-      _   <- tx.writeDatabase.persist(kafkaKey("key1"), "state-1") // commits under generation 1
-      _   <- gmRef.set(generation(2).some) // a rebalance advances the generation
-      _   <- tx.writeDatabase.persist(kafkaKey("key2"), "state-2") // must commit under generation 2, not a cached 1
+      _ <- tx.writeDatabase.write(kafkaKey("key1"), Stored.Live(("state-1"), none)) // commits under generation 1
+      _ <- gmRef.set(generation(2).some) // a rebalance advances the generation
+      _ <- tx
+        .writeDatabase
+        .write(kafkaKey("key2"), Stored.Live(("state-2"), none)) // must commit under generation 2, not a cached 1
       log <- events.get
     } yield assertEquals(log.collect { case Event.Offsets(_, generation) => generation }.toList, List(1, 2))
     test.unsafeRunSync()
@@ -226,7 +234,7 @@ class GroupCommitSpec extends FunSuite {
     val test = for {
       events <- Ref.of[IO, Vector[Event]](Vector.empty)
       tx     <- buildTransactional(recordingProducer(events, failCommit = true), ConsumerGroupMetadata.Empty.some, 256)
-      result <- tx.writeDatabase.persist(kafkaKey("key1"), "state-1").attempt
+      result <- tx.writeDatabase.write(kafkaKey("key1"), Stored.Live(("state-1"), none)).attempt
       log    <- events.get
     } yield {
       assert(result.isLeft, s"error surfaced: $result")

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -13,7 +13,7 @@ const sidebars = {
       type: "category",
       label: "Design notes",
       collapsed: false,
-      items: ["kafka-single-writer-design"],
+      items: ["kafka-single-writer-design", "cassandra-single-writer-design"],
     },
   ],
 };

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -1,6 +1,6 @@
 {
   "docs": {
     "Kafka-Flow": ["overview", "setup", "faq", "styleguide", "persistence"],
-    "Design notes": ["kafka-single-writer-design"]
+    "Design notes": ["kafka-single-writer-design", "cassandra-single-writer-design"]
   }
 }


### PR DESCRIPTION
**Stacked on (merge first):** #838

### Problem

The persist-only fence (#838) leaves `delete` last-write-wins, so a stale writer can still revive a just-deleted key. Events recovery has its own replay-window exposure: a journal fold could regress a key below an existing snapshot's offset and revive it.

### Fix

Extend the compare-and-set to the full fence: persist **and** delete are offset-fenced. A fenced delete always writes an offset-carrying tombstone — even for a never-persisted key — so a later replay of an already-deleted record cannot revive it. Events recovery seeds the replay-window floor from the snapshot store and routes `initPersisted` through the monotonic cell, closing the journal revive. A guard-expired row is read as absent and repaired via `IF offset = null`.

The store API changes (breaking): the `persist`/`delete` write pair and the `get`/`recover` read pair collapse into one `Stored[S]` ADT — a live snapshot or an offset-carrying tombstone — so the read, the write and the per-key buffer reason about one monotonic cell.

### Tests and docs

The compare-and-set suite, the replay-fencing spec (a replayed delete after its tombstone was TTL-reaped stays a fence), the per-key serialization race (the flushCell lost-write), the read-state floor gate, and the TTL-edge timing; the Cassandra ITs pin the image above the mode's version floor. The Cassandra design doc is made self-consistent for the full fence — including why the consumer generation cannot replace the offset as the fence token; persistence.md and the kafka design doc get matching updates.