### PR TITLE
Refresh the captured consumer generation after every poll

### DIFF
--- a/core-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/ConsumerGroupMetadataSpec.scala
+++ b/core-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/ConsumerGroupMetadataSpec.scala
@@ -1,0 +1,125 @@
+package com.evolutiongaming.kafka.flow
+
+import cats.data.{NonEmptyList, NonEmptySet}
+import cats.effect.unsafe.IORuntime
+import cats.effect.{IO, Ref, Resource}
+import cats.syntax.all.*
+import com.evolutiongaming.catshelper.{FromTry, LogOf}
+import com.evolutiongaming.kafka.flow.kafka.Codecs.*
+import com.evolutiongaming.kafka.flow.kafka.Consumer
+import com.evolutiongaming.skafka.consumer.{
+  AutoOffsetReset,
+  ConsumerConfig,
+  ConsumerOf,
+  RebalanceCallback,
+  RebalanceListener1
+}
+import com.evolutiongaming.skafka.{CommonConfig, Topic, TopicPartition}
+import org.apache.kafka.clients.admin.{AdminClient, AdminClientConfig, NewTopic}
+import org.apache.kafka.clients.consumer.CooperativeStickyAssignor
+import scodec.bits.ByteVector
+
+import java.util.Properties
+import java.util.concurrent.TimeUnit
+import scala.concurrent.duration.*
+import scala.jdk.CollectionConverters.*
+
+/** The scenario the post-poll refresh of `Consumer.of` exists for, against a real broker: with a cooperative assignor,
+  * a second member joining bumps the generation of a member that keeps all its partitions - the newly-assigned delta is
+  * empty, so no rebalance listener fires on it, and assignment-time capture alone would keep reporting the previous
+  * generation, spuriously fencing its next transactional snapshot flush (see the Kafka single-writer design doc,
+  * "Generation capture").
+  */
+class ConsumerGroupMetadataSpec extends ForAllKafkaSuite {
+  import ConsumerGroupMetadataSpec.*
+
+  implicit val ioRuntime: IORuntime = IORuntime.global
+  implicit val logOf: LogOf[IO]     = LogOf.slf4j[IO].unsafeRunSync()
+  implicit val fromTry: FromTry[IO] = FromTry.lift
+
+  private def consumerConfig(group: String, clientId: String): ConsumerConfig =
+    ConsumerConfig(
+      common = CommonConfig(
+        bootstrapServers = NonEmptyList.one(kafka.container.bootstrapServers),
+        clientId         = clientId.some,
+      ),
+      groupId                     = group.some,
+      autoCommit                  = false,
+      autoOffsetReset             = AutoOffsetReset.Earliest,
+      partitionAssignmentStrategy = classOf[CooperativeStickyAssignor].getName,
+    )
+
+  private def createTopic(topic: Topic, partitions: Int): IO[Unit] = {
+    val props = new Properties
+    props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, kafka.container.bootstrapServers)
+    Resource
+      .make(IO.delay(AdminClient.create(props)))(client => IO(client.close()))
+      .use { client =>
+        IO(client.createTopics(List(new NewTopic(topic, partitions, 1.toShort)).asJava))
+          .map(_.all().get(10, TimeUnit.SECONDS))
+      }
+      .void
+  }
+
+  /** A real consumer wrapped with the `Consumer.of` under test. */
+  private def consumer(group: String, clientId: String): Resource[IO, Consumer[IO]] =
+    ConsumerOf.apply1[IO]().apply[String, ByteVector](consumerConfig(group, clientId)).evalMap(Consumer.of[IO](_))
+
+  private def countingListener(counts: Ref[IO, Callbacks]): RebalanceListener1[IO] = new RebalanceListener1[IO] {
+    import com.evolutiongaming.skafka.consumer.RebalanceCallback.syntax.*
+    def onPartitionsAssigned(partitions: NonEmptySet[TopicPartition]): RebalanceCallback[IO, Unit] =
+      counts.update(c => c.copy(assigned = c.assigned + 1)).lift
+    def onPartitionsRevoked(partitions: NonEmptySet[TopicPartition]): RebalanceCallback[IO, Unit] =
+      counts.update(c => c.copy(revoked = c.revoked + 1)).lift
+    def onPartitionsLost(partitions: NonEmptySet[TopicPartition]): RebalanceCallback[IO, Unit] =
+      counts.update(c => c.copy(lost = c.lost + 1)).lift
+  }
+
+  /** Polls all `consumers` (each member must poll for a rebalance to complete) until `condition` holds. */
+  private def pollUntil(consumers: List[Consumer[IO]], attempts: Int)(condition: IO[Boolean]): IO[Unit] =
+    consumers.traverse_(_.poll(100.millis)) *> condition.flatMap {
+      case true                  => IO.unit
+      case false if attempts > 0 => pollUntil(consumers, attempts - 1)(condition)
+      case false                 => IO.raiseError(new RuntimeException("condition not met after polling"))
+    }
+
+  test("poll refreshes the captured generation when a cooperative rebalance assigns nothing new") {
+    val topic = "cooperative-generation-test"
+    val group = "cooperative-generation-group"
+
+    val test = for {
+      _      <- createTopic(topic, partitions = 1)
+      counts <- Ref.of[IO, Callbacks](Callbacks(0, 0, 0))
+      _ <- consumer(group, "consumer-a").use { a =>
+        for {
+          _      <- a.subscribe(NonEmptySet.of(topic), countingListener(counts))
+          _      <- pollUntil(List(a), attempts = 100)(a.groupMetadata.map(_.exists(_.generationId >= 1)))
+          joined <- a.groupMetadata.flatMap(gm => IO.fromOption(gm)(new IllegalStateException("not joined")))
+          // snapshot the callbacks A's own join produced; B joining below must not add to them
+          countsAfterJoin <- counts.get
+          _ <- consumer(group, "consumer-b").use { b =>
+            for {
+              _ <- b.subscribe(NonEmptySet.of(topic), RebalanceListener1.empty[IO])
+              // both members must poll: A re-joins keeping its single partition, B joins empty-handed (the topic has
+              // one partition and the sticky assignor leaves it on A), and the group generation is bumped
+              _ <- pollUntil(List(a, b), attempts = 100)(
+                a.groupMetadata.map(_.exists(_.generationId > joined.generationId))
+              )
+              // the premise of the scenario: A's assignment did not change, so no rebalance listener fired on A -
+              // the newer generation A now reports can only have come from the post-poll refresh
+              _ <- counts.get.map(assertEquals(_, countsAfterJoin))
+            } yield ()
+          }
+        } yield ()
+      }
+    } yield ()
+
+    test.unsafeRunSync()
+  }
+}
+
+object ConsumerGroupMetadataSpec {
+
+  /** Counts the rebalance callbacks a member receives, to pin down that a scenario ran without any. */
+  final case class Callbacks(assigned: Int, revoked: Int, lost: Int)
+}

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/PartitionAssignment.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/PartitionAssignment.scala
@@ -1,0 +1,24 @@
+package com.evolutiongaming.kafka.flow
+
+import com.evolutiongaming.skafka.consumer.ConsumerGroupMetadata
+import com.evolutiongaming.skafka.{Offset, TopicPartition}
+
+/** The facts of a partition assignment: everything the flow knows about an assigned partition that is fixed for the
+  * lifetime of the assignment. Capabilities that a component may override (such as
+  * [[com.evolutiongaming.kafka.flow.kafka.ScheduleCommit]]) are passed separately.
+  *
+  * @param topicPartition
+  *   the assigned topic-partition
+  * @param assignedAt
+  *   the first offset to be consumed under this assignment
+  * @param groupMetadata
+  *   a live reader of the group metadata (generation) of the consumer that drives this flow; `None` until the consumer
+  *   has joined. The reader is fixed, its result is not: it is re-evaluated on each use, so pass it along unevaluated -
+  *   a memoized (evaluate-once) value would go stale on the next rebalance. Used by the transactional Kafka snapshot
+  *   persistence to fence stale writers (KIP-447); flows that do not need it can ignore it.
+  */
+final case class PartitionAssignment[F[_]](
+  topicPartition: TopicPartition,
+  assignedAt: Offset,
+  groupMetadata: F[Option[ConsumerGroupMetadata]],
+)

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/PartitionFlowOf.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/PartitionFlowOf.scala
@@ -5,15 +5,24 @@ import cats.effect.kernel.Async
 import com.evolutiongaming.catshelper.LogOf
 import com.evolutiongaming.kafka.flow.PartitionFlow.FilterRecord
 import com.evolutiongaming.kafka.flow.kafka.ScheduleCommit
+import com.evolutiongaming.skafka.consumer.ConsumerGroupMetadata
 import com.evolutiongaming.skafka.{Offset, TopicPartition}
 
 trait PartitionFlowOf[F[_]] {
 
-  /** Creates partition record handler for assigned partition */
+  /** Creates partition record handler for assigned partition.
+    *
+    * @param groupMetadata
+    *   a live reader of the group metadata (generation) of the consumer that drives this flow; `None` until the
+    *   consumer has joined. It is re-evaluated on each use, so pass it along unevaluated - a memoized (evaluate-once)
+    *   value would go stale on the next rebalance. Used by the transactional Kafka snapshot persistence to fence stale
+    *   writers (KIP-447); flows that do not need it can ignore it.
+    */
   def apply(
     topicPartition: TopicPartition,
     assignedAt: Offset,
-    scheduleCommit: ScheduleCommit[F]
+    scheduleCommit: ScheduleCommit[F],
+    groupMetadata: F[Option[ConsumerGroupMetadata]]
   ): Resource[F, PartitionFlow[F]]
 
 }
@@ -36,7 +45,10 @@ object PartitionFlowOf {
     config: PartitionFlowConfig     = PartitionFlowConfig(),
     filter: Option[FilterRecord[F]] = None,
     remapKey: Option[RemapKey[F]]   = None,
-  ): PartitionFlowOf[F] = { (topicPartition, assignedAt, scheduleCommit) =>
-    PartitionFlow.resource(topicPartition, assignedAt, keyStateOf, config, filter, remapKey, scheduleCommit)
+  ): PartitionFlowOf[F] = {
+    // groupMetadata is ignored: only the transactional Kafka persistence fences by generation (see
+    // kafkapersistence.package)
+    (topicPartition, assignedAt, scheduleCommit, _) =>
+      PartitionFlow.resource(topicPartition, assignedAt, keyStateOf, config, filter, remapKey, scheduleCommit)
   }
 }

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/PartitionFlowOf.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/PartitionFlowOf.scala
@@ -5,25 +5,13 @@ import cats.effect.kernel.Async
 import com.evolutiongaming.catshelper.LogOf
 import com.evolutiongaming.kafka.flow.PartitionFlow.FilterRecord
 import com.evolutiongaming.kafka.flow.kafka.ScheduleCommit
