### PR TITLE
Derive transactional input topic and consumer generation from the flow

### DIFF
--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/PartitionAssignment.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/PartitionAssignment.scala
@@ -1,0 +1,24 @@
+package com.evolutiongaming.kafka.flow
+
+import com.evolutiongaming.skafka.consumer.ConsumerGroupMetadata
+import com.evolutiongaming.skafka.{Offset, TopicPartition}
+
+/** The facts of a partition assignment: everything the flow knows about an assigned partition that is fixed for the
+  * lifetime of the assignment. Capabilities that a component may override (such as
+  * [[com.evolutiongaming.kafka.flow.kafka.ScheduleCommit]]) are passed separately.
+  *
+  * @param topicPartition
+  *   the assigned topic-partition
+  * @param assignedAt
+  *   the first offset to be consumed under this assignment
+  * @param groupMetadata
+  *   a live reader of the group metadata (generation) of the consumer that drives this flow; `None` until the consumer
+  *   has joined. The reader is fixed, its result is not: it is re-evaluated on each use, so pass it along unevaluated -
+  *   a memoized (evaluate-once) value would go stale on the next rebalance. Used by the transactional Kafka snapshot
+  *   persistence to fence stale writers (KIP-447); flows that do not need it can ignore it.
+  */
+final case class PartitionAssignment[F[_]](
+  topicPartition: TopicPartition,
+  assignedAt: Offset,
+  groupMetadata: F[Option[ConsumerGroupMetadata]],
+)

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/PartitionFlowOf.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/PartitionFlowOf.scala
@@ -5,16 +5,13 @@ import cats.effect.kernel.Async
 import com.evolutiongaming.catshelper.LogOf
 import com.evolutiongaming.kafka.flow.PartitionFlow.FilterRecord
 import com.evolutiongaming.kafka.flow.kafka.ScheduleCommit
-import com.evolutiongaming.skafka.{Offset, TopicPartition}
 
 trait PartitionFlowOf[F[_]] {
 
-  /** Creates partition record handler for assigned partition */
-  def apply(
-    topicPartition: TopicPartition,
-    assignedAt: Offset,
-    scheduleCommit: ScheduleCommit[F]
-  ): Resource[F, PartitionFlow[F]]
+  /** Creates partition record handler for the partition described by `assignment`, committing offsets through
+    * `scheduleCommit`.
+    */
+  def apply(assignment: PartitionAssignment[F], scheduleCommit: ScheduleCommit[F]): Resource[F, PartitionFlow[F]]
 
 }
 object PartitionFlowOf {
@@ -36,7 +33,17 @@ object PartitionFlowOf {
     config: PartitionFlowConfig     = PartitionFlowConfig(),
     filter: Option[FilterRecord[F]] = None,
     remapKey: Option[RemapKey[F]]   = None,
-  ): PartitionFlowOf[F] = { (topicPartition, assignedAt, scheduleCommit) =>
-    PartitionFlow.resource(topicPartition, assignedAt, keyStateOf, config, filter, remapKey, scheduleCommit)
+  ): PartitionFlowOf[F] = { (assignment, scheduleCommit) =>
+    // assignment.groupMetadata is ignored: only the transactional Kafka persistence fences by generation (see
+    // kafkapersistence.package)
+    PartitionFlow.resource(
+      assignment.topicPartition,
+      assignment.assignedAt,
+      keyStateOf,
+      config,
+      filter,
+      remapKey,
+      scheduleCommit,
+    )
   }
 }

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/TopicFlow.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/TopicFlow.scala
@@ -126,7 +126,10 @@ object TopicFlow {
           case (partition, offset) =>
             val scheduleCommit = pendingCommits.newScheduleCommit(topic, partition)
             cache.getOrUpdateResource(partition) {
-              partitionFlowOf(TopicPartition(topic, partition), offset, scheduleCommit)
+              partitionFlowOf(
+                PartitionAssignment(TopicPartition(topic, partition), offset, consumer.groupMetadata),
+                scheduleCommit
+              )
             }
         }
       }

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/TopicFlowSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/TopicFlowSpec.scala
@@ -1,0 +1,58 @@
+package com.evolutiongaming.kafka.flow
+
+import cats.data.{NonEmptyMap, NonEmptySet}
+import cats.effect.unsafe.implicits.global
+import cats.effect.{IO, Ref, Resource}
+import cats.syntax.all.*
+import com.evolutiongaming.catshelper.{LogOf, Runtime}
+import com.evolutiongaming.kafka.flow.kafka.{Consumer, ScheduleCommit}
+import com.evolutiongaming.skafka.*
+import com.evolutiongaming.skafka.consumer.{ConsumerGroupMetadata, ConsumerRecord, ConsumerRecords, RebalanceListener1}
+import munit.FunSuite
+import scodec.bits.ByteVector
+
+import scala.concurrent.duration.FiniteDuration
+
+class TopicFlowSpec extends FunSuite {
+
+  private implicit val logOf: LogOf[IO]     = LogOf.empty[IO]
+  private implicit val runtime: Runtime[IO] = Runtime.lift[IO]
+
+  test("add threads the driving consumer's group metadata into the partition flow") {
+    val topic     = "topic"
+    val partition = Partition.min
+    val offset    = Offset.min
+    val generation =
+      ConsumerGroupMetadata(groupId = "group", generationId = 42, memberId = "member", groupInstanceId = none)
+
+    // a consumer whose generation is a distinctive sentinel, so we can tell it apart from a `pure(none)` regression
+    val consumer = new Consumer[IO] {
+      def subscribe(topics: NonEmptySet[Topic], listener: RebalanceListener1[IO]): IO[Unit] = IO.unit
+      def poll(timeout: FiniteDuration): IO[ConsumerRecords[String, ByteVector]]    = ConsumerRecords.empty.pure[IO]
+      def commit(offsets: NonEmptyMap[TopicPartition, OffsetAndMetadata]): IO[Unit] = IO.unit
+      def groupMetadata: IO[Option[ConsumerGroupMetadata]]                          = generation.some.pure[IO]
+    }
+
+    val test = for {
+      captured <- Ref.of[IO, Option[ConsumerGroupMetadata]](none)
+      partitionFlowOf = new PartitionFlowOf[IO] {
+        def apply(
+          assignment: PartitionAssignment[IO],
+          scheduleCommit: ScheduleCommit[IO]
+        ): Resource[IO, PartitionFlow[IO]] =
+          Resource
+            .eval(assignment.groupMetadata.flatMap(captured.set))
+            .as(
+              new PartitionFlow[IO] {
+                def apply(records: List[ConsumerRecord[String, ByteVector]]): IO[Unit] = IO.unit
+              }
+            )
+      }
+      result <- TopicFlow.of(consumer, topic, partitionFlowOf).use { topicFlow =>
+        topicFlow.add(NonEmptySet.of(partition -> offset)) *> captured.get
+      }
+    } yield assertEquals(result, generation.some)
+
+    test.unsafeRunSync()
+  }
+}

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/registry/EntityRegistryTest.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/registry/EntityRegistryTest.scala
@@ -60,9 +60,12 @@ class EntityRegistryTest extends FunSuite {
       config = PartitionFlowConfig()
     )
     partitionFlow <- partitionFlowOf.apply(
-      topicPartition = TopicPartition.empty,
-      assignedAt     = Offset.min,
-      scheduleCommit = ScheduleCommit.empty
+      PartitionAssignment[IO](
+        topicPartition = TopicPartition.empty,
+        assignedAt     = Offset.min,
+        groupMetadata  = IO.none
+      ),
+      ScheduleCommit.empty
     )
   } yield (partitionFlow, registry)
 