-import com.evolutiongaming.skafka.consumer.ConsumerGroupMetadata
-import com.evolutiongaming.skafka.{Offset, TopicPartition}
 
 trait PartitionFlowOf[F[_]] {
 
-  /** Creates partition record handler for assigned partition.
-    *
-    * @param groupMetadata
-    *   a live reader of the group metadata (generation) of the consumer that drives this flow; `None` until the
-    *   consumer has joined. It is re-evaluated on each use, so pass it along unevaluated - a memoized (evaluate-once)
-    *   value would go stale on the next rebalance. Used by the transactional Kafka snapshot persistence to fence stale
-    *   writers (KIP-447); flows that do not need it can ignore it.
+  /** Creates partition record handler for the partition described by `assignment`, committing offsets through
+    * `scheduleCommit`.
     */
-  def apply(
-    topicPartition: TopicPartition,
-    assignedAt: Offset,
-    scheduleCommit: ScheduleCommit[F],
-    groupMetadata: F[Option[ConsumerGroupMetadata]]
-  ): Resource[F, PartitionFlow[F]]
+  def apply(assignment: PartitionAssignment[F], scheduleCommit: ScheduleCommit[F]): Resource[F, PartitionFlow[F]]
 
 }
 object PartitionFlowOf {
@@ -45,10 +33,17 @@ object PartitionFlowOf {
     config: PartitionFlowConfig     = PartitionFlowConfig(),
     filter: Option[FilterRecord[F]] = None,
     remapKey: Option[RemapKey[F]]   = None,
-  ): PartitionFlowOf[F] = {
-    // groupMetadata is ignored: only the transactional Kafka persistence fences by generation (see
+  ): PartitionFlowOf[F] = { (assignment, scheduleCommit) =>
+    // assignment.groupMetadata is ignored: only the transactional Kafka persistence fences by generation (see
     // kafkapersistence.package)
-    (topicPartition, assignedAt, scheduleCommit, _) =>
-      PartitionFlow.resource(topicPartition, assignedAt, keyStateOf, config, filter, remapKey, scheduleCommit)
+    PartitionFlow.resource(
+      assignment.topicPartition,
+      assignment.assignedAt,
+      keyStateOf,
+      config,
+      filter,
+      remapKey,
+      scheduleCommit,
+    )
   }
 }

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/TopicFlow.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/TopicFlow.scala
@@ -126,7 +126,7 @@ object TopicFlow {
           case (partition, offset) =>
             val scheduleCommit = pendingCommits.newScheduleCommit(topic, partition)
             cache.getOrUpdateResource(partition) {
-              partitionFlowOf(TopicPartition(topic, partition), offset, scheduleCommit)
+              partitionFlowOf(TopicPartition(topic, partition), offset, scheduleCommit, consumer.groupMetadata)
             }
         }
       }

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/TopicFlow.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/TopicFlow.scala
@@ -126,7 +126,10 @@ object TopicFlow {
           case (partition, offset) =>
             val scheduleCommit = pendingCommits.newScheduleCommit(topic, partition)
             cache.getOrUpdateResource(partition) {
-              partitionFlowOf(TopicPartition(topic, partition), offset, scheduleCommit, consumer.groupMetadata)
+              partitionFlowOf(
+                PartitionAssignment(TopicPartition(topic, partition), offset, consumer.groupMetadata),
+                scheduleCommit
+              )
             }
         }
       }

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/TopicFlow.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/TopicFlow.scala
@@ -116,7 +116,23 @@ object TopicFlow {
         val topicPartitions = partitions map (TopicPartition(topic, _))
         val removeOffsets   = pendingCommits.remove(topicPartitions)
 
-        removePartitions *> removeOffsets *> {
+        // flows-alive guard. `remove` runs inside the (synchronous, pre-assign) revoke callback and must
+        // AWAIT teardown -- `cache.remove(_).flatten` blocks on each flow's release -- so that by the time
+        // the poll continues into the refreshed generation, no flow survives for a partition this consumer
+        // no longer owns. That coupling is the sole cross-partition fence support: the offset commit is
+        // fenced by consumer generation but not by per-partition ownership, so a flow left alive for a
+        // revoked partition could still commit under a fresh generation token (see the flows-alive
+        // invariant in docs/kafka-single-writer-design.md). This debug-level check pins the postcondition:
+        // a future fire-and-forget refactor of the teardown would leave a revoked partition live here and
+        // log the breach instead of failing silently. In correct (awaited) code it never fires.
+        val verifyTornDown = cache.keys flatMap { live =>
+          val stillLive = partitions.toSortedSet filter live.contains
+          Log[F]
+            .warn(s"flows-alive breach: flows still live after revoke teardown for $stillLive on topic $topic")
+            .whenA(stillLive.nonEmpty)
+        }
+
+        removePartitions *> removeOffsets *> verifyTornDown *> {
           Log[F].info(s"removed offsets without commit for: $topicPartitions")
         }
       }

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/TopicFlow.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/TopicFlow.scala
@@ -117,13 +117,12 @@ object TopicFlow {
         val removeOffsets   = pendingCommits.remove(topicPartitions)
 
         // `removePartitions` AWAITS each flow's teardown (`cache.remove(_).flatten` blocks on the
-        // release), which is load-bearing: this runs inside the synchronous, pre-assign revoke callback,
-        // so awaiting it means no flow survives for a partition this consumer no longer owns once the poll
-        // continues into the refreshed generation. That coupling is the sole cross-partition fence support
-        // (the offset commit is fenced by consumer generation, not per-partition ownership; see the
-        // flows-alive invariant in docs/kafka-single-writer-design.md). Keep the await: dropping it to a
-        // fire-and-forget teardown reintroduces the race. Pinned by TopicFlowSpec's
-        // "remove awaits the flow teardown" test.
+        // release), load-bearing because this runs inside the synchronous, pre-assign revoke callback:
+        // awaiting it means no flow survives for a partition this consumer no longer owns once the poll
+        // continues into the refreshed generation. It is the sole cross-partition fence support (the
+        // offset commit is fenced by consumer generation, not per-partition ownership; see the flows-alive
+        // invariant in docs/kafka-single-writer-design.md). A fire-and-forget teardown reintroduces the
+        // race. Pinned by TopicFlowSpec's "remove awaits the flow teardown" test.
         removePartitions *> removeOffsets *> {
           Log[F].info(s"removed offsets without commit for: $topicPartitions")
         }

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/TopicFlow.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/TopicFlow.scala
@@ -116,23 +116,15 @@ object TopicFlow {
         val topicPartitions = partitions map (TopicPartition(topic, _))
         val removeOffsets   = pendingCommits.remove(topicPartitions)
 
-        // flows-alive guard. `remove` runs inside the (synchronous, pre-assign) revoke callback and must
-        // AWAIT teardown -- `cache.remove(_).flatten` blocks on each flow's release -- so that by the time
-        // the poll continues into the refreshed generation, no flow survives for a partition this consumer
-        // no longer owns. That coupling is the sole cross-partition fence support: the offset commit is
-        // fenced by consumer generation but not by per-partition ownership, so a flow left alive for a
-        // revoked partition could still commit under a fresh generation token (see the flows-alive
-        // invariant in docs/kafka-single-writer-design.md). This debug-level check pins the postcondition:
-        // a future fire-and-forget refactor of the teardown would leave a revoked partition live here and
-        // log the breach instead of failing silently. In correct (awaited) code it never fires.
-        val verifyTornDown = cache.keys flatMap { live =>
-          val stillLive = partitions.toSortedSet filter live.contains
-          Log[F]
-            .warn(s"flows-alive breach: flows still live after revoke teardown for $stillLive on topic $topic")
-            .whenA(stillLive.nonEmpty)
-        }
-
-        removePartitions *> removeOffsets *> verifyTornDown *> {
+        // `removePartitions` AWAITS each flow's teardown (`cache.remove(_).flatten` blocks on the
+        // release), which is load-bearing: this runs inside the synchronous, pre-assign revoke callback,
+        // so awaiting it means no flow survives for a partition this consumer no longer owns once the poll
+        // continues into the refreshed generation. That coupling is the sole cross-partition fence support
+        // (the offset commit is fenced by consumer generation, not per-partition ownership; see the
+        // flows-alive invariant in docs/kafka-single-writer-design.md). Keep the await: dropping it to a
+        // fire-and-forget teardown reintroduces the race. Pinned by TopicFlowSpec's
+        // "remove awaits the flow teardown" test.
+        removePartitions *> removeOffsets *> {
           Log[F].info(s"removed offsets without commit for: $topicPartitions")
         }
       }

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/kafka/Consumer.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/kafka/Consumer.scala
@@ -37,21 +37,31 @@ object Consumer {
   def of[F[_]: Sync](
     consumer: KafkaConsumer[F, String, ByteVector]
   ): F[Consumer[F]] =
-    // capture the group metadata on assignment (on the poll thread, where it is safe to read) into a Ref so the
-    // transactional snapshot writer can read the current generation off-thread; None until the first assignment
+    // the group metadata is held in a Ref so the transactional snapshot writer can read the current generation
+    // off-thread; written on assignment (`capture`) and after every poll (`refresh`) - each says why it is needed
     Ref[F].of(none[ConsumerGroupMetadata]).map { groupMetadataRef =>
       new Consumer[F] {
+        // the single write path to the Ref: it only ever holds a real, joined generation. The client reports an
+        // unknown generation (-1) before the first join and after falling out of the group; publishing it would be
+        // worse than stale - -1 with an empty member id is the coordinator's pre-KIP-447 compatibility input, for
+        // which generation validation is SKIPPED, so a commit carrying it would land unfenced. Keeping the last
+        // captured value is safe: a fallen-out owner stays gated by the generation it actually held
+        private def publish(meta: ConsumerGroupMetadata): F[Unit] =
+          groupMetadataRef.set(meta.some).whenA(meta.generationId >= 0)
+
         def subscribe(topics: NonEmptySet[Topic], listener: RebalanceListener1[F]): F[Unit] = {
           val capturing = new RebalanceListener1WithConsumer[F] {
             import com.evolutiongaming.skafka.consumer.RebalanceCallback.syntax.*
-            // capture before the listener: assignment establishes the generation the listener (recovery, then every
-            // later flush) is gated by, and on a freshly assigned consumer groupMetadata cannot fail
+            // capture before the listener: the recovery and flushes it triggers must already be gated by the
+            // generation that assigned them - `refresh` runs only after the poll. On a freshly assigned consumer
+            // groupMetadata cannot fail and the generation is real, so `publish`'s guard is unreachable here
             private def capture: RebalanceCallback[F, Unit] =
-              this.consumer.groupMetadata.flatMap(meta => groupMetadataRef.set(meta.some).lift)
+              this.consumer.groupMetadata.flatMap(meta => publish(meta).lift)
             def onPartitionsAssigned(partitions: NonEmptySet[TopicPartition]): RebalanceCallback[F, Unit] =
               capture *> listener.onPartitionsAssigned(partitions)
-            // revoke/lost just delegate: the generation is unchanged until the next assignment (which re-captures), and
-            // a capture failure here could suppress the wrapped listener's flush/commit-on-revoke
+            // revoke/lost just delegate: a revoke-triggered flush must stay gated by the generation under which the
+            // member held the partitions - never a newer one - and a capture failure here could suppress the wrapped
+            // listener's flush/commit-on-revoke
             def onPartitionsRevoked(partitions: NonEmptySet[TopicPartition]): RebalanceCallback[F, Unit] =
               listener.onPartitionsRevoked(partitions)
             def onPartitionsLost(partitions: NonEmptySet[TopicPartition]): RebalanceCallback[F, Unit] =
@@ -61,7 +71,15 @@ object Consumer {
         }
 
         def poll(timeout: FiniteDuration): F[ConsumerRecords[String, ByteVector]] =
-          consumer.poll(timeout)
+          consumer.poll(timeout) <* refresh
+
+        // `capture` misses rebalances that assign this member nothing new (listeners see only partitions that
+        // changed hands - possible with a cooperative assignor): the generation bumps, the Ref lags, and the next
+        // flush of a retained partition is spuriously fenced. Rebalances complete within a poll, so refreshing after
+        // each poll closes the gap - safely, because revoked partitions were flushed inside the poll under the
+        // pre-rebalance value, so every flow still alive is owned in the refreshed generation
+        private def refresh: F[Unit] =
+          consumer.groupMetadata.flatMap(publish)
 
         def commit(offsets: NonEmptyMap[TopicPartition, OffsetAndMetadata]): F[Unit] =
           consumer.commit(offsets)

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/kafka/Consumer.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/kafka/Consumer.scala
@@ -59,9 +59,10 @@ object Consumer {
               this.consumer.groupMetadata.flatMap(meta => publish(meta).lift)
             def onPartitionsAssigned(partitions: NonEmptySet[TopicPartition]): RebalanceCallback[F, Unit] =
               capture *> listener.onPartitionsAssigned(partitions)
-            // revoke/lost just delegate: a revoke-triggered flush must stay gated by the generation under which the
-            // member held the partitions - never a newer one - and a capture failure here could suppress the wrapped
-            // listener's flush/commit-on-revoke
+            // revoke/lost just delegate: the release-triggered flush stays gated by the generation the partitions
+            // were held under, never a newer one - guaranteed by ordering: the client invokes revoked/lost before
+            // assigned, so `capture` has not run this cycle, and `refresh` runs only after the poll. Capturing here
+            // instead could suppress the wrapped listener's flush/commit-on-revoke on failure
             def onPartitionsRevoked(partitions: NonEmptySet[TopicPartition]): RebalanceCallback[F, Unit] =
               listener.onPartitionsRevoked(partitions)
             def onPartitionsLost(partitions: NonEmptySet[TopicPartition]): RebalanceCallback[F, Unit] =

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/kafka/Consumer.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/kafka/Consumer.scala
@@ -74,11 +74,15 @@ object Consumer {
         def poll(timeout: FiniteDuration): F[ConsumerRecords[String, ByteVector]] =
           consumer.poll(timeout) <* refresh
 
-        // `capture` misses rebalances that assign this member nothing new (listeners see only partitions that
-        // changed hands - possible with a cooperative assignor): the generation bumps, the Ref lags, and the next
-        // flush of a retained partition is spuriously fenced. Rebalances complete within a poll, so refreshing after
-        // each poll closes the gap - safely, because revoked partitions were flushed inside the poll under the
-        // pre-rebalance value, so every flow still alive is owned in the refreshed generation
+        // `capture` misses rebalances that assign this member nothing new (kafka-clients invokes the assigned
+        // callback with an EMPTY delta then - javadoc-guaranteed - but the typed listener layer cannot forward an
+        // empty set, so nothing observable fires): the generation bumps, the Ref lags, and the next flush of a
+        // retained partition is spuriously fenced. A rebalance's callbacks and metadata update run on the poll
+        // thread, so refreshing after each poll closes the gap - the join round itself may span polls (KIP-266:
+        // poll(Duration) does not block on it), in which case the refresh publishes the last COMPLETED join and
+        // converges on the poll after the round finishes; the interim lag is the safe direction. Safe also because
+        // revoked partitions were flushed inside the poll under the pre-rebalance value, so every flow still alive
+        // is owned in the refreshed generation
         private def refresh: F[Unit] =
           consumer.groupMetadata.flatMap(publish)
 

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/TopicFlowSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/TopicFlowSpec.scala
@@ -1,0 +1,60 @@
+package com.evolutiongaming.kafka.flow
+
+import cats.data.{NonEmptyMap, NonEmptySet}
+import cats.effect.unsafe.implicits.global
+import cats.effect.{IO, Ref, Resource}
+import cats.syntax.all.*
+import com.evolutiongaming.catshelper.{LogOf, Runtime}
+import com.evolutiongaming.kafka.flow.kafka.{Consumer, ScheduleCommit}
+import com.evolutiongaming.skafka.*
+import com.evolutiongaming.skafka.consumer.{ConsumerGroupMetadata, ConsumerRecord, ConsumerRecords, RebalanceListener1}
+import munit.FunSuite
+import scodec.bits.ByteVector
+
+import scala.concurrent.duration.FiniteDuration
+
+class TopicFlowSpec extends FunSuite {
+
+  private implicit val logOf: LogOf[IO]     = LogOf.empty[IO]
+  private implicit val runtime: Runtime[IO] = Runtime.lift[IO]
+
+  test("add threads the driving consumer's group metadata into the partition flow") {
+    val topic     = "topic"
+    val partition = Partition.min
+    val offset    = Offset.min
+    val generation =
+      ConsumerGroupMetadata(groupId = "group", generationId = 42, memberId = "member", groupInstanceId = none)
+
+    // a consumer whose generation is a distinctive sentinel, so we can tell it apart from a `pure(none)` regression
+    val consumer = new Consumer[IO] {
+      def subscribe(topics: NonEmptySet[Topic], listener: RebalanceListener1[IO]): IO[Unit] = IO.unit
+      def poll(timeout: FiniteDuration): IO[ConsumerRecords[String, ByteVector]]    = ConsumerRecords.empty.pure[IO]
+      def commit(offsets: NonEmptyMap[TopicPartition, OffsetAndMetadata]): IO[Unit] = IO.unit
+      def groupMetadata: IO[Option[ConsumerGroupMetadata]]                          = generation.some.pure[IO]
+    }
+
+    val test = for {
+      captured <- Ref.of[IO, Option[ConsumerGroupMetadata]](none)
+      partitionFlowOf = new PartitionFlowOf[IO] {
+        def apply(
+          topicPartition: TopicPartition,
+          assignedAt: Offset,
+          scheduleCommit: ScheduleCommit[IO],
+          groupMetadata: IO[Option[ConsumerGroupMetadata]]
+        ): Resource[IO, PartitionFlow[IO]] =
+          Resource
+            .eval(groupMetadata.flatMap(captured.set))
+            .as(
+              new PartitionFlow[IO] {
+                def apply(records: List[ConsumerRecord[String, ByteVector]]): IO[Unit] = IO.unit
+              }
+            )
+      }
+      result <- TopicFlow.of(consumer, topic, partitionFlowOf).use { topicFlow =>
+        topicFlow.add(NonEmptySet.of(partition -> offset)) *> captured.get
+      }
+    } yield assertEquals(result, generation.some)
+
+    test.unsafeRunSync()
+  }
+}

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/TopicFlowSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/TopicFlowSpec.scala
@@ -2,7 +2,7 @@ package com.evolutiongaming.kafka.flow
 
 import cats.data.{NonEmptyMap, NonEmptySet}
 import cats.effect.unsafe.implicits.global
-import cats.effect.{IO, Ref, Resource}
+import cats.effect.{Deferred, IO, Ref, Resource}
 import cats.syntax.all.*
 import com.evolutiongaming.catshelper.{LogOf, Runtime}
 import com.evolutiongaming.kafka.flow.kafka.{Consumer, ScheduleCommit}
@@ -52,6 +52,54 @@ class TopicFlowSpec extends FunSuite {
         topicFlow.add(NonEmptySet.of(partition -> offset)) *> captured.get
       }
     } yield assertEquals(result, generation.some)
+
+    test.unsafeRunSync()
+  }
+
+  test("remove awaits the flow teardown (flows-alive: no flow survives a revoke)") {
+    // The cross-partition fence has a single support: `TopicFlow.remove` must AWAIT each partition flow's
+    // teardown (its Resource release) before returning. It runs inside the synchronous, pre-assign revoke
+    // callback, so awaiting the teardown is what guarantees no flow is still alive for a revoked partition
+    // once the poll continues into the refreshed generation (the offset commit is fenced by consumer
+    // generation, not per-partition ownership). Modelled abstractly as INV_FlowsAlive in
+    // models/FlowsAlive.tla; pinned here. A fire-and-forget teardown would leave `released` uncompleted
+    // when `remove` returns and fail this test.
+    val topic     = "topic"
+    val partition = Partition.min
+    val offset    = Offset.min
+
+    val consumer = new Consumer[IO] {
+      def subscribe(topics: NonEmptySet[Topic], listener: RebalanceListener1[IO]): IO[Unit] = IO.unit
+      def poll(timeout: FiniteDuration): IO[ConsumerRecords[String, ByteVector]]    = ConsumerRecords.empty.pure[IO]
+      def commit(offsets: NonEmptyMap[TopicPartition, OffsetAndMetadata]): IO[Unit] = IO.unit
+      def groupMetadata: IO[Option[ConsumerGroupMetadata]] = none[ConsumerGroupMetadata].pure[IO]
+    }
+
+    val test = for {
+      released <- Deferred[IO, Unit]
+      partitionFlowOf = new PartitionFlowOf[IO] {
+        def apply(
+          assignment: PartitionAssignment[IO],
+          scheduleCommit: ScheduleCommit[IO]
+        ): Resource[IO, PartitionFlow[IO]] =
+          Resource
+            .onFinalize(released.complete(()).void)
+            .as(new PartitionFlow[IO] {
+              def apply(records: List[ConsumerRecord[String, ByteVector]]): IO[Unit] = IO.unit
+            })
+      }
+      result <- TopicFlow.of(consumer, topic, partitionFlowOf).use { topicFlow =>
+        for {
+          _            <- topicFlow.add(NonEmptySet.of(partition -> offset))
+          liveAfterAdd <- released.tryGet // flow is alive: its teardown has not run yet
+          _            <- topicFlow.remove(NonEmptySet.of(partition))
+          downAfterRm  <- released.tryGet // remove awaited teardown, so it has run by the time remove returned
+        } yield (liveAfterAdd, downAfterRm)
+      }
+    } yield {
+      assertEquals(result._1, none[Unit], "the flow must still be alive after add (teardown not yet run)")
+      assertEquals(result._2, ().some, "remove must await the flow teardown before returning")
+    }
 
     test.unsafeRunSync()
   }

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/TopicFlowSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/TopicFlowSpec.scala
@@ -61,9 +61,8 @@ class TopicFlowSpec extends FunSuite {
     // returning: it runs inside the synchronous, pre-assign revoke callback, so awaiting guarantees
     // no flow is still alive for a revoked partition once the poll continues into the refreshed
     // generation (the offset commit is fenced by consumer generation, not per-partition ownership).
-    // This is the sole cross-partition fence support, modelled abstractly as INV_FlowsAlive in
-    // models/FlowsAlive.tla. A fire-and-forget teardown would leave `released` uncompleted when
-    // `remove` returns and fail this test.
+    // This is the sole cross-partition fence support. A fire-and-forget teardown would leave
+    // `released` uncompleted when `remove` returns and fail this test.
     val topic     = "topic"
     val partition = Partition.min
     val offset    = Offset.min

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/TopicFlowSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/TopicFlowSpec.scala
@@ -57,13 +57,13 @@ class TopicFlowSpec extends FunSuite {
   }
 
   test("remove awaits the flow teardown (flows-alive: no flow survives a revoke)") {
-    // The cross-partition fence has a single support: `TopicFlow.remove` must AWAIT each partition flow's
-    // teardown (its Resource release) before returning. It runs inside the synchronous, pre-assign revoke
-    // callback, so awaiting the teardown is what guarantees no flow is still alive for a revoked partition
-    // once the poll continues into the refreshed generation (the offset commit is fenced by consumer
-    // generation, not per-partition ownership). Modelled abstractly as INV_FlowsAlive in
-    // models/FlowsAlive.tla; pinned here. A fire-and-forget teardown would leave `released` uncompleted
-    // when `remove` returns and fail this test.
+    // `TopicFlow.remove` must AWAIT each partition flow's teardown (its Resource release) before
+    // returning: it runs inside the synchronous, pre-assign revoke callback, so awaiting guarantees
+    // no flow is still alive for a revoked partition once the poll continues into the refreshed
+    // generation (the offset commit is fenced by consumer generation, not per-partition ownership).
+    // This is the sole cross-partition fence support, modelled abstractly as INV_FlowsAlive in
+    // models/FlowsAlive.tla. A fire-and-forget teardown would leave `released` uncompleted when
+    // `remove` returns and fail this test.
     val topic     = "topic"
     val partition = Partition.min
     val offset    = Offset.min

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/TopicFlowSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/TopicFlowSpec.scala
@@ -37,13 +37,11 @@ class TopicFlowSpec extends FunSuite {
       captured <- Ref.of[IO, Option[ConsumerGroupMetadata]](none)
       partitionFlowOf = new PartitionFlowOf[IO] {
         def apply(
-          topicPartition: TopicPartition,
-          assignedAt: Offset,
-          scheduleCommit: ScheduleCommit[IO],
-          groupMetadata: IO[Option[ConsumerGroupMetadata]]
+          assignment: PartitionAssignment[IO],
+          scheduleCommit: ScheduleCommit[IO]
         ): Resource[IO, PartitionFlow[IO]] =
           Resource
-            .eval(groupMetadata.flatMap(captured.set))
+            .eval(assignment.groupMetadata.flatMap(captured.set))
             .as(
               new PartitionFlow[IO] {
                 def apply(records: List[ConsumerRecord[String, ByteVector]]): IO[Unit] = IO.unit

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/registry/EntityRegistryTest.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/registry/EntityRegistryTest.scala
@@ -62,7 +62,8 @@ class EntityRegistryTest extends FunSuite {
     partitionFlow <- partitionFlowOf.apply(
       topicPartition = TopicPartition.empty,
       assignedAt     = Offset.min,
-      scheduleCommit = ScheduleCommit.empty
+      scheduleCommit = ScheduleCommit.empty,
+      groupMetadata  = IO.pure(None)
     )
   } yield (partitionFlow, registry)
 

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/registry/EntityRegistryTest.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/registry/EntityRegistryTest.scala
@@ -60,10 +60,12 @@ class EntityRegistryTest extends FunSuite {
       config = PartitionFlowConfig()
     )
     partitionFlow <- partitionFlowOf.apply(
-      topicPartition = TopicPartition.empty,
-      assignedAt     = Offset.min,
-      scheduleCommit = ScheduleCommit.empty,
-      groupMetadata  = IO.pure(None)
+      PartitionAssignment[IO](
+        topicPartition = TopicPartition.empty,
+        assignedAt     = Offset.min,
+        groupMetadata  = IO.none
+      ),
+      ScheduleCommit.empty
     )
   } yield (partitionFlow, registry)
 

--- a/docs/kafka-single-writer-design.md
+++ b/docs/kafka-single-writer-design.md
@@ -98,9 +98,11 @@ Key points:
   (`CommitFailedException`) propagate into the flow and crash a stale owner, rather than being lost on a
   fire-and-forget commit thread.
 
-Wiring needs the input topic and a reader of the driving consumer's group metadata
-(`Consumer.groupMetadata`, captured on each partition assignment on the poll thread). A fence surfaces as
-`CommitFailedException` on the failing snapshot write (or offset-only commit).
+The mechanism needs the input topic-partition and a reader of the driving consumer's group metadata
+(`Consumer.groupMetadata`, captured on each partition assignment on the poll thread). Both are supplied by
+the flow from the partition assignment — not configured by hand — so they always match the consumer that
+drives the flow. A fence surfaces as `CommitFailedException` on the failing snapshot write (or offset-only
+commit).
 
 ### No epoch fencing
 

--- a/docs/kafka-single-writer-design.md
+++ b/docs/kafka-single-writer-design.md
@@ -99,10 +99,10 @@ Key points:
   fire-and-forget commit thread.
 
 The mechanism needs the input topic-partition and a reader of the driving consumer's group metadata
-(`Consumer.groupMetadata`, captured on each partition assignment on the poll thread). Both are supplied by
-the flow from the partition assignment — not configured by hand — so they always match the consumer that
-drives the flow. A fence surfaces as `CommitFailedException` on the failing snapshot write (or offset-only
-commit).
+(`Consumer.groupMetadata`, captured on each partition assignment and refreshed after every poll, on the
+poll thread). Both are supplied by the flow from the partition assignment — not configured by hand — so
+they always match the consumer that drives the flow. A fence surfaces as `CommitFailedException` on the
+failing snapshot write (or offset-only commit).
 
 ### No epoch fencing
 
@@ -153,8 +153,14 @@ Entry point: `KafkaPersistenceModuleOf.cachingTransactional`. In the current cod
   persistence-kafka `package` object). That bypasses the default path, where offsets are normally staged
   through `PendingCommits` and committed by `TopicFlow.commitPending` via `consumer.commit`; with nothing
   staged, it commits nothing (a no-op).
-- **Generation capture** on each partition assignment — the `Consumer` wrapper, holding `groupMetadata`
-  in a `Ref` read off the poll thread.
+- **Generation capture** — the `Consumer` wrapper, holding `groupMetadata` in a `Ref` read off the poll
+  thread. Captured on each partition assignment *before* the wrapped listener runs (the recovery and
+  flushes it triggers are gated by the generation that assigned them), and refreshed after every poll:
+  listeners see only partitions that changed hands, so a rebalance that assigns a member nothing new —
+  possible with a cooperative assignor — would otherwise leave the captured generation behind and
+  spuriously fence the next flush of a retained partition. Publishing after the poll is safe: revoked
+  partitions were flushed inside it under the pre-rebalance generation, so every flow still alive is
+  owned in the refreshed one.
 
 ## Measurements
 
@@ -222,12 +228,26 @@ with a recording in-memory producer (no broker).
   ([KIP-345](https://cwiki.apache.org/confluence/display/KAFKA/KIP-345%3A+Introduce+static+membership+protocol+to+reduce+consumer+rebalances))
   is not a substitute: it suppresses rebalances only for graceful restarts within `session.timeout.ms`,
   and does not fence a stuck owner whose session expired.)
+- **Live `groupMetadata` reads (no capture)**: would never lag, but flush-on-revoke runs inside the
+  rebalance callback, where the serialized consumer cannot be called (skafka exposes `RebalanceConsumer`
+  there for exactly this reason); the client reports an unknown generation mid-rejoin and after falling
+  out of the group, surfacing as wiring errors instead of a clean broker fence; and for a fencing token
+  lagging is safe (the member fences itself and replays) while leading could let a stale write land —
+  capture plus refresh keeps the safe side of that asymmetry by construction, not by scheduling luck.
 - **Transaction per write**: correct but O(keys) round-trips on the poll path (cap = 1 above).
 - **Unbounded batches**: ~7% faster, but transaction duration scales unbounded against the coordinator
   timeout.
 - **Transactional output produces (full exactly-once)**: out of scope; output stays at-least-once.
 
 ## Forward-looking
+
+This design is analyzed under the **classic** consumer rebalance protocol. Under
+[KIP-848](https://cwiki.apache.org/confluence/display/KAFKA/KIP-848%3A+The+Next+Generation+of+the+Consumer+Rebalance+Protocol)
+— GA since Kafka 4.0, supported by the kafka-clients on the classpath behind `group.protocol=consumer`
+(`classic` is the default) — the reported "generation" becomes a *member epoch* that can advance on the
+background heartbeat thread rather than only inside `poll`, validated as `STALE_MEMBER_EPOCH`. The
+fail-safe direction appears preserved (a lagging token self-fences), but the capture/refresh timing
+arguments here need re-auditing before the mode is used with it.
 
 [KIP-939 (participation in 2PC)](https://cwiki.apache.org/confluence/display/KAFKA/KIP-939:+Support+Participation+in+2PC)
 is the route to extend this fence to non-Kafka snapshot stores: a transactional producer in an

--- a/docs/kafka-single-writer-design.md
+++ b/docs/kafka-single-writer-design.md
@@ -158,9 +158,10 @@ Entry point: `KafkaPersistenceModuleOf.cachingTransactional`. In the current cod
   flushes it triggers are gated by the generation that assigned them), and refreshed after every poll:
   listeners see only partitions that changed hands, so a rebalance that assigns a member nothing new —
   possible with a cooperative assignor — would otherwise leave the captured generation behind and
-  spuriously fence the next flush of a retained partition. Publishing after the poll is safe: revoked
-  partitions were flushed inside it under the pre-rebalance generation, so every flow still alive is
-  owned in the refreshed one.
+  spuriously fence the next flush of a retained partition. Publishing after the poll is safe: the client
+  invokes revoked/lost before assigned and the refresh runs only after the poll, so a revoke-time flush can
+  never observe a newer token than its partitions were held under, and every flow that survives the poll is
+  owned in the refreshed generation.
 
 ## Measurements
 

--- a/docs/kafka-single-writer-design.md
+++ b/docs/kafka-single-writer-design.md
@@ -167,12 +167,11 @@ Entry point: `KafkaPersistenceModuleOf.cachingTransactional`. In the current cod
   contract — `onPartitionsRevoked`/`onPartitionsLost` run synchronously on the poll thread, before
   `onPartitionsAssigned` and before `poll` returns (`ConsumerRebalanceListener` javadoc) — together with
   `TopicFlow.remove` **awaiting** the teardown inside that callback (`cache.remove(_).flatten` under
-  `parTraverse_`, on both the revoked and lost paths). It is the *only* net for a lingering
-  foreign-partition flow (`TxnOffsetCommit` fences member + generation, not per-partition ownership), so
-  it hinges on that teardown staying synchronous and awaited. That postcondition is pinned by a unit test
-  (`TopicFlowSpec`, "remove awaits the flow teardown"): a partition flow whose release completes a
-  `Deferred`, asserted already completed by the time `remove` returns — so a future fire-and-forget
-  refactor fails the build. One nuance: a join round
+  `parTraverse_`, on both the revoked and lost paths). That await is the *only* thing keeping a lingering
+  foreign-partition flow off the wire — `TxnOffsetCommit` fences member + generation, not per-partition
+  ownership — so a fire-and-forget teardown would let a revoked flow commit under the next generation's
+  token. `TopicFlowSpec` ("remove awaits the flow teardown") fails the build if the await is dropped.
+  One nuance: a join round
   can span polls (KIP-266 —
   `poll(Duration)` does not block on it), so the refresh publishes the last *completed* join and converges
   on the poll after the round finishes; the interim lag only self-fences, never un-fences.

--- a/docs/kafka-single-writer-design.md
+++ b/docs/kafka-single-writer-design.md
@@ -249,6 +249,11 @@ with a recording in-memory producer (no broker).
   reports the unknown sentinel), so a live read buys no freshness there anyway; and for a fencing token
   lagging is safe (the member fences itself and replays) while leading could let a stale write land —
   capture plus refresh keeps the safe side of that asymmetry by construction, not by scheduling luck.
+  The unknown sentinel is a sharper hazard than a merely lagging token: it does not just fail to fence,
+  it *disables* the fence — the broker skips generation validation for the pre-KIP-447 `-1`/empty-`memberId`
+  shape, so an offset commit carrying it lands **unfenced**. That is why `Consumer.publish` refuses to
+  publish any `generationId < 0` at all (keeping the sentinel off the wire), a guard the lag/lead
+  asymmetry above does not cover.
 - **Transaction per write**: correct but O(keys) round-trips on the poll path (cap = 1 above).
 - **Unbounded batches**: ~7% faster, but transaction duration scales unbounded against the coordinator
   timeout.

--- a/docs/kafka-single-writer-design.md
+++ b/docs/kafka-single-writer-design.md
@@ -169,9 +169,10 @@ Entry point: `KafkaPersistenceModuleOf.cachingTransactional`. In the current cod
   `TopicFlow.remove` **awaiting** the teardown inside that callback (`cache.remove(_).flatten` under
   `parTraverse_`, on both the revoked and lost paths). It is the *only* net for a lingering
   foreign-partition flow (`TxnOffsetCommit` fences member + generation, not per-partition ownership), so
-  it hinges on that teardown staying synchronous and awaited — a property no test or model pins, so a
-  future refactor to fire-and-forget teardown would break it silently (future work: a post-poll
-  assertion that live flows ⊆ current assignment, or a teardown-race model). One nuance: a join round
+  it hinges on that teardown staying synchronous and awaited. `TopicFlow.remove` pins that postcondition
+  with a debug-level guard: after the awaited teardown it verifies no revoked partition is still live in
+  the cache and logs a breach otherwise, so a future fire-and-forget refactor trips a warning rather than
+  failing silently. One nuance: a join round
   can span polls (KIP-266 —
   `poll(Duration)` does not block on it), so the refresh publishes the last *completed* join and converges
   on the poll after the round finishes; the interim lag only self-fences, never un-fences.

--- a/docs/kafka-single-writer-design.md
+++ b/docs/kafka-single-writer-design.md
@@ -162,7 +162,16 @@ Entry point: `KafkaPersistenceModuleOf.cachingTransactional`. In the current cod
   cannot forward an empty set, so no observable callback fires). Publishing after the poll is safe: the
   client invokes revoked/lost before assigned and the refresh runs only after the poll, so a revoke-time
   flush can never observe a newer token than its partitions were held under, and every flow that survives
-  the poll is owned in the refreshed generation. One nuance: a join round can span polls (KIP-266 —
+  the poll is owned in the refreshed generation. That last step holds by Kafka's documented rebalance
+  contract — `onPartitionsRevoked`/`onPartitionsLost` run synchronously on the poll thread, before
+  `onPartitionsAssigned` and before `poll` returns (`ConsumerRebalanceListener` javadoc) — together with
+  `TopicFlow.remove` **awaiting** the teardown inside that callback (`cache.remove(_).flatten` under
+  `parTraverse_`, on both the revoked and lost paths). It is the *only* net for a lingering
+  foreign-partition flow (`TxnOffsetCommit` fences member + generation, not per-partition ownership), so
+  it hinges on that teardown staying synchronous and awaited — a property no test or model pins, so a
+  future refactor to fire-and-forget teardown would break it silently (future work: a post-poll
+  assertion that live flows ⊆ current assignment, or a teardown-race model). One nuance: a join round
+  can span polls (KIP-266 —
   `poll(Duration)` does not block on it), so the refresh publishes the last *completed* join and converges
   on the poll after the round finishes; the interim lag only self-fences, never un-fences.
 

--- a/docs/kafka-single-writer-design.md
+++ b/docs/kafka-single-writer-design.md
@@ -169,10 +169,10 @@ Entry point: `KafkaPersistenceModuleOf.cachingTransactional`. In the current cod
   `TopicFlow.remove` **awaiting** the teardown inside that callback (`cache.remove(_).flatten` under
   `parTraverse_`, on both the revoked and lost paths). It is the *only* net for a lingering
   foreign-partition flow (`TxnOffsetCommit` fences member + generation, not per-partition ownership), so
-  it hinges on that teardown staying synchronous and awaited. `TopicFlow.remove` pins that postcondition
-  with a debug-level guard: after the awaited teardown it verifies no revoked partition is still live in
-  the cache and logs a breach otherwise, so a future fire-and-forget refactor trips a warning rather than
-  failing silently. One nuance: a join round
+  it hinges on that teardown staying synchronous and awaited. That postcondition is pinned by a unit test
+  (`TopicFlowSpec`, "remove awaits the flow teardown"): a partition flow whose release completes a
+  `Deferred`, asserted already completed by the time `remove` returns — so a future fire-and-forget
+  refactor fails the build. One nuance: a join round
   can span polls (KIP-266 —
   `poll(Duration)` does not block on it), so the refresh publishes the last *completed* join and converges
   on the poll after the round finishes; the interim lag only self-fences, never un-fences.

--- a/docs/kafka-single-writer-design.md
+++ b/docs/kafka-single-writer-design.md
@@ -156,12 +156,15 @@ Entry point: `KafkaPersistenceModuleOf.cachingTransactional`. In the current cod
 - **Generation capture** — the `Consumer` wrapper, holding `groupMetadata` in a `Ref` read off the poll
   thread. Captured on each partition assignment *before* the wrapped listener runs (the recovery and
   flushes it triggers are gated by the generation that assigned them), and refreshed after every poll:
-  listeners see only partitions that changed hands, so a rebalance that assigns a member nothing new —
-  possible with a cooperative assignor — would otherwise leave the captured generation behind and
-  spuriously fence the next flush of a retained partition. Publishing after the poll is safe: the client
-  invokes revoked/lost before assigned and the refresh runs only after the poll, so a revoke-time flush can
-  never observe a newer token than its partitions were held under, and every flow that survives the poll is
-  owned in the refreshed generation.
+  a rebalance that assigns a member nothing new — possible with a cooperative assignor — would otherwise
+  leave the captured generation behind and spuriously fence the next flush of a retained partition
+  (kafka-clients invokes the assigned callback with an *empty* delta then, but the typed listener layer
+  cannot forward an empty set, so no observable callback fires). Publishing after the poll is safe: the
+  client invokes revoked/lost before assigned and the refresh runs only after the poll, so a revoke-time
+  flush can never observe a newer token than its partitions were held under, and every flow that survives
+  the poll is owned in the refreshed generation. One nuance: a join round can span polls (KIP-266 —
+  `poll(Duration)` does not block on it), so the refresh publishes the last *completed* join and converges
+  on the poll after the round finishes; the interim lag only self-fences, never un-fences.
 
 ## Measurements
 
@@ -231,8 +234,9 @@ with a recording in-memory producer (no broker).
   and does not fence a stuck owner whose session expired.)
 - **Live `groupMetadata` reads (no capture)**: would never lag, but flush-on-revoke runs inside the
   rebalance callback, where the serialized consumer cannot be called (skafka exposes `RebalanceConsumer`
-  there for exactly this reason); the client reports an unknown generation mid-rejoin and after falling
-  out of the group, surfacing as wiring errors instead of a clean broker fence; and for a fencing token
+  there for exactly this reason); the public `groupMetadata` deliberately keeps
+  the last *joined* token mid-rejoin and after falling out of the group (only the pre-first-join state
+  reports the unknown sentinel), so a live read buys no freshness there anyway; and for a fencing token
   lagging is safe (the member fences itself and replays) while leading could let a stale write land —
   capture plus refresh keeps the safe side of that asymmetry by construction, not by scheduling luck.
 - **Transaction per write**: correct but O(keys) round-trips on the poll path (cap = 1 above).

--- a/docs/kafka-single-writer-design.md
+++ b/docs/kafka-single-writer-design.md
@@ -45,8 +45,9 @@ transaction** via
 the group coordinator validates the consumer **generation** and rejects a commit from a stale one
 (`ILLEGAL_GENERATION`, surfaced to the client as `CommitFailedException`).
 Since that commit and the snapshot writes share a transaction, the rejection aborts the writes too.
-The generation — authoritative for partition ownership — gates both, so a stale owner can neither
-advance offsets nor overwrite a newer snapshot.
+The generation — the group's ownership authority, validated at commit time as member + generation
+(not per partition) — gates both, so a stale owner can neither advance offsets nor overwrite a newer
+snapshot.
 
 Seen as a whole, the mechanism combines two ideas — a distributed lock, and a transactional snapshot
 write + offset commit. Kafka's consumer group is the lock, and it already provides both an ownership

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -61,31 +61,38 @@ replays the affected events.
 
 ### Transactional snapshot writes (Kafka)
 
-Enable with `KafkaPersistenceModuleOf.cachingTransactional`, built from the consumer that drives the
-flow (it reads that consumer's group metadata to fence by generation):
+Enable with `KafkaPersistenceModuleOf.cachingTransactional`. The flow supplies the driving consumer's
+group metadata (generation) to the module, which uses it to fence stale writers — so you build the
+module like any other and wire it into the flow as usual:
 
 ```scala
-// allocate the driving consumer first so the module can read its group metadata (generation)
-consumer.use { consumer =>
-  val moduleOf = KafkaPersistenceModuleOf.cachingTransactional[F, State](
-    consumerOf = consumerOf,
-    producerOf = producerOf,
-    config = KafkaPersistenceModule.TransactionalConfig(
-      consumerConfig        = snapshotConsumerConfig,
-      producerConfig        = snapshotProducerConfig,
-      transactionalIdPrefix = s"$groupId-$inputTopic",
-      snapshotTopic         = stateTopic,
-      inputTopic            = inputTopic,
-    ),
-    groupMetadata = consumer.groupMetadata, // the SAME consumer that drives the flow
-  )
-  // ... wire moduleOf into the flow, driven by `consumer`
-}
+val moduleOf = KafkaPersistenceModuleOf.cachingTransactional[F, State](
+  consumerOf = consumerOf,
+  producerOf = producerOf,
+  config = KafkaPersistenceModule.TransactionalConfig(
+    consumerConfig        = snapshotConsumerConfig,
+    producerConfig        = snapshotProducerConfig,
+    transactionalIdPrefix = applicationId,
+    snapshotTopic         = stateTopic,
+  ),
+)
+// wire it into the flow as usual:
+// KafkaFlow.resource(consumerResource, ConsumerFlowOf(inputTopic, TopicFlowOf(kafkaEagerRecovery(moduleOf, /* ... */))))
 ```
 
 `idempotence` and the per-partition `transactional.id` are set for you — don't configure them in
 `producerConfig` — and the snapshot `consumerConfig`'s isolation level is forced to `read_committed`.
-The id is regenerated per assignment, not stable per partition.
+The id is regenerated per assignment, not stable per partition. The input topic whose offsets are
+committed transactionally, and the consumer generation used to fence stale writers, are both supplied
+by the flow (from the assigned partition and the driving consumer), so neither is part of
+`TransactionalConfig`. One module serves one flow: snapshots are keyed by partition *number* alone, so
+each input topic needs its own module with its own `snapshotTopic` — sharing a snapshot topic between
+flows would mix their state on recovery.
+
+`transactionalIdPrefix` does not affect fencing (that is by consumer generation) — it is a readable
+label and, on an ACL-secured cluster, the `transactional.id` prefix your producer principal must be
+authorized for. Use your `applicationId`; an application running several flows can append any per-flow
+discriminator (e.g. the input topic) — an `"<applicationId>*"` prefixed ACL still covers it.
 
 Snapshot writes and the input-offset commit run in one Kafka transaction per assigned partition; a
 write from a stale consumer generation is fenced by the broker

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -127,6 +127,9 @@ Limitations:
   downstream consumer of your output — can stall behind its last-stable-offset.
 - The mode always uses the identity `KafkaPersistencePartitionMapper` (fencing is per input partition);
   a non-identity mapper is not supported here.
+- Only the **classic** consumer rebalance protocol is supported — do not use the mode with KIP-848's
+  `group.protocol=consumer`. Today that protocol is not selectable through skafka's `ConsumerConfig`,
+  so this only concerns hand-wired consumers.
 
 ### Custom snapshot storage
 

--- a/metrics/src/main/scala/com/evolutiongaming/kafka/flow/PartitionFlowMetrics.scala
+++ b/metrics/src/main/scala/com/evolutiongaming/kafka/flow/PartitionFlowMetrics.scala
@@ -6,7 +6,7 @@ import com.evolutiongaming.catshelper.MeasureDuration
 import com.evolutiongaming.kafka.flow.kafka.ScheduleCommit
 import com.evolutiongaming.kafka.flow.metrics.MetricsOf
 import com.evolutiongaming.kafka.flow.metrics.syntax.*
-import com.evolutiongaming.skafka.consumer.ConsumerRecord
+import com.evolutiongaming.skafka.consumer.{ConsumerGroupMetadata, ConsumerRecord}
 import com.evolutiongaming.skafka.{Offset, TopicPartition}
 import com.evolutiongaming.smetrics.MetricsHelper.*
 import com.evolutiongaming.smetrics.{LabelNames, Quantile, Quantiles}
@@ -54,8 +54,13 @@ object PartitionFlowMetrics {
   implicit def partitionFlowOfMetricsOf[F[_]: Monad: MeasureDuration]: MetricsOf[F, PartitionFlowOf[F]] =
     partitionFlowMetricsOf[F] transform { implicit metrics => partitionFlowOf =>
       new PartitionFlowOf[F] {
-        def apply(topicPartition: TopicPartition, assignedAt: Offset, scheduleCommit: ScheduleCommit[F]) =
-          partitionFlowOf(topicPartition, assignedAt, scheduleCommit) map (_.withMetrics)
+        def apply(
+          topicPartition: TopicPartition,
+          assignedAt: Offset,
+          scheduleCommit: ScheduleCommit[F],
+          groupMetadata: F[Option[ConsumerGroupMetadata]]
+        ) =
+          partitionFlowOf(topicPartition, assignedAt, scheduleCommit, groupMetadata) map (_.withMetrics)
       }
     }
 

--- a/metrics/src/main/scala/com/evolutiongaming/kafka/flow/PartitionFlowMetrics.scala
+++ b/metrics/src/main/scala/com/evolutiongaming/kafka/flow/PartitionFlowMetrics.scala
@@ -6,8 +6,7 @@ import com.evolutiongaming.catshelper.MeasureDuration
 import com.evolutiongaming.kafka.flow.kafka.ScheduleCommit
 import com.evolutiongaming.kafka.flow.metrics.MetricsOf
 import com.evolutiongaming.kafka.flow.metrics.syntax.*
-import com.evolutiongaming.skafka.consumer.{ConsumerGroupMetadata, ConsumerRecord}
-import com.evolutiongaming.skafka.{Offset, TopicPartition}
+import com.evolutiongaming.skafka.consumer.ConsumerRecord
 import com.evolutiongaming.smetrics.MetricsHelper.*
 import com.evolutiongaming.smetrics.{LabelNames, Quantile, Quantiles}
 import scodec.bits.ByteVector
@@ -54,13 +53,8 @@ object PartitionFlowMetrics {
   implicit def partitionFlowOfMetricsOf[F[_]: Monad: MeasureDuration]: MetricsOf[F, PartitionFlowOf[F]] =
     partitionFlowMetricsOf[F] transform { implicit metrics => partitionFlowOf =>
       new PartitionFlowOf[F] {
-        def apply(
-          topicPartition: TopicPartition,
-          assignedAt: Offset,
-          scheduleCommit: ScheduleCommit[F],
-          groupMetadata: F[Option[ConsumerGroupMetadata]]
-        ) =
-          partitionFlowOf(topicPartition, assignedAt, scheduleCommit, groupMetadata) map (_.withMetrics)
+        def apply(assignment: PartitionAssignment[F], scheduleCommit: ScheduleCommit[F]) =
+          partitionFlowOf(assignment, scheduleCommit) map (_.withMetrics)
       }
     }
 

--- a/persistence-kafka-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/StatefulProcessingWithKafkaSpec.scala
+++ b/persistence-kafka-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/StatefulProcessingWithKafkaSpec.scala
@@ -8,7 +8,7 @@ import cats.syntax.all.*
 import com.evolution.playjson.jsoniter.PlayJsonJsoniter
 import com.evolutiongaming.catshelper.{Log, LogOf}
 import com.evolutiongaming.kafka.flow.StatefulProcessingWithKafkaSpec.*
-import com.evolutiongaming.kafka.flow.kafka.{Consumer, KafkaModule}
+import com.evolutiongaming.kafka.flow.kafka.KafkaModule
 import com.evolutiongaming.kafka.flow.kafkapersistence.{
   KafkaPersistenceModule,
   KafkaPersistenceModuleOf,
@@ -20,9 +20,15 @@ import com.evolutiongaming.kafka.flow.registry.EntityRegistry
 import com.evolutiongaming.kafka.flow.snapshot.{SnapshotDatabase, SnapshotsOf}
 import com.evolutiongaming.kafka.flow.timer.{TimerFlowOf, TimersOf}
 import com.evolutiongaming.retry.Retry
-import com.evolutiongaming.skafka.consumer.{AutoOffsetReset, ConsumerConfig, ConsumerOf, ConsumerRecord}
+import com.evolutiongaming.skafka.consumer.{
+  AutoOffsetReset,
+  ConsumerConfig,
+  ConsumerGroupMetadata,
+  ConsumerOf,
+  ConsumerRecord
+}
 import com.evolutiongaming.skafka.producer.{ProducerConfig, ProducerOf, ProducerRecord, RecordMetadata}
-import com.evolutiongaming.skafka.{Bytes, CommonConfig, Offset, Partition}
+import com.evolutiongaming.skafka.{Bytes, CommonConfig, Offset, Partition, TopicPartition}
 import play.api.libs.json.{JsResultException, Json, OFormat}
 import scodec.bits.ByteVector
 
@@ -73,7 +79,11 @@ class StatefulProcessingWithKafkaSpec extends ForAllKafkaSuite {
 
   private val inMemoryPersistenceModuleOf: KafkaPersistenceModuleOf[IO, State] =
     new KafkaPersistenceModuleOf[IO, State] {
-      override def make(partition: Partition, assignedAt: Offset): Resource[IO, KafkaPersistenceModule[IO, State]] =
+      override def make(
+        topicPartition: TopicPartition,
+        assignedAt: Offset,
+        groupMetadata: IO[Option[ConsumerGroupMetadata]]
+      ): Resource[IO, KafkaPersistenceModule[IO, State]] =
         Resource.pure(inMemoryPersistenceModule)
     }
 
@@ -121,14 +131,14 @@ class StatefulProcessingWithKafkaSpec extends ForAllKafkaSuite {
   test("stateful processing using in-memory persistence") {
     // unique input topic per test to isolate tests (munit suites run in parallel)
     val inputTopic = "in-memory-persistence-test"
-    comboTestCase(kafkaModule(), _ => inMemoryPersistenceModuleOf, inputTopic).unsafeRunSync()
+    comboTestCase(kafkaModule(), inMemoryPersistenceModuleOf, inputTopic).unsafeRunSync()
   }
 
   test("stateful processing using kafka persistence") {
     // unique input topic per test to isolate tests (munit suites run in parallel)
     val inputTopic = "kafka-persistence-test"
     kafkaPersistenceModuleOf
-      .use(module => comboTestCase(kafkaModule(), _ => module, inputTopic))
+      .use(module => comboTestCase(kafkaModule(), module, inputTopic))
       .unsafeRunSync()
   }
 
@@ -137,9 +147,9 @@ class StatefulProcessingWithKafkaSpec extends ForAllKafkaSuite {
     val inputTopic = "kafka-transactional-persistence-test"
     val stateTopic = "state-topic-tx-StatefulProcessingWithKafkaSpec"
 
-    // the module reads the driving consumer's group metadata so offsets are committed transactionally with the
-    // snapshot writes; the recovery assertions below would fail if those offset commits did not land
-    def makeModuleOf(consumer: Consumer[IO]): KafkaPersistenceModuleOf[IO, State] =
+    // the framework supplies the driving consumer's group metadata to the module, so offsets are committed
+    // transactionally with the snapshot writes; the recovery assertions below would fail if those commits did not land
+    val moduleOf: KafkaPersistenceModuleOf[IO, State] =
       KafkaPersistenceModuleOf.cachingTransactional[IO, State](
         consumerOf = ConsumerOf.apply1[IO](),
         producerOf = ProducerOf.apply1[IO](),
@@ -150,33 +160,29 @@ class StatefulProcessingWithKafkaSpec extends ForAllKafkaSuite {
             autoOffsetReset = AutoOffsetReset.Earliest
           ),
           producerConfig        = producerConfig,
-          transactionalIdPrefix = s"$testGroupId-$inputTopic",
+          transactionalIdPrefix = appId,
           snapshotTopic         = stateTopic,
-          inputTopic            = inputTopic,
         ),
-        groupMetadata = consumer.groupMetadata,
       )
 
-    (createTopic(stateTopic, 2) *> comboTestCase(kafkaModule(), makeModuleOf, inputTopic)).unsafeRunSync()
+    (createTopic(stateTopic, 2) *> comboTestCase(kafkaModule(), moduleOf, inputTopic)).unsafeRunSync()
   }
 
-  // the module factory is built from the consumer that drives the flow so that, in transactional mode, the snapshot
-  // writer can read that consumer's group metadata (generation) for offset binding; non-transactional cases ignore it
   private def comboTestCase(
     kafka: KafkaModule[IO],
-    makeModuleOf: Consumer[IO] => KafkaPersistenceModuleOf[IO, State],
+    moduleOf: KafkaPersistenceModuleOf[IO, State],
     inputTopic: String
   ): IO[Unit] = {
     for {
       _ <- createTopic(inputTopic, 2)
-      _ <- testCase(kafka, makeModuleOf, inputTopic, Partition.unsafe(0), "key0")
-      _ <- testCase(kafka, makeModuleOf, inputTopic, Partition.unsafe(1), "key1")
+      _ <- testCase(kafka, moduleOf, inputTopic, Partition.unsafe(0), "key0")
+      _ <- testCase(kafka, moduleOf, inputTopic, Partition.unsafe(1), "key1")
     } yield ()
   }
 
   private def testCase(
     kafka: KafkaModule[IO],
-    makeModuleOf: Consumer[IO] => KafkaPersistenceModuleOf[IO, State],
+    moduleOf: KafkaPersistenceModuleOf[IO, State],
     inputTopic: String,
     partition: Partition,
     key: String
@@ -193,26 +199,22 @@ class StatefulProcessingWithKafkaSpec extends ForAllKafkaSuite {
       }
     }
 
-    // allocate the consumer first, then build the module from it (so transactional offset binding reads this
-    // consumer's generation) and drive the flow with the same consumer instance
     def program: IO[List[Output]] =
-      kafka.consumerOf("groupId-StatefulProcessingWithKafkaSpec").use { consumer =>
-        for {
-          output   <- Ref.of[IO, List[Output]](List.empty)
-          finished <- Deferred[IO, Unit]
-          flowOf   <- topicFlowOf(makeModuleOf(consumer), output, finished)
-          run = KafkaFlow.resource(
-            consumer = Resource.pure[IO, Consumer[IO]](consumer),
-            flowOf = ConsumerFlowOf[IO](
-              topic  = inputTopic,
-              flowOf = flowOf
-            )
+      for {
+        output   <- Ref.of[IO, List[Output]](List.empty)
+        finished <- Deferred[IO, Unit]
+        flowOf   <- topicFlowOf(moduleOf, output, finished)
+        run = KafkaFlow.resource(
+          consumer = kafka.consumerOf("groupId-StatefulProcessingWithKafkaSpec"),
+          flowOf = ConsumerFlowOf[IO](
+            topic  = inputTopic,
+            flowOf = flowOf
           )
-          // wait for records to be processed
-          _      <- run.use(_ => finished.get.timeout(5.seconds))
-          output <- output.get
-        } yield output
-      }
+        )
+        // wait for records to be processed
+        _      <- run.use(_ => finished.get.timeout(5.seconds))
+        output <- output.get
+      } yield output
 
     for {
       _      <- produceInput(1)

--- a/persistence-kafka-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/StatefulProcessingWithKafkaSpec.scala
+++ b/persistence-kafka-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/StatefulProcessingWithKafkaSpec.scala
@@ -20,15 +20,9 @@ import com.evolutiongaming.kafka.flow.registry.EntityRegistry
 import com.evolutiongaming.kafka.flow.snapshot.{SnapshotDatabase, SnapshotsOf}
 import com.evolutiongaming.kafka.flow.timer.{TimerFlowOf, TimersOf}
 import com.evolutiongaming.retry.Retry
-import com.evolutiongaming.skafka.consumer.{
-  AutoOffsetReset,
-  ConsumerConfig,
-  ConsumerGroupMetadata,
-  ConsumerOf,
-  ConsumerRecord
-}
+import com.evolutiongaming.skafka.consumer.{AutoOffsetReset, ConsumerConfig, ConsumerOf, ConsumerRecord}
 import com.evolutiongaming.skafka.producer.{ProducerConfig, ProducerOf, ProducerRecord, RecordMetadata}
-import com.evolutiongaming.skafka.{Bytes, CommonConfig, Offset, Partition, TopicPartition}
+import com.evolutiongaming.skafka.{Bytes, CommonConfig, Partition}
 import play.api.libs.json.{JsResultException, Json, OFormat}
 import scodec.bits.ByteVector
 
@@ -80,9 +74,7 @@ class StatefulProcessingWithKafkaSpec extends ForAllKafkaSuite {
   private val inMemoryPersistenceModuleOf: KafkaPersistenceModuleOf[IO, State] =
     new KafkaPersistenceModuleOf[IO, State] {
       override def make(
-        topicPartition: TopicPartition,
-        assignedAt: Offset,
-        groupMetadata: IO[Option[ConsumerGroupMetadata]]
+        assignment: PartitionAssignment[IO]
       ): Resource[IO, KafkaPersistenceModule[IO, State]] =
         Resource.pure(inMemoryPersistenceModule)
     }

--- a/persistence-kafka-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/TransactionalKafkaPersistenceSpec.scala
+++ b/persistence-kafka-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/TransactionalKafkaPersistenceSpec.scala
@@ -144,7 +144,9 @@ class TransactionalKafkaPersistenceSpec extends ForAllKafkaSuite {
     */
   private def staleFlushScenario(
     moduleOfA: KafkaPersistenceModuleOf[IO, String],
+    groupMetadataA: IO[Option[ConsumerGroupMetadata]],
     moduleOfB: KafkaPersistenceModuleOf[IO, String],
+    groupMetadataB: IO[Option[ConsumerGroupMetadata]],
     stateTopic: String,
     key: String,
   ): IO[(Either[Throwable, Unit], BytesByKey)] = {
@@ -153,17 +155,23 @@ class TransactionalKafkaPersistenceSpec extends ForAllKafkaSuite {
     val eventsA    = (1 to 5).toList.map(i => s"e$i")
     val eventsB    = (1 to 10).toList.map(i => s"e$i")
 
-    def allocateFlow(moduleOf: KafkaPersistenceModuleOf[IO, String]): IO[(PartitionFlow[IO], IO[Unit])] =
-      flowOf(moduleOf, flushOnRevokeOnly).flatMap(_.apply(tp, Offset.min, ScheduleCommit.empty[IO]).allocated)
+    // each flow gets its own generation: flow A (the previous owner) a stale one, flow B (the new owner) the current one
+    def allocateFlow(
+      moduleOf: KafkaPersistenceModuleOf[IO, String],
+      groupMetadata: IO[Option[ConsumerGroupMetadata]],
+    ): IO[(PartitionFlow[IO], IO[Unit])] =
+      flowOf(moduleOf, flushOnRevokeOnly).flatMap(
+        _.apply(tp, Offset.min, ScheduleCommit.empty[IO], groupMetadata).allocated
+      )
 
     for {
       _ <- createTopic(stateTopic, 1)
       // the previous owner: folds events, snapshots stay buffered in memory
-      flowA             <- allocateFlow(moduleOfA)
+      flowA             <- allocateFlow(moduleOfA, groupMetadataA)
       (flowA_, releaseA) = flowA
       _                 <- flowA_(inputRecords(inputTopic, key, eventsA))
       // the new owner: eagerly recovers (finds nothing), folds all events, flushes on release
-      flowB             <- allocateFlow(moduleOfB)
+      flowB             <- allocateFlow(moduleOfB, groupMetadataB)
       (flowB_, releaseB) = flowB
       _                 <- flowB_(inputRecords(inputTopic, key, eventsB))
       _                 <- releaseB
@@ -191,7 +199,9 @@ class TransactionalKafkaPersistenceSpec extends ForAllKafkaSuite {
         consumerConfig = consumerConfig,
         snapshotTopic  = stateTopic,
       )
-      staleFlushScenario(moduleOf, moduleOf, stateTopic, key).map {
+      // caching (non-transactional) ignores group metadata
+      val noGm = IO.pure(none[ConsumerGroupMetadata])
+      staleFlushScenario(moduleOf, noGm, moduleOf, noGm, stateTopic, key).map {
         case (staleFlush, stored) =>
           assertEquals(clue(staleFlush), Right(()))
           // recovery now returns the STALE snapshot (events 6..10 are lost although the new owner persisted them):
@@ -209,24 +219,22 @@ class TransactionalKafkaPersistenceSpec extends ForAllKafkaSuite {
     val group      = s"$groupId-flush-on-revoke"
     val key        = "key1"
 
-    def moduleOf(gm: ConsumerGroupMetadata): KafkaPersistenceModuleOf[IO, String] =
+    val moduleOf: KafkaPersistenceModuleOf[IO, String] =
       KafkaPersistenceModuleOf.cachingTransactional[IO, String](
         consumerOf = consumerOf,
         producerOf = producerOf,
         config = KafkaPersistenceModule.TransactionalConfig(
           consumerConfig        = consumerConfig,
           producerConfig        = producerConfig,
-          transactionalIdPrefix = s"$group-$inputTopic",
+          transactionalIdPrefix = appId,
           snapshotTopic         = stateTopic,
-          inputTopic            = inputTopic,
         ),
-        groupMetadata = IO.pure(gm.some),
       )
 
     // the previous owner (flow A) carries a stale generation; the new owner (flow B) carries the current one
     val test = createTopic(inputTopic, 1) *> withJoinedConsumer(group, inputTopic) { current =>
       val stale = staleGeneration(current)
-      staleFlushScenario(moduleOf(stale), moduleOf(current), stateTopic, key).map {
+      staleFlushScenario(moduleOf, IO.pure(stale.some), moduleOf, IO.pure(current.some), stateTopic, key).map {
         case (staleFlush, stored) =>
           // the release itself succeeds: the rejected write surfaces as a logged-and-swallowed cache entry release
           // error ("scache: failed to release cache entry: ... CommitFailedException"), which is the desired
@@ -259,18 +267,17 @@ class TransactionalKafkaPersistenceSpec extends ForAllKafkaSuite {
             config = KafkaPersistenceModule.TransactionalConfig(
               consumerConfig        = consumerConfig,
               producerConfig        = producerConfig,
-              transactionalIdPrefix = s"$group-$inputTopic",
+              transactionalIdPrefix = appId,
               snapshotTopic         = stateTopic,
-              inputTopic            = inputTopic,
             ),
-            groupMetadata = gmRef.get.map(_.some),
           )
-          // flush on every records application, so the writer hits the conflict on its next poll cycle
+          // flush on every records application, so the writer hits the conflict on its next poll cycle; the generation
+          // is read live from gmRef at flush time, so flipping it to stale below takes effect on the next flush
           flow <- flowOf(
             moduleOf,
             TimerFlowOf.persistPeriodically[IO](fireEvery = 0.seconds, persistEvery = 0.seconds),
             PartitionFlowConfig(triggerTimersInterval     = 0.seconds),
-          ).flatMap(_.apply(tp, Offset.min, ScheduleCommit.empty[IO]).allocated)
+          ).flatMap(_.apply(tp, Offset.min, ScheduleCommit.empty[IO], gmRef.get.map(_.some)).allocated)
           (flow_, release) = flow
           // persists fine while the generation is current
           _ <- flow_(inputRecords(inputTopic, key, List("e1", "e2", "e3")))

--- a/persistence-kafka-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/TransactionalKafkaPersistenceSpec.scala
+++ b/persistence-kafka-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/TransactionalKafkaPersistenceSpec.scala
@@ -13,6 +13,7 @@ import com.evolutiongaming.kafka.flow.{
   FoldOption,
   ForAllKafkaSuite,
   KafkaKey,
+  PartitionAssignment,
   PartitionFlow,
   PartitionFlowConfig,
   PartitionFlowOf,
@@ -161,7 +162,7 @@ class TransactionalKafkaPersistenceSpec extends ForAllKafkaSuite {
       groupMetadata: IO[Option[ConsumerGroupMetadata]],
     ): IO[(PartitionFlow[IO], IO[Unit])] =
       flowOf(moduleOf, flushOnRevokeOnly).flatMap(
-        _.apply(tp, Offset.min, ScheduleCommit.empty[IO], groupMetadata).allocated
+        _.apply(PartitionAssignment(tp, Offset.min, groupMetadata), ScheduleCommit.empty[IO]).allocated
       )
 
     for {
@@ -277,7 +278,12 @@ class TransactionalKafkaPersistenceSpec extends ForAllKafkaSuite {
             moduleOf,
             TimerFlowOf.persistPeriodically[IO](fireEvery = 0.seconds, persistEvery = 0.seconds),
             PartitionFlowConfig(triggerTimersInterval     = 0.seconds),
-          ).flatMap(_.apply(tp, Offset.min, ScheduleCommit.empty[IO], gmRef.get.map(_.some)).allocated)
+          ).flatMap(
+            _.apply(
+              PartitionAssignment(tp, Offset.min, gmRef.get.map(_.some)),
+              ScheduleCommit.empty[IO]
+            ).allocated
+          )
           (flow_, release) = flow
           // persists fine while the generation is current
           _ <- flow_(inputRecords(inputTopic, key, List("e1", "e2", "e3")))

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModule.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModule.scala
@@ -13,7 +13,7 @@ import com.evolutiongaming.kafka.flow.snapshot.{SnapshotDatabase, SnapshotWriteD
 import com.evolutiongaming.kafka.flow.{FlowMetrics, KafkaKey}
 import com.evolutiongaming.skafka.consumer.{ConsumerConfig, ConsumerGroupMetadata, ConsumerOf, IsolationLevel}
 import com.evolutiongaming.skafka.producer.{Producer, ProducerConfig, ProducerOf}
-import com.evolutiongaming.skafka.{FromBytes, Offset, Partition, ToBytes, Topic, TopicPartition}
+import com.evolutiongaming.skafka.{FromBytes, Offset, ToBytes, Topic, TopicPartition}
 import com.evolutiongaming.sstream.Stream
 import scodec.bits.ByteVector
 import com.evolutiongaming.skafka.consumer.ConsumerRecord
@@ -43,13 +43,13 @@ object KafkaPersistenceModule {
     *   base config for the snapshot producer; `transactionalId` and `idempotence` are overridden per producer and
     *   `clientId` is suffixed with it
     * @param transactionalIdPrefix
-    *   prefix for `transactional.id` (partition number and a unique per-producer suffix are appended). Fencing is by
-    *   consumer generation, not this id, so it is just a readable label (e.g. a `"<groupId>-<inputTopic>"` string).
+    *   prefix for `transactional.id` (partition number and a unique per-producer suffix are appended). It does not
+    *   affect fencing (that is by consumer generation), so its only roles are a readable label and, on an ACL-secured
+    *   cluster, the `transactional.id` prefix the producer principal must be authorized for. Use your `applicationId`;
+    *   an application running several flows can append any per-flow discriminator (e.g. the input topic), which an
+    *   `"<applicationId>*"` prefixed ACL still covers.
     * @param snapshotTopic
     *   snapshot topic name (should be configured as a 'compacted' topic) to read/write snapshots
-    * @param inputTopic
-    *   the input topic kafka-flow consumes; its offsets are committed transactionally with the snapshot writes (same
-    *   partition number as the snapshot partition - the mode forces the identity mapping)
     * @param maxWritesPerTransaction
     *   upper bound of snapshot writes group committed in one per-partition, serialized transaction, see
     *   [[KafkaSnapshotWriteDatabase.transactional]]
@@ -59,14 +59,14 @@ object KafkaPersistenceModule {
     producerConfig: ProducerConfig,
     transactionalIdPrefix: String,
     snapshotTopic: Topic,
-    inputTopic: Topic,
     maxWritesPerTransaction: Int = KafkaSnapshotWriteDatabase.DefaultMaxWritesPerTransaction,
   )
 
   /** The per-assignment context [[cachingTransactional]] needs to fence stale writers.
     *
-    * @param partition
-    *   the assigned partition (used for both the snapshot and the input topic-partition)
+    * @param inputTopicPartition
+    *   the assigned input topic-partition; its offsets are committed into the snapshot transaction, and its partition
+    *   number is reused for the snapshot topic-partition (the mode forces the identity mapping)
     * @param assignedAt
     *   the offset the partition was assigned at; seeds the offset-to-commit so even the first write is generation-gated
     * @param groupMetadata
@@ -74,7 +74,7 @@ object KafkaPersistenceModule {
     *   fences a stale owner (KIP-447). `None` means the consumer is not joined.
     */
   final case class PartitionAssignment[F[_]](
-    partition: Partition,
+    inputTopicPartition: TopicPartition,
     assignedAt: Offset,
     groupMetadata: F[Option[ConsumerGroupMetadata]],
   )
@@ -176,7 +176,7 @@ object KafkaPersistenceModule {
     fromBytesState: FromBytes[F, S],
     toBytesState: ToBytes[F, S]
   ): Resource[F, KafkaPersistenceModule[F, S]] = {
-    val snapshotTopicPartition = TopicPartition(config.snapshotTopic, assignment.partition)
+    val snapshotTopicPartition = TopicPartition(config.snapshotTopic, assignment.inputTopicPartition.partition)
     for {
       transactional <- transactionalWriteDatabase[F, S](producerOf, config, assignment, snapshotTopicPartition)
       // records of aborted transactions (e.g. of a fenced previous owner) must not be recovered as snapshots
@@ -207,12 +207,10 @@ object KafkaPersistenceModule {
     implicit toBytesState: ToBytes[F, S]
   ): Resource[F, KafkaSnapshotWriteDatabase.Transactional[F, S]] = {
     implicit val fromTry: FromTry[F] = FromTry.lift
-    import config.{inputTopic, maxWritesPerTransaction, producerConfig, transactionalIdPrefix}
-    import assignment.{assignedAt, groupMetadata, partition}
+    import config.{maxWritesPerTransaction, producerConfig, transactionalIdPrefix}
+    import assignment.{assignedAt, groupMetadata, inputTopicPartition}
 
-    // offsets are committed for the input partition with the same number as the assigned (snapshot) partition - the
-    // mode forces the identity mapping
-    val inputTopicPartition = TopicPartition(inputTopic, partition)
+    val partition = inputTopicPartition.partition
 
     for {
       // unique per producer: fencing is by consumer generation, not this id, so a fresh id per assignment is fine

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModule.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModule.scala
@@ -10,10 +10,10 @@ import com.evolutiongaming.kafka.flow.key.{Keys, KeysOf}
 import com.evolutiongaming.kafka.flow.metrics.syntax.*
 import com.evolutiongaming.kafka.flow.persistence.{PersistenceOf, SnapshotPersistenceOf}
 import com.evolutiongaming.kafka.flow.snapshot.{SnapshotDatabase, SnapshotWriteDatabase, SnapshotsOf}
-import com.evolutiongaming.kafka.flow.{FlowMetrics, KafkaKey}
-import com.evolutiongaming.skafka.consumer.{ConsumerConfig, ConsumerGroupMetadata, ConsumerOf, IsolationLevel}
+import com.evolutiongaming.kafka.flow.{FlowMetrics, KafkaKey, PartitionAssignment}
+import com.evolutiongaming.skafka.consumer.{ConsumerConfig, ConsumerOf, IsolationLevel}
 import com.evolutiongaming.skafka.producer.{Producer, ProducerConfig, ProducerOf}
-import com.evolutiongaming.skafka.{FromBytes, Offset, ToBytes, Topic, TopicPartition}
+import com.evolutiongaming.skafka.{FromBytes, ToBytes, Topic, TopicPartition}
 import com.evolutiongaming.sstream.Stream
 import scodec.bits.ByteVector
 import com.evolutiongaming.skafka.consumer.ConsumerRecord
@@ -60,23 +60,6 @@ object KafkaPersistenceModule {
     transactionalIdPrefix: String,
     snapshotTopic: Topic,
     maxWritesPerTransaction: Int = KafkaSnapshotWriteDatabase.DefaultMaxWritesPerTransaction,
-  )
-
-  /** The per-assignment context [[cachingTransactional]] needs to fence stale writers.
-    *
-    * @param inputTopicPartition
-    *   the assigned input topic-partition; its offsets are committed into the snapshot transaction, and its partition
-    *   number is reused for the snapshot topic-partition (the mode forces the identity mapping)
-    * @param assignedAt
-    *   the offset the partition was assigned at; seeds the offset-to-commit so even the first write is generation-gated
-    * @param groupMetadata
-    *   group metadata of the SAME consumer that drives this flow (use `Consumer.groupMetadata`); its generation is what
-    *   fences a stale owner (KIP-447). `None` means the consumer is not joined.
-    */
-  final case class PartitionAssignment[F[_]](
-    inputTopicPartition: TopicPartition,
-    assignedAt: Offset,
-    groupMetadata: F[Option[ConsumerGroupMetadata]],
   )
 
   def caching[F[_]: LogOf: Concurrent: Parallel: Runtime, S](
@@ -164,6 +147,10 @@ object KafkaPersistenceModule {
     * `read_committed`, and unlike `caching` the identity partition mapping is always used; output stays at-least-once.
     * See the "Protecting against stale snapshot writes" persistence docs for guarantees, limitations, costs and
     * rollout, and `docs/kafka-single-writer-design.md` for the mechanism.
+    *
+    * The `assignment` must describe the input partition of the SAME consumer that drives this flow (its `groupMetadata`
+    * generation is what fences a stale owner); `assignedAt` seeds the offset-to-commit so even the first write is
+    * generation-gated, and the input partition number is reused for the snapshot topic-partition.
     */
   def cachingTransactional[F[_]: LogOf: Async: Parallel: Runtime, S](
     consumerOf: ConsumerOf[F],
@@ -176,7 +163,7 @@ object KafkaPersistenceModule {
     fromBytesState: FromBytes[F, S],
     toBytesState: ToBytes[F, S]
   ): Resource[F, KafkaPersistenceModule[F, S]] = {
-    val snapshotTopicPartition = TopicPartition(config.snapshotTopic, assignment.inputTopicPartition.partition)
+    val snapshotTopicPartition = TopicPartition(config.snapshotTopic, assignment.topicPartition.partition)
     for {
       transactional <- transactionalWriteDatabase[F, S](producerOf, config, assignment, snapshotTopicPartition)
       // records of aborted transactions (e.g. of a fenced previous owner) must not be recovered as snapshots
@@ -208,7 +195,7 @@ object KafkaPersistenceModule {
   ): Resource[F, KafkaSnapshotWriteDatabase.Transactional[F, S]] = {
     implicit val fromTry: FromTry[F] = FromTry.lift
     import config.{maxWritesPerTransaction, producerConfig, transactionalIdPrefix}
-    import assignment.{assignedAt, groupMetadata, inputTopicPartition}
+    import assignment.{assignedAt, groupMetadata, topicPartition as inputTopicPartition}
 
     val partition = inputTopicPartition.partition
 

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModule.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModule.scala
@@ -145,8 +145,10 @@ object KafkaPersistenceModule {
     * commit the input offset. A stale consumer generation is rejected by the broker (KIP-447), aborting the
     * transaction, so a stale owner can neither advance offsets nor overwrite a newer snapshot. Recovery reads with
     * `read_committed`, and unlike `caching` the identity partition mapping is always used; output stays at-least-once.
-    * See the "Protecting against stale snapshot writes" persistence docs for guarantees, limitations, costs and
-    * rollout, and `docs/kafka-single-writer-design.md` for the mechanism.
+    * Only the classic consumer rebalance protocol is supported - do not use with KIP-848's `group.protocol=consumer`
+    * (not selectable through skafka's `ConsumerConfig` today). See the "Protecting against stale snapshot writes"
+    * persistence docs for guarantees, limitations, costs and rollout, and `docs/kafka-single-writer-design.md` for the
+    * mechanism.
     *
     * The `assignment` must describe the input partition of the SAME consumer that drives this flow (its `groupMetadata`
     * generation is what fences a stale owner); `assignedAt` seeds the offset-to-commit so even the first write is

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModuleOf.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModuleOf.scala
@@ -9,11 +9,16 @@ import com.evolutiongaming.skafka.producer.{Producer, ProducerOf}
 import com.evolutiongaming.skafka.*
 
 /** Convenience factory trait to create an instance of [[KafkaPersistenceModule]] for an assigned partition.
-  * `assignedAt` is the offset the partition was assigned at; the transactional module seeds it as the initial
-  * offset-to-commit (ignored by the non-transactional caching module).
+  * `assignedAt` and `groupMetadata` are supplied by the flow and used only by the transactional module - to seed the
+  * initial offset-to-commit and to fence stale writers (KIP-447) respectively; the non-transactional caching module
+  * ignores both.
   */
 trait KafkaPersistenceModuleOf[F[_], S] {
-  def make(partition: Partition, assignedAt: Offset): Resource[F, KafkaPersistenceModule[F, S]]
+  def make(
+    topicPartition: TopicPartition,
+    assignedAt: Offset,
+    groupMetadata: F[Option[ConsumerGroupMetadata]]
+  ): Resource[F, KafkaPersistenceModule[F, S]]
 }
 
 object KafkaPersistenceModuleOf {
@@ -46,13 +51,17 @@ object KafkaPersistenceModuleOf {
     fromBytesState: FromBytes[F, S],
     toBytesState: ToBytes[F, S]
   ): KafkaPersistenceModuleOf[F, S] = new KafkaPersistenceModuleOf[F, S] {
-    // assignedAt is unused: the non-transactional caching module does not commit offsets through a producer
-    override def make(partition: Partition, assignedAt: Offset): Resource[F, KafkaPersistenceModule[F, S]] =
+    // caching ignores assignedAt/groupMetadata - it doesn't commit offsets through a producer
+    override def make(
+      topicPartition: TopicPartition,
+      assignedAt: Offset,
+      groupMetadata: F[Option[ConsumerGroupMetadata]]
+    ): Resource[F, KafkaPersistenceModule[F, S]] =
       KafkaPersistenceModule.caching(
         consumerOf             = consumerOf,
         producer               = producer,
         consumerConfig         = consumerConfig,
-        snapshotTopicPartition = TopicPartition(snapshotTopic, partition),
+        snapshotTopicPartition = TopicPartition(snapshotTopic, topicPartition.partition),
         metrics                = metrics,
         partitionMapper        = partitionMapper,
       )
@@ -70,31 +79,30 @@ object KafkaPersistenceModuleOf {
   ): KafkaPersistenceModuleOf[F, S] =
     caching(consumerOf, producer, consumerConfig, snapshotTopic, FlowMetrics.empty[F])
 
-  /** Create a [[KafkaPersistenceModuleOf]] factory producing transactional [[KafkaPersistenceModule]]s that protect the
-    * snapshot topic from stale writers. See `KafkaPersistenceModule.cachingTransactional` for semantics and trade-offs.
-    * The snapshot and input topics are part of `config` (see [[KafkaPersistenceModule.TransactionalConfig]]).
-    *
-    * @param groupMetadata
-    *   group metadata of the SAME consumer that drives this flow (use `Consumer.groupMetadata`); its generation is what
-    *   fences a stale owner (KIP-447)
+  /** A transactional [[KafkaPersistenceModule]] factory that protects the snapshot topic from stale writers - see
+    * `KafkaPersistenceModule.cachingTransactional` for semantics and trade-offs. The input topic and consumer
+    * generation are supplied by the flow, so they are not part of `config`.
     */
   def cachingTransactional[F[_]: LogOf: Async: Parallel: Runtime, S](
     consumerOf: ConsumerOf[F],
     producerOf: ProducerOf[F],
     config: KafkaPersistenceModule.TransactionalConfig,
-    groupMetadata: F[Option[ConsumerGroupMetadata]],
     metrics: FlowMetrics[F] = FlowMetrics.empty[F],
   )(
     implicit fromBytesKey: FromBytes[F, String],
     fromBytesState: FromBytes[F, S],
     toBytesState: ToBytes[F, S]
   ): KafkaPersistenceModuleOf[F, S] = new KafkaPersistenceModuleOf[F, S] {
-    override def make(partition: Partition, assignedAt: Offset): Resource[F, KafkaPersistenceModule[F, S]] =
+    override def make(
+      topicPartition: TopicPartition,
+      assignedAt: Offset,
+      groupMetadata: F[Option[ConsumerGroupMetadata]]
+    ): Resource[F, KafkaPersistenceModule[F, S]] =
       KafkaPersistenceModule.cachingTransactional(
         consumerOf = consumerOf,
         producerOf = producerOf,
         config     = config,
-        assignment = KafkaPersistenceModule.PartitionAssignment(partition, assignedAt, groupMetadata),
+        assignment = KafkaPersistenceModule.PartitionAssignment(topicPartition, assignedAt, groupMetadata),
         metrics    = metrics,
       )
   }

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModuleOf.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModuleOf.scala
@@ -3,22 +3,18 @@ package com.evolutiongaming.kafka.flow.kafkapersistence
 import cats.Parallel
 import cats.effect.{Async, Concurrent, Resource}
 import com.evolutiongaming.catshelper.{LogOf, Runtime}
-import com.evolutiongaming.kafka.flow.FlowMetrics
-import com.evolutiongaming.skafka.consumer.{ConsumerConfig, ConsumerGroupMetadata, ConsumerOf}
+import com.evolutiongaming.kafka.flow.{FlowMetrics, PartitionAssignment}
+import com.evolutiongaming.skafka.consumer.{ConsumerConfig, ConsumerOf}
 import com.evolutiongaming.skafka.producer.{Producer, ProducerOf}
 import com.evolutiongaming.skafka.*
 
-/** Convenience factory trait to create an instance of [[KafkaPersistenceModule]] for an assigned partition.
-  * `assignedAt` and `groupMetadata` are supplied by the flow and used only by the transactional module - to seed the
-  * initial offset-to-commit and to fence stale writers (KIP-447) respectively; the non-transactional caching module
-  * ignores both.
+/** Convenience factory trait to create an instance of [[KafkaPersistenceModule]] for an assigned partition. The
+  * `PartitionAssignment` is supplied by the flow; its `assignedAt` and `groupMetadata` are used only by the
+  * transactional module - to seed the initial offset-to-commit and to fence stale writers (KIP-447) respectively; the
+  * non-transactional caching module ignores both.
   */
 trait KafkaPersistenceModuleOf[F[_], S] {
-  def make(
-    topicPartition: TopicPartition,
-    assignedAt: Offset,
-    groupMetadata: F[Option[ConsumerGroupMetadata]]
-  ): Resource[F, KafkaPersistenceModule[F, S]]
+  def make(assignment: PartitionAssignment[F]): Resource[F, KafkaPersistenceModule[F, S]]
 }
 
 object KafkaPersistenceModuleOf {
@@ -53,15 +49,13 @@ object KafkaPersistenceModuleOf {
   ): KafkaPersistenceModuleOf[F, S] = new KafkaPersistenceModuleOf[F, S] {
     // caching ignores assignedAt/groupMetadata - it doesn't commit offsets through a producer
     override def make(
-      topicPartition: TopicPartition,
-      assignedAt: Offset,
-      groupMetadata: F[Option[ConsumerGroupMetadata]]
+      assignment: PartitionAssignment[F]
     ): Resource[F, KafkaPersistenceModule[F, S]] =
       KafkaPersistenceModule.caching(
         consumerOf             = consumerOf,
         producer               = producer,
         consumerConfig         = consumerConfig,
-        snapshotTopicPartition = TopicPartition(snapshotTopic, topicPartition.partition),
+        snapshotTopicPartition = TopicPartition(snapshotTopic, assignment.topicPartition.partition),
         metrics                = metrics,
         partitionMapper        = partitionMapper,
       )
@@ -94,15 +88,13 @@ object KafkaPersistenceModuleOf {
     toBytesState: ToBytes[F, S]
   ): KafkaPersistenceModuleOf[F, S] = new KafkaPersistenceModuleOf[F, S] {
     override def make(
-      topicPartition: TopicPartition,
-      assignedAt: Offset,
-      groupMetadata: F[Option[ConsumerGroupMetadata]]
+      assignment: PartitionAssignment[F]
     ): Resource[F, KafkaPersistenceModule[F, S]] =
       KafkaPersistenceModule.cachingTransactional(
         consumerOf = consumerOf,
         producerOf = producerOf,
         config     = config,
-        assignment = KafkaPersistenceModule.PartitionAssignment(topicPartition, assignedAt, groupMetadata),
+        assignment = assignment,
         metrics    = metrics,
       )
   }

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/package.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/package.scala
@@ -9,7 +9,7 @@ import com.evolutiongaming.kafka.flow.kafka.ScheduleCommit
 import com.evolutiongaming.kafka.flow.metrics.syntax.*
 import com.evolutiongaming.kafka.flow.registry.EntityRegistry
 import com.evolutiongaming.kafka.flow.timer.{TimerFlowOf, TimersOf}
-import com.evolutiongaming.skafka.consumer.ConsumerRecord
+import com.evolutiongaming.skafka.consumer.{ConsumerGroupMetadata, ConsumerRecord}
 import com.evolutiongaming.skafka.{Offset, TopicPartition}
 import com.evolutiongaming.sstream.{FoldWhile, Stream}
 import scodec.bits.ByteVector
@@ -143,12 +143,13 @@ package object kafkapersistence {
       override def apply(
         topicPartition: TopicPartition,
         assignedAt: Offset,
-        scheduleCommit: ScheduleCommit[F]
+        scheduleCommit: ScheduleCommit[F],
+        groupMetadata: F[Option[ConsumerGroupMetadata]]
       ): Resource[F, PartitionFlow[F]] = {
         for {
           // TODO: per-partition persistence module with 'String -> ByteVector' cache or global persistence module with 'KafkaKey -> ByteVector' cache?
           // Latter would require initialization of PartitionFlowOf as a Resource
-          kafkaPersistenceModule <- kafkaPersistenceModuleOf.make(topicPartition.partition, assignedAt)
+          kafkaPersistenceModule <- kafkaPersistenceModuleOf.make(topicPartition, assignedAt, groupMetadata)
           // transactional mode commits offsets through its own producer transaction; otherwise fall back to consumer commit
           effectiveScheduleCommit = kafkaPersistenceModule.scheduleCommit.getOrElse(scheduleCommit)
           partitionFlowOf = PartitionFlowOf.apply[F](
@@ -170,7 +171,7 @@ package object kafkapersistence {
             filter   = filter,
             remapKey = remapKey,
           )
-          partitionFlow <- partitionFlowOf(topicPartition, assignedAt, effectiveScheduleCommit)
+          partitionFlow <- partitionFlowOf(topicPartition, assignedAt, effectiveScheduleCommit, groupMetadata)
         } yield partitionFlow
       }
     }

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/package.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/package.scala
@@ -9,8 +9,7 @@ import com.evolutiongaming.kafka.flow.kafka.ScheduleCommit
 import com.evolutiongaming.kafka.flow.metrics.syntax.*
 import com.evolutiongaming.kafka.flow.registry.EntityRegistry
 import com.evolutiongaming.kafka.flow.timer.{TimerFlowOf, TimersOf}
-import com.evolutiongaming.skafka.consumer.{ConsumerGroupMetadata, ConsumerRecord}
-import com.evolutiongaming.skafka.{Offset, TopicPartition}
+import com.evolutiongaming.skafka.consumer.ConsumerRecord
 import com.evolutiongaming.sstream.{FoldWhile, Stream}
 import scodec.bits.ByteVector
 
@@ -141,15 +140,13 @@ package object kafkapersistence {
   ): PartitionFlowOf[F] =
     new PartitionFlowOf[F] {
       override def apply(
-        topicPartition: TopicPartition,
-        assignedAt: Offset,
-        scheduleCommit: ScheduleCommit[F],
-        groupMetadata: F[Option[ConsumerGroupMetadata]]
+        assignment: PartitionAssignment[F],
+        scheduleCommit: ScheduleCommit[F]
       ): Resource[F, PartitionFlow[F]] = {
         for {
           // TODO: per-partition persistence module with 'String -> ByteVector' cache or global persistence module with 'KafkaKey -> ByteVector' cache?
           // Latter would require initialization of PartitionFlowOf as a Resource
-          kafkaPersistenceModule <- kafkaPersistenceModuleOf.make(topicPartition, assignedAt, groupMetadata)
+          kafkaPersistenceModule <- kafkaPersistenceModuleOf.make(assignment)
           // transactional mode commits offsets through its own producer transaction; otherwise fall back to consumer commit
           effectiveScheduleCommit = kafkaPersistenceModule.scheduleCommit.getOrElse(scheduleCommit)
           partitionFlowOf = PartitionFlowOf.apply[F](
@@ -171,7 +168,7 @@ package object kafkapersistence {
             filter   = filter,
             remapKey = remapKey,
           )
-          partitionFlow <- partitionFlowOf(topicPartition, assignedAt, effectiveScheduleCommit, groupMetadata)
+          partitionFlow <- partitionFlowOf(assignment, effectiveScheduleCommit)
         } yield partitionFlow
       }
     }


### PR DESCRIPTION
Stacked on #842 — merge that first.

Rebalance listeners fire only for partitions that changed hands, so with a cooperative assignor a rebalance can bump the generation without any callback on a member that keeps its partitions — its next transactional flush is then spuriously fenced.

Fix: also refresh the captured metadata after every poll (rebalances complete within a poll). The token can still lag the ownership epoch but never lead it, so the fence is unaffected. Covered by a new integration test with `CooperativeStickyAssignor`; docs scope the analysis to the classic rebalance protocol.