--- a/docs/kafka-single-writer-design.md
+++ b/docs/kafka-single-writer-design.md
@@ -98,9 +98,11 @@ Key points:
   (`CommitFailedException`) propagate into the flow and crash a stale owner, rather than being lost on a
   fire-and-forget commit thread.
 
-Wiring needs the input topic and a reader of the driving consumer's group metadata
-(`Consumer.groupMetadata`, captured on each partition assignment on the poll thread). A fence surfaces as
-`CommitFailedException` on the failing snapshot write (or offset-only commit).
+The mechanism needs the input topic-partition and a reader of the driving consumer's group metadata
+(`Consumer.groupMetadata`, captured on each partition assignment on the poll thread). Both are supplied by
+the flow from the partition assignment — not configured by hand — so they always match the consumer that
+drives the flow. A fence surfaces as `CommitFailedException` on the failing snapshot write (or offset-only
+commit).
 
 ### No epoch fencing
 

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -61,31 +61,38 @@ replays the affected events.
 
 ### Transactional snapshot writes (Kafka)
 
-Enable with `KafkaPersistenceModuleOf.cachingTransactional`, built from the consumer that drives the
-flow (it reads that consumer's group metadata to fence by generation):
+Enable with `KafkaPersistenceModuleOf.cachingTransactional`. The flow supplies the driving consumer's
+group metadata (generation) to the module, which uses it to fence stale writers — so you build the
+module like any other and wire it into the flow as usual:
 
 ```scala
-// allocate the driving consumer first so the module can read its group metadata (generation)
-consumer.use { consumer =>
-  val moduleOf = KafkaPersistenceModuleOf.cachingTransactional[F, State](
-    consumerOf = consumerOf,
-    producerOf = producerOf,
-    config = KafkaPersistenceModule.TransactionalConfig(
-      consumerConfig        = snapshotConsumerConfig,
-      producerConfig        = snapshotProducerConfig,
-      transactionalIdPrefix = s"$groupId-$inputTopic",
-      snapshotTopic         = stateTopic,
-      inputTopic            = inputTopic,
-    ),
-    groupMetadata = consumer.groupMetadata, // the SAME consumer that drives the flow
-  )
-  // ... wire moduleOf into the flow, driven by `consumer`
-}
+val moduleOf = KafkaPersistenceModuleOf.cachingTransactional[F, State](
+  consumerOf = consumerOf,
+  producerOf = producerOf,
+  config = KafkaPersistenceModule.TransactionalConfig(
+    consumerConfig        = snapshotConsumerConfig,
+    producerConfig        = snapshotProducerConfig,
+    transactionalIdPrefix = applicationId,
+    snapshotTopic         = stateTopic,
+  ),
+)
+// wire it into the flow as usual:
+// KafkaFlow.resource(consumerResource, ConsumerFlowOf(inputTopic, TopicFlowOf(kafkaEagerRecovery(moduleOf, /* ... */))))
 ```
 
 `idempotence` and the per-partition `transactional.id` are set for you — don't configure them in
 `producerConfig` — and the snapshot `consumerConfig`'s isolation level is forced to `read_committed`.
-The id is regenerated per assignment, not stable per partition.
+The id is regenerated per assignment, not stable per partition. The input topic whose offsets are
+committed transactionally, and the consumer generation used to fence stale writers, are both supplied
+by the flow (from the assigned partition and the driving consumer), so neither is part of
+`TransactionalConfig`. One module serves one flow: snapshots are keyed by partition *number* alone, so
+each input topic needs its own module with its own `snapshotTopic` — sharing a snapshot topic between
+flows would mix their state on recovery.
+
+`transactionalIdPrefix` does not affect fencing (that is by consumer generation) — it is a readable
+label and, on an ACL-secured cluster, the `transactional.id` prefix your producer principal must be
+authorized for. Use your `applicationId`; an application running several flows can append any per-flow
+discriminator (e.g. the input topic) — an `"<applicationId>*"` prefixed ACL still covers it.
 
 Snapshot writes and the input-offset commit run in one Kafka transaction per assigned partition; a
 write from a stale consumer generation is fenced by the broker

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -61,6 +61,10 @@ replays the affected events.
 
 ### Transactional snapshot writes (Kafka)
 
+**EXPERIMENTAL** — use at your own risk: the mechanism is design-verified but not yet proven in
+production operation, and unknown defects may remain. No compatibility guarantee: configuration, API,
+and behavior may change in any release, without deprecation.
+
 Enable with `KafkaPersistenceModuleOf.cachingTransactional`. The flow supplies the driving consumer's
 group metadata (generation) to the module, which uses it to fence stale writers — so you build the
 module like any other and wire it into the flow as usual:

--- a/metrics/src/main/scala/com/evolutiongaming/kafka/flow/PartitionFlowMetrics.scala
+++ b/metrics/src/main/scala/com/evolutiongaming/kafka/flow/PartitionFlowMetrics.scala
@@ -7,7 +7,6 @@ import com.evolutiongaming.kafka.flow.kafka.ScheduleCommit
 import com.evolutiongaming.kafka.flow.metrics.MetricsOf
 import com.evolutiongaming.kafka.flow.metrics.syntax.*
 import com.evolutiongaming.skafka.consumer.ConsumerRecord
-import com.evolutiongaming.skafka.{Offset, TopicPartition}
 import com.evolutiongaming.smetrics.MetricsHelper.*
 import com.evolutiongaming.smetrics.{LabelNames, Quantile, Quantiles}
 import scodec.bits.ByteVector
@@ -54,8 +53,8 @@ object PartitionFlowMetrics {
   implicit def partitionFlowOfMetricsOf[F[_]: Monad: MeasureDuration]: MetricsOf[F, PartitionFlowOf[F]] =
     partitionFlowMetricsOf[F] transform { implicit metrics => partitionFlowOf =>
       new PartitionFlowOf[F] {
-        def apply(topicPartition: TopicPartition, assignedAt: Offset, scheduleCommit: ScheduleCommit[F]) =
-          partitionFlowOf(topicPartition, assignedAt, scheduleCommit) map (_.withMetrics)
+        def apply(assignment: PartitionAssignment[F], scheduleCommit: ScheduleCommit[F]) =
+          partitionFlowOf(assignment, scheduleCommit) map (_.withMetrics)
       }
     }
 

--- a/persistence-kafka-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/StatefulProcessingWithKafkaSpec.scala
+++ b/persistence-kafka-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/StatefulProcessingWithKafkaSpec.scala
@@ -8,7 +8,7 @@ import cats.syntax.all.*
 import com.evolution.playjson.jsoniter.PlayJsonJsoniter
 import com.evolutiongaming.catshelper.{Log, LogOf}
 import com.evolutiongaming.kafka.flow.StatefulProcessingWithKafkaSpec.*
-import com.evolutiongaming.kafka.flow.kafka.{Consumer, KafkaModule}
+import com.evolutiongaming.kafka.flow.kafka.KafkaModule
 import com.evolutiongaming.kafka.flow.kafkapersistence.{
   KafkaPersistenceModule,
   KafkaPersistenceModuleOf,
@@ -22,7 +22,7 @@ import com.evolutiongaming.kafka.flow.timer.{TimerFlowOf, TimersOf}
 import com.evolutiongaming.retry.Retry
 import com.evolutiongaming.skafka.consumer.{AutoOffsetReset, ConsumerConfig, ConsumerOf, ConsumerRecord}
 import com.evolutiongaming.skafka.producer.{ProducerConfig, ProducerOf, ProducerRecord, RecordMetadata}
-import com.evolutiongaming.skafka.{Bytes, CommonConfig, Offset, Partition}
+import com.evolutiongaming.skafka.{Bytes, CommonConfig, Partition}
 import play.api.libs.json.{JsResultException, Json, OFormat}
 import scodec.bits.ByteVector
 
@@ -73,7 +73,9 @@ class StatefulProcessingWithKafkaSpec extends ForAllKafkaSuite {
 
   private val inMemoryPersistenceModuleOf: KafkaPersistenceModuleOf[IO, State] =
     new KafkaPersistenceModuleOf[IO, State] {
-      override def make(partition: Partition, assignedAt: Offset): Resource[IO, KafkaPersistenceModule[IO, State]] =
+      override def make(
+        assignment: PartitionAssignment[IO]
+      ): Resource[IO, KafkaPersistenceModule[IO, State]] =
         Resource.pure(inMemoryPersistenceModule)
     }
 
@@ -121,14 +123,14 @@ class StatefulProcessingWithKafkaSpec extends ForAllKafkaSuite {
   test("stateful processing using in-memory persistence") {
     // unique input topic per test to isolate tests (munit suites run in parallel)
     val inputTopic = "in-memory-persistence-test"
-    comboTestCase(kafkaModule(), _ => inMemoryPersistenceModuleOf, inputTopic).unsafeRunSync()
+    comboTestCase(kafkaModule(), inMemoryPersistenceModuleOf, inputTopic).unsafeRunSync()
   }
 
   test("stateful processing using kafka persistence") {
     // unique input topic per test to isolate tests (munit suites run in parallel)
     val inputTopic = "kafka-persistence-test"
     kafkaPersistenceModuleOf
-      .use(module => comboTestCase(kafkaModule(), _ => module, inputTopic))
+      .use(module => comboTestCase(kafkaModule(), module, inputTopic))
       .unsafeRunSync()
   }
 
@@ -137,9 +139,9 @@ class StatefulProcessingWithKafkaSpec extends ForAllKafkaSuite {
     val inputTopic = "kafka-transactional-persistence-test"
     val stateTopic = "state-topic-tx-StatefulProcessingWithKafkaSpec"
 
-    // the module reads the driving consumer's group metadata so offsets are committed transactionally with the
-    // snapshot writes; the recovery assertions below would fail if those offset commits did not land
-    def makeModuleOf(consumer: Consumer[IO]): KafkaPersistenceModuleOf[IO, State] =
+    // the framework supplies the driving consumer's group metadata to the module, so offsets are committed
+    // transactionally with the snapshot writes; the recovery assertions below would fail if those commits did not land
+    val moduleOf: KafkaPersistenceModuleOf[IO, State] =
       KafkaPersistenceModuleOf.cachingTransactional[IO, State](
         consumerOf = ConsumerOf.apply1[IO](),
         producerOf = ProducerOf.apply1[IO](),
@@ -150,33 +152,29 @@ class StatefulProcessingWithKafkaSpec extends ForAllKafkaSuite {
             autoOffsetReset = AutoOffsetReset.Earliest
           ),
           producerConfig        = producerConfig,
-          transactionalIdPrefix = s"$testGroupId-$inputTopic",
+          transactionalIdPrefix = appId,
           snapshotTopic         = stateTopic,
-          inputTopic            = inputTopic,
         ),
-        groupMetadata = consumer.groupMetadata,
       )
 
-    (createTopic(stateTopic, 2) *> comboTestCase(kafkaModule(), makeModuleOf, inputTopic)).unsafeRunSync()
+    (createTopic(stateTopic, 2) *> comboTestCase(kafkaModule(), moduleOf, inputTopic)).unsafeRunSync()
   }
 
-  // the module factory is built from the consumer that drives the flow so that, in transactional mode, the snapshot
-  // writer can read that consumer's group metadata (generation) for offset binding; non-transactional cases ignore it
   private def comboTestCase(
     kafka: KafkaModule[IO],
-    makeModuleOf: Consumer[IO] => KafkaPersistenceModuleOf[IO, State],
+    moduleOf: KafkaPersistenceModuleOf[IO, State],
     inputTopic: String
   ): IO[Unit] = {
     for {
       _ <- createTopic(inputTopic, 2)
-      _ <- testCase(kafka, makeModuleOf, inputTopic, Partition.unsafe(0), "key0")
-      _ <- testCase(kafka, makeModuleOf, inputTopic, Partition.unsafe(1), "key1")
+      _ <- testCase(kafka, moduleOf, inputTopic, Partition.unsafe(0), "key0")
+      _ <- testCase(kafka, moduleOf, inputTopic, Partition.unsafe(1), "key1")
     } yield ()
   }
 
   private def testCase(
     kafka: KafkaModule[IO],
-    makeModuleOf: Consumer[IO] => KafkaPersistenceModuleOf[IO, State],
+    moduleOf: KafkaPersistenceModuleOf[IO, State],
     inputTopic: String,
     partition: Partition,
     key: String
@@ -193,26 +191,22 @@ class StatefulProcessingWithKafkaSpec extends ForAllKafkaSuite {
       }
     }
 
-    // allocate the consumer first, then build the module from it (so transactional offset binding reads this
-    // consumer's generation) and drive the flow with the same consumer instance
     def program: IO[List[Output]] =
-      kafka.consumerOf("groupId-StatefulProcessingWithKafkaSpec").use { consumer =>
-        for {
-          output   <- Ref.of[IO, List[Output]](List.empty)
-          finished <- Deferred[IO, Unit]
-          flowOf   <- topicFlowOf(makeModuleOf(consumer), output, finished)
-          run = KafkaFlow.resource(
-            consumer = Resource.pure[IO, Consumer[IO]](consumer),
-            flowOf = ConsumerFlowOf[IO](
-              topic  = inputTopic,
-              flowOf = flowOf
-            )
+      for {
+        output   <- Ref.of[IO, List[Output]](List.empty)
+        finished <- Deferred[IO, Unit]
+        flowOf   <- topicFlowOf(moduleOf, output, finished)
+        run = KafkaFlow.resource(
+          consumer = kafka.consumerOf("groupId-StatefulProcessingWithKafkaSpec"),
+          flowOf = ConsumerFlowOf[IO](
+            topic  = inputTopic,
+            flowOf = flowOf
           )
-          // wait for records to be processed
-          _      <- run.use(_ => finished.get.timeout(5.seconds))
-          output <- output.get
-        } yield output
-      }
+        )
+        // wait for records to be processed
+        _      <- run.use(_ => finished.get.timeout(5.seconds))
+        output <- output.get
+      } yield output
 
     for {
       _      <- produceInput(1)

--- a/persistence-kafka-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/TransactionalKafkaPersistenceSpec.scala
+++ b/persistence-kafka-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/TransactionalKafkaPersistenceSpec.scala
@@ -13,6 +13,7 @@ import com.evolutiongaming.kafka.flow.{
   FoldOption,
   ForAllKafkaSuite,
   KafkaKey,
+  PartitionAssignment,
   PartitionFlow,
   PartitionFlowConfig,
   PartitionFlowOf,
@@ -144,7 +145,9 @@ class TransactionalKafkaPersistenceSpec extends ForAllKafkaSuite {
     */
   private def staleFlushScenario(
     moduleOfA: KafkaPersistenceModuleOf[IO, String],
+    groupMetadataA: IO[Option[ConsumerGroupMetadata]],
     moduleOfB: KafkaPersistenceModuleOf[IO, String],
+    groupMetadataB: IO[Option[ConsumerGroupMetadata]],
     stateTopic: String,
     key: String,
   ): IO[(Either[Throwable, Unit], BytesByKey)] = {
@@ -153,17 +156,23 @@ class TransactionalKafkaPersistenceSpec extends ForAllKafkaSuite {
     val eventsA    = (1 to 5).toList.map(i => s"e$i")
     val eventsB    = (1 to 10).toList.map(i => s"e$i")
 
-    def allocateFlow(moduleOf: KafkaPersistenceModuleOf[IO, String]): IO[(PartitionFlow[IO], IO[Unit])] =
-      flowOf(moduleOf, flushOnRevokeOnly).flatMap(_.apply(tp, Offset.min, ScheduleCommit.empty[IO]).allocated)
+    // each flow gets its own generation: flow A (the previous owner) a stale one, flow B (the new owner) the current one
+    def allocateFlow(
+      moduleOf: KafkaPersistenceModuleOf[IO, String],
+      groupMetadata: IO[Option[ConsumerGroupMetadata]],
+    ): IO[(PartitionFlow[IO], IO[Unit])] =
+      flowOf(moduleOf, flushOnRevokeOnly).flatMap(
+        _.apply(PartitionAssignment(tp, Offset.min, groupMetadata), ScheduleCommit.empty[IO]).allocated
+      )
 
     for {
       _ <- createTopic(stateTopic, 1)
       // the previous owner: folds events, snapshots stay buffered in memory
-      flowA             <- allocateFlow(moduleOfA)
+      flowA             <- allocateFlow(moduleOfA, groupMetadataA)
       (flowA_, releaseA) = flowA
       _                 <- flowA_(inputRecords(inputTopic, key, eventsA))
       // the new owner: eagerly recovers (finds nothing), folds all events, flushes on release
-      flowB             <- allocateFlow(moduleOfB)
+      flowB             <- allocateFlow(moduleOfB, groupMetadataB)
       (flowB_, releaseB) = flowB
       _                 <- flowB_(inputRecords(inputTopic, key, eventsB))
       _                 <- releaseB
@@ -191,7 +200,9 @@ class TransactionalKafkaPersistenceSpec extends ForAllKafkaSuite {
         consumerConfig = consumerConfig,
         snapshotTopic  = stateTopic,
       )
-      staleFlushScenario(moduleOf, moduleOf, stateTopic, key).map {
+      // caching (non-transactional) ignores group metadata
+      val noGm = IO.pure(none[ConsumerGroupMetadata])
+      staleFlushScenario(moduleOf, noGm, moduleOf, noGm, stateTopic, key).map {
         case (staleFlush, stored) =>
           assertEquals(clue(staleFlush), Right(()))
           // recovery now returns the STALE snapshot (events 6..10 are lost although the new owner persisted them):
@@ -209,24 +220,22 @@ class TransactionalKafkaPersistenceSpec extends ForAllKafkaSuite {
     val group      = s"$groupId-flush-on-revoke"
     val key        = "key1"
 
-    def moduleOf(gm: ConsumerGroupMetadata): KafkaPersistenceModuleOf[IO, String] =
+    val moduleOf: KafkaPersistenceModuleOf[IO, String] =
       KafkaPersistenceModuleOf.cachingTransactional[IO, String](
         consumerOf = consumerOf,
         producerOf = producerOf,
         config = KafkaPersistenceModule.TransactionalConfig(
           consumerConfig        = consumerConfig,
           producerConfig        = producerConfig,
-          transactionalIdPrefix = s"$group-$inputTopic",
+          transactionalIdPrefix = appId,
           snapshotTopic         = stateTopic,
-          inputTopic            = inputTopic,
         ),
-        groupMetadata = IO.pure(gm.some),
       )
 
     // the previous owner (flow A) carries a stale generation; the new owner (flow B) carries the current one
     val test = createTopic(inputTopic, 1) *> withJoinedConsumer(group, inputTopic) { current =>
       val stale = staleGeneration(current)
-      staleFlushScenario(moduleOf(stale), moduleOf(current), stateTopic, key).map {
+      staleFlushScenario(moduleOf, IO.pure(stale.some), moduleOf, IO.pure(current.some), stateTopic, key).map {
         case (staleFlush, stored) =>
           // the release itself succeeds: the rejected write surfaces as a logged-and-swallowed cache entry release
           // error ("scache: failed to release cache entry: ... CommitFailedException"), which is the desired
@@ -259,18 +268,22 @@ class TransactionalKafkaPersistenceSpec extends ForAllKafkaSuite {
             config = KafkaPersistenceModule.TransactionalConfig(
               consumerConfig        = consumerConfig,
               producerConfig        = producerConfig,
-              transactionalIdPrefix = s"$group-$inputTopic",
+              transactionalIdPrefix = appId,
               snapshotTopic         = stateTopic,
-              inputTopic            = inputTopic,
             ),
-            groupMetadata = gmRef.get.map(_.some),
           )
-          // flush on every records application, so the writer hits the conflict on its next poll cycle
+          // flush on every records application, so the writer hits the conflict on its next poll cycle; the generation
+          // is read live from gmRef at flush time, so flipping it to stale below takes effect on the next flush
           flow <- flowOf(
             moduleOf,
             TimerFlowOf.persistPeriodically[IO](fireEvery = 0.seconds, persistEvery = 0.seconds),
             PartitionFlowConfig(triggerTimersInterval     = 0.seconds),
-          ).flatMap(_.apply(tp, Offset.min, ScheduleCommit.empty[IO]).allocated)
+          ).flatMap(
+            _.apply(
+              PartitionAssignment(tp, Offset.min, gmRef.get.map(_.some)),
+              ScheduleCommit.empty[IO]
+            ).allocated
+          )
           (flow_, release) = flow
           // persists fine while the generation is current
           _ <- flow_(inputRecords(inputTopic, key, List("e1", "e2", "e3")))

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModule.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModule.scala
@@ -139,7 +139,11 @@ object KafkaPersistenceModule {
     }
   }
 
-  /** Variant of `caching` protecting the snapshot topic from stale writers by binding the input-offset commit into the
+  /** EXPERIMENTAL - use at your own risk: design-verified but not yet proven in production operation, and unknown
+    * defects may remain. No compatibility guarantee: configuration, API, and behavior may change in any release,
+    * without deprecation.
+    *
+    * Variant of `caching` protecting the snapshot topic from stale writers by binding the input-offset commit into the
     * snapshot transaction. Each assigned partition gets a transactional producer with a unique `transactional.id`;
     * snapshot writes run in group-committed transactions (see [[KafkaSnapshotWriteDatabase.transactional]]) that also
     * commit the input offset. A stale consumer generation is rejected by the broker (KIP-447), aborting the

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModule.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModule.scala
@@ -10,10 +10,10 @@ import com.evolutiongaming.kafka.flow.key.{Keys, KeysOf}
 import com.evolutiongaming.kafka.flow.metrics.syntax.*
 import com.evolutiongaming.kafka.flow.persistence.{PersistenceOf, SnapshotPersistenceOf}
 import com.evolutiongaming.kafka.flow.snapshot.{SnapshotDatabase, SnapshotWriteDatabase, SnapshotsOf}
-import com.evolutiongaming.kafka.flow.{FlowMetrics, KafkaKey}
-import com.evolutiongaming.skafka.consumer.{ConsumerConfig, ConsumerGroupMetadata, ConsumerOf, IsolationLevel}
+import com.evolutiongaming.kafka.flow.{FlowMetrics, KafkaKey, PartitionAssignment}
+import com.evolutiongaming.skafka.consumer.{ConsumerConfig, ConsumerOf, IsolationLevel}
 import com.evolutiongaming.skafka.producer.{Producer, ProducerConfig, ProducerOf}
-import com.evolutiongaming.skafka.{FromBytes, Offset, Partition, ToBytes, Topic, TopicPartition}
+import com.evolutiongaming.skafka.{FromBytes, ToBytes, Topic, TopicPartition}
 import com.evolutiongaming.sstream.Stream
 import scodec.bits.ByteVector
 import com.evolutiongaming.skafka.consumer.ConsumerRecord
@@ -43,13 +43,13 @@ object KafkaPersistenceModule {
     *   base config for the snapshot producer; `transactionalId` and `idempotence` are overridden per producer and
     *   `clientId` is suffixed with it
     * @param transactionalIdPrefix
-    *   prefix for `transactional.id` (partition number and a unique per-producer suffix are appended). Fencing is by
-    *   consumer generation, not this id, so it is just a readable label (e.g. a `"<groupId>-<inputTopic>"` string).
+    *   prefix for `transactional.id` (partition number and a unique per-producer suffix are appended). It does not
+    *   affect fencing (that is by consumer generation), so its only roles are a readable label and, on an ACL-secured
+    *   cluster, the `transactional.id` prefix the producer principal must be authorized for. Use your `applicationId`;
+    *   an application running several flows can append any per-flow discriminator (e.g. the input topic), which an
+    *   `"<applicationId>*"` prefixed ACL still covers.
     * @param snapshotTopic
     *   snapshot topic name (should be configured as a 'compacted' topic) to read/write snapshots
-    * @param inputTopic
-    *   the input topic kafka-flow consumes; its offsets are committed transactionally with the snapshot writes (same
-    *   partition number as the snapshot partition - the mode forces the identity mapping)
     * @param maxWritesPerTransaction
     *   upper bound of snapshot writes group committed in one per-partition, serialized transaction, see
     *   [[KafkaSnapshotWriteDatabase.transactional]]
@@ -59,24 +59,7 @@ object KafkaPersistenceModule {
     producerConfig: ProducerConfig,
     transactionalIdPrefix: String,
     snapshotTopic: Topic,
-    inputTopic: Topic,
     maxWritesPerTransaction: Int = KafkaSnapshotWriteDatabase.DefaultMaxWritesPerTransaction,
-  )
-
-  /** The per-assignment context [[cachingTransactional]] needs to fence stale writers.
-    *
-    * @param partition
-    *   the assigned partition (used for both the snapshot and the input topic-partition)
-    * @param assignedAt
-    *   the offset the partition was assigned at; seeds the offset-to-commit so even the first write is generation-gated
-    * @param groupMetadata
-    *   group metadata of the SAME consumer that drives this flow (use `Consumer.groupMetadata`); its generation is what
-    *   fences a stale owner (KIP-447). `None` means the consumer is not joined.
-    */
-  final case class PartitionAssignment[F[_]](
-    partition: Partition,
-    assignedAt: Offset,
-    groupMetadata: F[Option[ConsumerGroupMetadata]],
   )
 
   def caching[F[_]: LogOf: Concurrent: Parallel: Runtime, S](
@@ -164,6 +147,10 @@ object KafkaPersistenceModule {
     * `read_committed`, and unlike `caching` the identity partition mapping is always used; output stays at-least-once.
     * See the "Protecting against stale snapshot writes" persistence docs for guarantees, limitations, costs and
     * rollout, and `docs/kafka-single-writer-design.md` for the mechanism.
+    *
+    * The `assignment` must describe the input partition of the SAME consumer that drives this flow (its `groupMetadata`
+    * generation is what fences a stale owner); `assignedAt` seeds the offset-to-commit so even the first write is
+    * generation-gated, and the input partition number is reused for the snapshot topic-partition.
     */
   def cachingTransactional[F[_]: LogOf: Async: Parallel: Runtime, S](
     consumerOf: ConsumerOf[F],
@@ -176,7 +163,7 @@ object KafkaPersistenceModule {
     fromBytesState: FromBytes[F, S],
     toBytesState: ToBytes[F, S]
   ): Resource[F, KafkaPersistenceModule[F, S]] = {
-    val snapshotTopicPartition = TopicPartition(config.snapshotTopic, assignment.partition)
+    val snapshotTopicPartition = TopicPartition(config.snapshotTopic, assignment.topicPartition.partition)
     for {
       transactional <- transactionalWriteDatabase[F, S](producerOf, config, assignment, snapshotTopicPartition)
       // records of aborted transactions (e.g. of a fenced previous owner) must not be recovered as snapshots
@@ -207,12 +194,10 @@ object KafkaPersistenceModule {
     implicit toBytesState: ToBytes[F, S]
   ): Resource[F, KafkaSnapshotWriteDatabase.Transactional[F, S]] = {
     implicit val fromTry: FromTry[F] = FromTry.lift
-    import config.{inputTopic, maxWritesPerTransaction, producerConfig, transactionalIdPrefix}
-    import assignment.{assignedAt, groupMetadata, partition}
+    import config.{maxWritesPerTransaction, producerConfig, transactionalIdPrefix}
+    import assignment.{assignedAt, groupMetadata, topicPartition as inputTopicPartition}
 
-    // offsets are committed for the input partition with the same number as the assigned (snapshot) partition - the
-    // mode forces the identity mapping
-    val inputTopicPartition = TopicPartition(inputTopic, partition)
+    val partition = inputTopicPartition.partition
 
     for {
       // unique per producer: fencing is by consumer generation, not this id, so a fresh id per assignment is fine

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModuleOf.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModuleOf.scala
@@ -73,7 +73,11 @@ object KafkaPersistenceModuleOf {
   ): KafkaPersistenceModuleOf[F, S] =
     caching(consumerOf, producer, consumerConfig, snapshotTopic, FlowMetrics.empty[F])
 
-  /** A transactional [[KafkaPersistenceModule]] factory that protects the snapshot topic from stale writers - see
+  /** EXPERIMENTAL - use at your own risk: design-verified but not yet proven in production operation, and unknown
+    * defects may remain. No compatibility guarantee: configuration, API, and behavior may change in any release,
+    * without deprecation.
+    *
+    * A transactional [[KafkaPersistenceModule]] factory that protects the snapshot topic from stale writers - see
     * `KafkaPersistenceModule.cachingTransactional` for semantics and trade-offs. The input topic and consumer
     * generation are supplied by the flow, so they are not part of `config`.
     */

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModuleOf.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModuleOf.scala
@@ -3,17 +3,18 @@ package com.evolutiongaming.kafka.flow.kafkapersistence
 import cats.Parallel
 import cats.effect.{Async, Concurrent, Resource}
 import com.evolutiongaming.catshelper.{LogOf, Runtime}
-import com.evolutiongaming.kafka.flow.FlowMetrics
-import com.evolutiongaming.skafka.consumer.{ConsumerConfig, ConsumerGroupMetadata, ConsumerOf}
+import com.evolutiongaming.kafka.flow.{FlowMetrics, PartitionAssignment}
+import com.evolutiongaming.skafka.consumer.{ConsumerConfig, ConsumerOf}
 import com.evolutiongaming.skafka.producer.{Producer, ProducerOf}
 import com.evolutiongaming.skafka.*
 
-/** Convenience factory trait to create an instance of [[KafkaPersistenceModule]] for an assigned partition.
-  * `assignedAt` is the offset the partition was assigned at; the transactional module seeds it as the initial
-  * offset-to-commit (ignored by the non-transactional caching module).
+/** Convenience factory trait to create an instance of [[KafkaPersistenceModule]] for an assigned partition. The
+  * `PartitionAssignment` is supplied by the flow; its `assignedAt` and `groupMetadata` are used only by the
+  * transactional module - to seed the initial offset-to-commit and to fence stale writers (KIP-447) respectively; the
+  * non-transactional caching module ignores both.
   */
 trait KafkaPersistenceModuleOf[F[_], S] {
-  def make(partition: Partition, assignedAt: Offset): Resource[F, KafkaPersistenceModule[F, S]]
+  def make(assignment: PartitionAssignment[F]): Resource[F, KafkaPersistenceModule[F, S]]
 }
 
 object KafkaPersistenceModuleOf {
@@ -46,13 +47,15 @@ object KafkaPersistenceModuleOf {
     fromBytesState: FromBytes[F, S],
     toBytesState: ToBytes[F, S]
   ): KafkaPersistenceModuleOf[F, S] = new KafkaPersistenceModuleOf[F, S] {
-    // assignedAt is unused: the non-transactional caching module does not commit offsets through a producer
-    override def make(partition: Partition, assignedAt: Offset): Resource[F, KafkaPersistenceModule[F, S]] =
+    // caching ignores assignedAt/groupMetadata - it doesn't commit offsets through a producer
+    override def make(
+      assignment: PartitionAssignment[F]
+    ): Resource[F, KafkaPersistenceModule[F, S]] =
       KafkaPersistenceModule.caching(
         consumerOf             = consumerOf,
         producer               = producer,
         consumerConfig         = consumerConfig,
-        snapshotTopicPartition = TopicPartition(snapshotTopic, partition),
+        snapshotTopicPartition = TopicPartition(snapshotTopic, assignment.topicPartition.partition),
         metrics                = metrics,
         partitionMapper        = partitionMapper,
       )
@@ -70,31 +73,28 @@ object KafkaPersistenceModuleOf {
   ): KafkaPersistenceModuleOf[F, S] =
     caching(consumerOf, producer, consumerConfig, snapshotTopic, FlowMetrics.empty[F])
 
-  /** Create a [[KafkaPersistenceModuleOf]] factory producing transactional [[KafkaPersistenceModule]]s that protect the
-    * snapshot topic from stale writers. See `KafkaPersistenceModule.cachingTransactional` for semantics and trade-offs.
-    * The snapshot and input topics are part of `config` (see [[KafkaPersistenceModule.TransactionalConfig]]).
-    *
-    * @param groupMetadata
-    *   group metadata of the SAME consumer that drives this flow (use `Consumer.groupMetadata`); its generation is what
-    *   fences a stale owner (KIP-447)
+  /** A transactional [[KafkaPersistenceModule]] factory that protects the snapshot topic from stale writers - see
+    * `KafkaPersistenceModule.cachingTransactional` for semantics and trade-offs. The input topic and consumer
+    * generation are supplied by the flow, so they are not part of `config`.
     */
   def cachingTransactional[F[_]: LogOf: Async: Parallel: Runtime, S](
     consumerOf: ConsumerOf[F],
     producerOf: ProducerOf[F],
     config: KafkaPersistenceModule.TransactionalConfig,
-    groupMetadata: F[Option[ConsumerGroupMetadata]],
     metrics: FlowMetrics[F] = FlowMetrics.empty[F],
   )(
     implicit fromBytesKey: FromBytes[F, String],
     fromBytesState: FromBytes[F, S],
     toBytesState: ToBytes[F, S]
   ): KafkaPersistenceModuleOf[F, S] = new KafkaPersistenceModuleOf[F, S] {
-    override def make(partition: Partition, assignedAt: Offset): Resource[F, KafkaPersistenceModule[F, S]] =
+    override def make(
+      assignment: PartitionAssignment[F]
+    ): Resource[F, KafkaPersistenceModule[F, S]] =
       KafkaPersistenceModule.cachingTransactional(
         consumerOf = consumerOf,
         producerOf = producerOf,
         config     = config,
-        assignment = KafkaPersistenceModule.PartitionAssignment(partition, assignedAt, groupMetadata),
+        assignment = assignment,
         metrics    = metrics,
       )
   }

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/package.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/package.scala
@@ -10,7 +10,6 @@ import com.evolutiongaming.kafka.flow.metrics.syntax.*
 import com.evolutiongaming.kafka.flow.registry.EntityRegistry
 import com.evolutiongaming.kafka.flow.timer.{TimerFlowOf, TimersOf}
 import com.evolutiongaming.skafka.consumer.ConsumerRecord
-import com.evolutiongaming.skafka.{Offset, TopicPartition}
 import com.evolutiongaming.sstream.{FoldWhile, Stream}
 import scodec.bits.ByteVector
 
@@ -141,14 +140,13 @@ package object kafkapersistence {
   ): PartitionFlowOf[F] =
     new PartitionFlowOf[F] {
       override def apply(
-        topicPartition: TopicPartition,
-        assignedAt: Offset,
+        assignment: PartitionAssignment[F],
         scheduleCommit: ScheduleCommit[F]
       ): Resource[F, PartitionFlow[F]] = {
         for {
           // TODO: per-partition persistence module with 'String -> ByteVector' cache or global persistence module with 'KafkaKey -> ByteVector' cache?
           // Latter would require initialization of PartitionFlowOf as a Resource
-          kafkaPersistenceModule <- kafkaPersistenceModuleOf.make(topicPartition.partition, assignedAt)
+          kafkaPersistenceModule <- kafkaPersistenceModuleOf.make(assignment)
           // transactional mode commits offsets through its own producer transaction; otherwise fall back to consumer commit
           effectiveScheduleCommit = kafkaPersistenceModule.scheduleCommit.getOrElse(scheduleCommit)
           partitionFlowOf = PartitionFlowOf.apply[F](
@@ -170,7 +168,7 @@ package object kafkapersistence {
             filter   = filter,
             remapKey = remapKey,
           )
-          partitionFlow <- partitionFlowOf(topicPartition, assignedAt, effectiveScheduleCommit)
+          partitionFlow <- partitionFlowOf(assignment, effectiveScheduleCommit)
         } yield partitionFlow
       }
     }


### PR DESCRIPTION
The transactional persistence required the input topic twice (once to the flow, again as `TransactionalConfig.inputTopic`, unvalidated — a mismatch silently commits offsets for the wrong topic) and the driving consumer's group metadata wired by hand.

Both now come from the flow: `KafkaPersistenceModuleOf.make` takes the assigned `TopicPartition` and `PartitionFlowOf.apply` threads the consumer's `groupMetadata` through, so `TransactionalConfig.inputTopic` and the `groupMetadata` parameter are gone. With the topic out of the config, docs now recommend plain `applicationId` as `transactionalIdPrefix`.