### PR TITLE
Fail a recovery read stalled far beyond any transient hiccup (draft)

### DIFF
--- a/persistence-kafka-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/TransactionalKafkaPersistenceSpec.scala
+++ b/persistence-kafka-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/TransactionalKafkaPersistenceSpec.scala
@@ -76,6 +76,7 @@ class TransactionalKafkaPersistenceSpec extends ForAllKafkaSuite {
       consumerConfig = consumerConfig.copy(isolationLevel = IsolationLevel.ReadCommitted),
       snapshotTopic  = stateTopic,
       partition      = Partition.min,
+      stallTimeout   = KafkaPartitionPersistence.defaultStallTimeout,
     )
 
   private def utf8(value: String): Option[ByteVector] = ByteVector.encodeUtf8(value).toOption

--- a/persistence-kafka-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/TransactionalKafkaPersistenceSpec.scala
+++ b/persistence-kafka-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/TransactionalKafkaPersistenceSpec.scala
@@ -76,7 +76,7 @@ class TransactionalKafkaPersistenceSpec extends ForAllKafkaSuite {
       consumerConfig = consumerConfig.copy(isolationLevel = IsolationLevel.ReadCommitted),
       snapshotTopic  = stateTopic,
       partition      = Partition.min,
-      stallTimeout   = KafkaPartitionPersistence.defaultStallTimeout,
+      stallTimeout   = KafkaPartitionPersistence.defaultStallTimeout.some,
     )
 
   private def utf8(value: String): Option[ByteVector] = ByteVector.encodeUtf8(value).toOption

--- a/persistence-kafka-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/TransactionalWriteThroughputSpec.scala
+++ b/persistence-kafka-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/TransactionalWriteThroughputSpec.scala
@@ -63,6 +63,7 @@ class TransactionalWriteThroughputSpec extends ForAllKafkaSuite {
       ),
       snapshotTopic = stateTopic,
       partition     = Partition.min,
+      stallTimeout  = KafkaPartitionPersistence.defaultStallTimeout,
     )
 
   private def timed(io: IO[Unit]): IO[FiniteDuration] =

--- a/persistence-kafka-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/TransactionalWriteThroughputSpec.scala
+++ b/persistence-kafka-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/TransactionalWriteThroughputSpec.scala
@@ -63,7 +63,7 @@ class TransactionalWriteThroughputSpec extends ForAllKafkaSuite {
       ),
       snapshotTopic = stateTopic,
       partition     = Partition.min,
-      stallTimeout  = KafkaPartitionPersistence.defaultStallTimeout,
+      stallTimeout  = KafkaPartitionPersistence.defaultStallTimeout.some,
     )
 
   private def timed(io: IO[Unit]): IO[FiniteDuration] =

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPartitionPersistence.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPartitionPersistence.scala
@@ -43,13 +43,15 @@ object KafkaPartitionPersistence {
       )
       with NoStackTrace
 
-  /** Default no-progress deadline for a snapshot recovery read, used when a caller does not set one explicitly.
+  /** Default no-progress deadline for a snapshot recovery read in the transactional mode. Only that mode arms a
+    * deadline: it captures a `read_committed` end offset that an unclean-leader-election truncation can strand the read
+    * below, and it hangs the poll thread inside the rebalance callback where a hang is silently evicted. The
+    * non-transactional caching mode keeps its original behaviour and passes no deadline (`None`).
     *
     * Two bounds motivate the value, but neither is derivable from a single config here, so it is a plain default to
     * override rather than a computed one:
-    *   - it must fire before the broker evicts the member around the stuck poll thread (recovery runs inside the
-    *     rebalance callback, so the eviction is silent) - i.e. below `max.poll.interval.ms` (5m default), with room to
-    *     raise, unwind the consumer resource and rejoin;
+    *   - it must fire before the broker evicts the member around the stuck poll thread - i.e. below `max.poll.interval.ms`
+    *     (5m default), with room to raise, unwind the consumer resource and rejoin;
     *   - it should sit above any self-healing stall - a hung transaction aborts within the *producer's*
     *     `transaction.timeout.ms` (60s default) plus the broker's abort scan.
     *
@@ -75,7 +77,7 @@ object KafkaPartitionPersistence {
     consumer: SkafkaConsumer[F, String, ByteVector],
     snapshotPartition: TopicPartition,
     targetOffset: Offset,
-    stallTimeout: FiniteDuration,
+    stallTimeout: Option[FiniteDuration],
   ): F[BytesByKey] =
     Log[F].info(s"Snapshot topic read started up to offset $targetOffset") *>
       Clock[F].monotonic.flatMap { start =>
@@ -103,10 +105,11 @@ object KafkaPartitionPersistence {
                             s"stalled for ${stalledFor.toSeconds}s"
                         )
                         .whenA(shouldLog)
-                      // waiting cannot fix a stall this long - fail loudly (see the error's scaladoc)
+                      // waiting cannot fix a stall this long - fail loudly (see the error's scaladoc). With no deadline
+                      // (non-transactional mode) the read keeps its original behaviour and never fails here.
                       val failStalled = RecoveryReadStalledError(snapshotPartition, offset, targetOffset)
                         .raiseError[F, Unit]
-                        .whenA(stalledFor >= stallTimeout)
+                        .whenA(stallTimeout.exists(stalledFor >= _))
 
                       failStalled *> logStalled *>
                         consumer
@@ -134,7 +137,7 @@ object KafkaPartitionPersistence {
     consumerConfig: ConsumerConfig,
     snapshotTopic: Topic,
     partition: Partition,
-    stallTimeout: FiniteDuration,
+    stallTimeout: Option[FiniteDuration],
   )(implicit fromBytes: FromBytes[F, String]): F[BytesByKey] = {
     consumerOf
       .apply[String, ByteVector](

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPartitionPersistence.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPartitionPersistence.scala
@@ -1,7 +1,8 @@
 package com.evolutiongaming.kafka.flow.kafkapersistence
 
 import cats.implicits.*
-import cats.{FlatMap, Monad, data}
+import cats.effect.Clock
+import cats.{FlatMap, MonadThrow, data}
 import com.evolutiongaming.catshelper.{BracketThrowable, Log}
 import com.evolutiongaming.kafka.flow.kafka.Codecs.*
 import com.evolutiongaming.skafka.*
@@ -22,31 +23,111 @@ object KafkaPartitionPersistence {
 
   private case class MissingOffsetError(topicPartition: TopicPartition) extends NoStackTrace
 
-  private[kafkapersistence] def readPartition[F[_]: Monad: Log](
+  /** The recovery read made no progress for far longer than any transient hiccup explains, so waiting cannot fix it:
+    * every record below the target is decided and fetchable (the target was this consumer's own end offset - under
+    * `read_committed` the last stable offset, below which every transaction is decided), so the likely cause is a log
+    * end that regressed below the captured target - log truncation after an unclean leader election, i.e. the cluster
+    * lost acknowledged snapshot records. Failing loudly beats hanging: recovery runs on the poll thread inside the
+    * rebalance callback, so a hang does not crash anything - `max.poll.interval.ms` silently evicts the member from the
+    * group while the thread stays stuck, invisible to process-level health checks.
+    */
+  final case class RecoveryReadStalledError(
+    topicPartition: TopicPartition,
+    position: Offset,
+    targetOffset: Offset,
+  ) extends RuntimeException(
+        s"recovery read of $topicPartition made no progress at offset $position, short of target $targetOffset, " +
+          "far beyond any transient broker hiccup; the log end has likely regressed below the captured target " +
+          "(log truncation after an unclean leader election) - failing rather than hanging or silently recovering " +
+          "possibly incomplete state"
+      )
+      with NoStackTrace
+
+  // Floor for the no-progress deadline: comfortably above any self-healing stall. The longest of those is a hung
+  // transaction, which the broker aborts within the *producer's* `transaction.timeout.ms` (60s default) plus its abort
+  // scan - a producer setting not visible on this consumer's config, hence a fixed floor rather than a derived one.
+  private[kafkapersistence] val minStallTimeout: FiniteDuration = 2.minutes
+
+  // ~5s between "no progress" log lines while stalled, so a stuck recovery is visible long before the deadline trips
+  private val logStallEvery: FiniteDuration = 5.seconds
+
+  /** No-progress deadline derived from the consumer's own `max.poll.interval.ms`. Two bounds pin it:
+    *   - it MUST fire before the broker evicts the member around the stuck poll thread (recovery runs inside the
+    *     rebalance callback, so the eviction is silent). We reserve `evictionMargin` below `max.poll.interval.ms` to
+    *     raise, unwind the consumer resource and rejoin cleanly. This is a safety bound and wins when the window is
+    *     tight (a low `max.poll.interval.ms`);
+    *   - it SHOULD sit above any self-healing stall, so we floor it at [[minStallTimeout]].
+    *
+    * At the default `max.poll.interval.ms` (5m) this yields the intended ~2m. A slow-but-progressing read never nears
+    * it: the deadline is measured from the last advance and reset on every advance.
+    */
+  private[kafkapersistence] def stallTimeoutFor(consumerConfig: ConsumerConfig): FiniteDuration = {
+    val maxPollIntervalMs = consumerConfig.maxPollInterval.toMillis
+    // room to fail + rejoin before eviction: a fifth of the window, but at least 30s
+    val evictionMarginMs = math.max(maxPollIntervalMs / 5, 30.seconds.toMillis)
+    val ceilingMs        = maxPollIntervalMs - evictionMarginMs
+    // prefer the floor, but never cross the ceiling (safety over liveness); keep it strictly positive
+    val stallMs = math.max(math.min(minStallTimeout.toMillis, ceilingMs), 1.second.toMillis)
+    FiniteDuration(stallMs, MILLISECONDS)
+  }
+
+  // loop state of `readPartition`: accumulated snapshot, last observed position, and the monotonic timestamps of the
+  // last advance and the last "no progress" log line - both used to detect a stall by elapsed wall time, not poll count
+  private final case class ReadState(
+    acc: BytesByKey,
+    lastPosition: Option[Offset],
+    lastProgressAt: FiniteDuration,
+    lastLogAt: FiniteDuration,
+  )
+
+  private[kafkapersistence] def readPartition[F[_]: MonadThrow: Clock: Log](
     consumer: SkafkaConsumer[F, String, ByteVector],
     snapshotPartition: TopicPartition,
-    targetOffset: Offset
+    targetOffset: Offset,
+    stallTimeout: FiniteDuration,
   ): F[BytesByKey] =
     Log[F].info(s"Snapshot topic read started up to offset $targetOffset") *>
-      FlatMap[F]
-        .tailRecM[BytesByKey, BytesByKey](BytesByKey.empty) { acc =>
-          consumer
-            .position(snapshotPartition)
-            .flatMap {
-              case offset if offset >= targetOffset =>
-                acc.asRight[BytesByKey].pure[F]
-              case _ =>
-                consumer
-                  .poll(10.millis) // TODO: make poll timeout configurable
-                  .map(
-                    _.values
-                      .values
-                      .flatMap(_.toIterable)
-                      .foldLeft(acc)(processRecord)
-                      .asLeft
-                  )
-            }
-        }
+      Clock[F].monotonic.flatMap { start =>
+        FlatMap[F]
+          .tailRecM[ReadState, BytesByKey](ReadState(BytesByKey.empty, none, start, start)) {
+            case ReadState(acc, lastPosition, lastProgressAt, lastLogAt) =>
+              consumer
+                .position(snapshotPartition)
+                .flatMap {
+                  case offset if offset >= targetOffset =>
+                    acc.asRight[ReadState].pure[F]
+                  case offset =>
+                    Clock[F].monotonic.flatMap { now =>
+                      val progressed = !lastPosition.contains(offset)
+                      // time is measured from the last advance, so a stall is elapsed wall time, not a poll count -
+                      // robust to how long each poll actually blocks and to a configurable poll timeout
+                      val progressAt = if (progressed) now else lastProgressAt
+                      val stalledFor = now - progressAt
+                      val shouldLog  = !progressed && (now - lastLogAt) >= logStallEvery
+                      val nextLogAt  = if (progressed || shouldLog) now else lastLogAt
+
+                      val logStalled = Log[F]
+                        .info(
+                          s"Snapshot topic read making no progress at offset $offset, target $targetOffset, " +
+                            s"stalled for ${stalledFor.toSeconds}s"
+                        )
+                        .whenA(shouldLog)
+                      // waiting cannot fix a stall this long - fail loudly (see the error's scaladoc)
+                      val failStalled = RecoveryReadStalledError(snapshotPartition, offset, targetOffset)
+                        .raiseError[F, Unit]
+                        .whenA(stalledFor >= stallTimeout)
+
+                      failStalled *> logStalled *>
+                        consumer
+                          .poll(10.millis) // TODO: make poll timeout configurable
+                          .map { records =>
+                            val read = records.values.values.flatMap(_.toIterable).foldLeft(acc)(processRecord)
+                            ReadState(read, offset.some, progressAt, nextLogAt).asLeft[BytesByKey]
+                          }
+                    }
+                }
+          }
+      }
 
   private[kafkapersistence] def processRecord(
     map: BytesByKey,
@@ -57,7 +138,7 @@ object KafkaPartitionPersistence {
     case _ => map // ignore records with no key for now
   }
 
-  private[kafkapersistence] def readSnapshots[F[_]: BracketThrowable: Log](
+  private[kafkapersistence] def readSnapshots[F[_]: BracketThrowable: Clock: Log](
     consumerOf: ConsumerOf[F],
     consumerConfig: ConsumerConfig,
     snapshotTopic: Topic,
@@ -87,7 +168,8 @@ object KafkaPartitionPersistence {
           bytesByKey <- readPartition(
             consumer,
             snapshotsPartition,
-            targetOffset
+            targetOffset,
+            stallTimeoutFor(consumerConfig),
           )
           _ <- Log[F].info(
             s"Snapshot topic $snapshotTopic partition $partition read complete at offset $targetOffset, ${bytesByKey.size} keys read"

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPartitionPersistence.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPartitionPersistence.scala
@@ -43,33 +43,24 @@ object KafkaPartitionPersistence {
       )
       with NoStackTrace
 
-  // Floor for the no-progress deadline: comfortably above any self-healing stall. The longest of those is a hung
-  // transaction, which the broker aborts within the *producer's* `transaction.timeout.ms` (60s default) plus its abort
-  // scan - a producer setting not visible on this consumer's config, hence a fixed floor rather than a derived one.
-  private[kafkapersistence] val minStallTimeout: FiniteDuration = 2.minutes
+  /** Default no-progress deadline for a snapshot recovery read, used when a caller does not set one explicitly.
+    *
+    * Two bounds motivate the value, but neither is derivable from a single config here, so it is a plain default to
+    * override rather than a computed one:
+    *   - it must fire before the broker evicts the member around the stuck poll thread (recovery runs inside the
+    *     rebalance callback, so the eviction is silent) - i.e. below `max.poll.interval.ms` (5m default), with room to
+    *     raise, unwind the consumer resource and rejoin;
+    *   - it should sit above any self-healing stall - a hung transaction aborts within the *producer's*
+    *     `transaction.timeout.ms` (60s default) plus the broker's abort scan.
+    *
+    * 2 minutes sits between those defaults. Override it (see `TransactionalConfig.recoveryStallTimeout`) whenever
+    * `max.poll.interval.ms` is retuned - it must stay comfortably below it. A slow-but-progressing read never nears the
+    * deadline: it is measured from the last advance and reset on every advance.
+    */
+  val defaultStallTimeout: FiniteDuration = 2.minutes
 
   // ~5s between "no progress" log lines while stalled, so a stuck recovery is visible long before the deadline trips
   private val logStallEvery: FiniteDuration = 5.seconds
-
-  /** No-progress deadline derived from the consumer's own `max.poll.interval.ms`. Two bounds pin it:
-    *   - it MUST fire before the broker evicts the member around the stuck poll thread (recovery runs inside the
-    *     rebalance callback, so the eviction is silent). We reserve `evictionMargin` below `max.poll.interval.ms` to
-    *     raise, unwind the consumer resource and rejoin cleanly. This is a safety bound and wins when the window is
-    *     tight (a low `max.poll.interval.ms`);
-    *   - it SHOULD sit above any self-healing stall, so we floor it at [[minStallTimeout]].
-    *
-    * At the default `max.poll.interval.ms` (5m) this yields the intended ~2m. A slow-but-progressing read never nears
-    * it: the deadline is measured from the last advance and reset on every advance.
-    */
-  private[kafkapersistence] def stallTimeoutFor(consumerConfig: ConsumerConfig): FiniteDuration = {
-    val maxPollIntervalMs = consumerConfig.maxPollInterval.toMillis
-    // room to fail + rejoin before eviction: a fifth of the window, but at least 30s
-    val evictionMarginMs = math.max(maxPollIntervalMs / 5, 30.seconds.toMillis)
-    val ceilingMs        = maxPollIntervalMs - evictionMarginMs
-    // prefer the floor, but never cross the ceiling (safety over liveness); keep it strictly positive
-    val stallMs = math.max(math.min(minStallTimeout.toMillis, ceilingMs), 1.second.toMillis)
-    FiniteDuration(stallMs, MILLISECONDS)
-  }
 
   // loop state of `readPartition`: accumulated snapshot, last observed position, and the monotonic timestamps of the
   // last advance and the last "no progress" log line - both used to detect a stall by elapsed wall time, not poll count
@@ -143,6 +134,7 @@ object KafkaPartitionPersistence {
     consumerConfig: ConsumerConfig,
     snapshotTopic: Topic,
     partition: Partition,
+    stallTimeout: FiniteDuration,
   )(implicit fromBytes: FromBytes[F, String]): F[BytesByKey] = {
     consumerOf
       .apply[String, ByteVector](
@@ -169,7 +161,7 @@ object KafkaPartitionPersistence {
             consumer,
             snapshotsPartition,
             targetOffset,
-            stallTimeoutFor(consumerConfig),
+            stallTimeout,
           )
           _ <- Log[F].info(
             s"Snapshot topic $snapshotTopic partition $partition read complete at offset $targetOffset, ${bytesByKey.size} keys read"

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPartitionPersistence.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPartitionPersistence.scala
@@ -50,8 +50,8 @@ object KafkaPartitionPersistence {
     *
     * Two bounds motivate the value, but neither is derivable from a single config here, so it is a plain default to
     * override rather than a computed one:
-    *   - it must fire before the broker evicts the member around the stuck poll thread - i.e. below `max.poll.interval.ms`
-    *     (5m default), with room to raise, unwind the consumer resource and rejoin;
+    *   - it must fire before the broker evicts the member around the stuck poll thread - i.e. below
+    *     `max.poll.interval.ms` (5m default), with room to raise, unwind the consumer resource and rejoin;
     *   - it should sit above any self-healing stall - a hung transaction aborts within the *producer's*
     *     `transaction.timeout.ms` (60s default) plus the broker's abort scan.
     *

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModule.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModule.scala
@@ -1,7 +1,7 @@
 package com.evolutiongaming.kafka.flow.kafkapersistence
 
 import cats.Parallel
-import cats.effect.{Async, Concurrent, Resource}
+import cats.effect.{Async, Clock, Concurrent, Resource}
 import cats.syntax.all.*
 import com.evolution.scache.Cache
 import com.evolutiongaming.catshelper.{FromTry, LogOf, Runtime}
@@ -79,7 +79,7 @@ object KafkaPersistenceModule {
     groupMetadata: F[Option[ConsumerGroupMetadata]],
   )
 
-  def caching[F[_]: LogOf: Concurrent: Parallel: Runtime, S](
+  def caching[F[_]: LogOf: Concurrent: Parallel: Runtime: Clock, S](
     consumerOf: ConsumerOf[F],
     producer: Producer[F],
     consumerConfig: ConsumerConfig,
@@ -130,7 +130,7 @@ object KafkaPersistenceModule {
     * @see
     *   com.evolutiongaming.kafka.flow.KeyFlow.of for implementation details of state recovery for a specific key
     */
-  def caching[F[_]: LogOf: Concurrent: Parallel: Runtime, S](
+  def caching[F[_]: LogOf: Concurrent: Parallel: Runtime: Clock, S](
     consumerOf: ConsumerOf[F],
     producer: Producer[F],
     consumerConfig: ConsumerConfig,
@@ -244,7 +244,7 @@ object KafkaPersistenceModule {
   /** Builds the cached `keysOf` + `persistenceOf` for a partition; the module's `scheduleCommit` is attached by the
     * caller via [[module]] (transactional binds the offset, caching defers to the consumer).
     */
-  private def of[F[_]: LogOf: Concurrent: Parallel: Runtime, S](
+  private def of[F[_]: LogOf: Concurrent: Parallel: Runtime: Clock, S](
     consumerOf: ConsumerOf[F],
     consumerConfig: ConsumerConfig,
     snapshotTopicPartition: TopicPartition,
@@ -279,7 +279,7 @@ object KafkaPersistenceModule {
       override def scheduleCommit: Option[ScheduleCommit[F]] = commit
     }
 
-  private def makeKeysOf[F[_]: LogOf: Concurrent](
+  private def makeKeysOf[F[_]: LogOf: Concurrent: Clock](
     cache: Cache[F, String, ByteVector],
     consumerOf: ConsumerOf[F],
     consumerConfig: ConsumerConfig,

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModule.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModule.scala
@@ -158,8 +158,9 @@ object KafkaPersistenceModule {
       metrics                = metrics,
       partitionMapper        = partitionMapper,
       writeDatabase          = KafkaSnapshotWriteDatabase.of[F, S](snapshotTopicPartition, producer, partitionMapper),
-      // the non-transactional path is not configurable for this; transactional exposes TransactionalConfig.recoveryStallTimeout
-      stallTimeout           = KafkaPartitionPersistence.defaultStallTimeout,
+      // non-transactional recovery keeps its original behaviour: no stall deadline (the deadline is a transactional
+      // concern - see KafkaPartitionPersistence.defaultStallTimeout / TransactionalConfig.recoveryStallTimeout)
+      stallTimeout           = none,
     ).map {
       // non-transactional: offsets are committed the default way (by the consumer), see package.scala
       case (keysOf, persistenceOf) => module(keysOf, persistenceOf, commit = None)
@@ -197,7 +198,7 @@ object KafkaPersistenceModule {
         metrics                = metrics,
         partitionMapper        = KafkaPersistencePartitionMapper.identity,
         writeDatabase          = transactional.writeDatabase,
-        stallTimeout           = config.recoveryStallTimeout,
+        stallTimeout           = config.recoveryStallTimeout.some,
       )
     } yield {
       val (keysOf, persistenceOf) = parts
@@ -262,7 +263,7 @@ object KafkaPersistenceModule {
     metrics: FlowMetrics[F],
     partitionMapper: KafkaPersistencePartitionMapper,
     writeDatabase: SnapshotWriteDatabase[F, KafkaKey, S],
-    stallTimeout: FiniteDuration,
+    stallTimeout: Option[FiniteDuration],
   )(
     implicit fromBytesKey: FromBytes[F, String],
     fromBytesState: FromBytes[F, S],
@@ -297,7 +298,7 @@ object KafkaPersistenceModule {
     consumerConfig: ConsumerConfig,
     snapshotTopicPartition: TopicPartition,
     partitionMapper: KafkaPersistencePartitionMapper,
-    stallTimeout: FiniteDuration,
+    stallTimeout: Option[FiniteDuration],
   )(implicit fromBytesKey: FromBytes[F, String]): F[KeysOf[F, KafkaKey]] =
     LogOf[F].apply(classOf[KeysOf[F, KafkaKey]]).map { implicit log =>
       def readPartitionData: F[BytesByKey] = {

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModule.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModule.scala
@@ -189,6 +189,17 @@ object KafkaPersistenceModule {
   ): Resource[F, KafkaPersistenceModule[F, S]] = {
     val snapshotTopicPartition = TopicPartition(config.snapshotTopic, assignment.partition)
     for {
+      // a deadline at or above max.poll.interval.ms is silently defeated: the broker evicts the stuck member first
+      _ <- Resource.eval {
+        LogOf[F].apply(KafkaPersistenceModule.getClass).flatMap { log =>
+          log
+            .warn(
+              s"recoveryStallTimeout ${config.recoveryStallTimeout} is not below max.poll.interval.ms " +
+                s"${config.consumerConfig.maxPollInterval}: a stalled recovery would be evicted before it fails"
+            )
+            .whenA(config.recoveryStallTimeout >= config.consumerConfig.maxPollInterval)
+        }
+      }
       transactional <- transactionalWriteDatabase[F, S](producerOf, config, assignment, snapshotTopicPartition)
       // records of aborted transactions (e.g. of a fenced previous owner) must not be recovered as snapshots
       parts <- of(

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModule.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModule.scala
@@ -93,8 +93,7 @@ object KafkaPersistenceModule {
     consumerConfig: ConsumerConfig,
     snapshotTopicPartition: TopicPartition
   )(
-    implicit fromBytesKey: FromBytes[F, String],
-    fromBytesState: FromBytes[F, S],
+    implicit fromBytesState: FromBytes[F, S],
     toBytesState: ToBytes[F, S]
   ): Resource[F, KafkaPersistenceModule[F, S]] =
     caching(consumerOf, producer, consumerConfig, snapshotTopicPartition, FlowMetrics.empty[F])
@@ -146,8 +145,7 @@ object KafkaPersistenceModule {
     metrics: FlowMetrics[F],
     partitionMapper: KafkaPersistencePartitionMapper = KafkaPersistencePartitionMapper.identity,
   )(
-    implicit fromBytesKey: FromBytes[F, String],
-    fromBytesState: FromBytes[F, S],
+    implicit fromBytesState: FromBytes[F, S],
     toBytesState: ToBytes[F, S]
   ): Resource[F, KafkaPersistenceModule[F, S]] = {
     implicit val fromTry: FromTry[F] = FromTry.lift
@@ -183,8 +181,7 @@ object KafkaPersistenceModule {
     assignment: PartitionAssignment[F],
     metrics: FlowMetrics[F] = FlowMetrics.empty[F],
   )(
-    implicit fromBytesKey: FromBytes[F, String],
-    fromBytesState: FromBytes[F, S],
+    implicit fromBytesState: FromBytes[F, S],
     toBytesState: ToBytes[F, S]
   ): Resource[F, KafkaPersistenceModule[F, S]] = {
     val snapshotTopicPartition = TopicPartition(config.snapshotTopic, assignment.partition)
@@ -276,8 +273,7 @@ object KafkaPersistenceModule {
     writeDatabase: SnapshotWriteDatabase[F, KafkaKey, S],
     stallTimeout: Option[FiniteDuration],
   )(
-    implicit fromBytesKey: FromBytes[F, String],
-    fromBytesState: FromBytes[F, S],
+    implicit fromBytesState: FromBytes[F, S],
   ): Resource[F, (KeysOf[F, KafkaKey], SnapshotPersistenceOf[F, KafkaKey, S, ConsumerRecord[String, ByteVector]])] =
     for {
       partitionDataCache <- Cache.loading[F, String, ByteVector]
@@ -317,7 +313,9 @@ object KafkaPersistenceModule {
     snapshotTopicPartition: TopicPartition,
     partitionMapper: KafkaPersistencePartitionMapper,
     stallTimeout: Option[FiniteDuration],
-  )(implicit fromBytesKey: FromBytes[F, String]): F[KeysOf[F, KafkaKey]] =
+  ): F[KeysOf[F, KafkaKey]] = {
+    // the snapshot key is always String; derive its codec here instead of demanding a FromBytes[F, String] from callers
+    implicit val fromTry: FromTry[F] = FromTry.lift
     LogOf[F].apply(classOf[KeysOf[F, KafkaKey]]).map { implicit log =>
       def readPartitionData: F[BytesByKey] = {
         val targetPartition = partitionMapper.getStatePartition(snapshotTopicPartition.partition)
@@ -351,6 +349,7 @@ object KafkaPersistenceModule {
         }
       }
     }
+  }
 
   private def makeSnapshotPersistenceOf[F[_]: LogOf: Concurrent, S](
     keysOf: KeysOf[F, KafkaKey],

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModule.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModule.scala
@@ -67,7 +67,7 @@ object KafkaPersistenceModule {
     transactionalIdPrefix: String,
     snapshotTopic: Topic,
     inputTopic: Topic,
-    maxWritesPerTransaction: Int = KafkaSnapshotWriteDatabase.DefaultMaxWritesPerTransaction,
+    maxWritesPerTransaction: Int         = KafkaSnapshotWriteDatabase.DefaultMaxWritesPerTransaction,
     recoveryStallTimeout: FiniteDuration = KafkaPartitionPersistence.defaultStallTimeout,
   )
 
@@ -160,7 +160,7 @@ object KafkaPersistenceModule {
       writeDatabase          = KafkaSnapshotWriteDatabase.of[F, S](snapshotTopicPartition, producer, partitionMapper),
       // non-transactional recovery keeps its original behaviour: no stall deadline (the deadline is a transactional
       // concern - see KafkaPartitionPersistence.defaultStallTimeout / TransactionalConfig.recoveryStallTimeout)
-      stallTimeout           = none,
+      stallTimeout = none,
     ).map {
       // non-transactional: offsets are committed the default way (by the consumer), see package.scala
       case (keysOf, persistenceOf) => module(keysOf, persistenceOf, commit = None)
@@ -282,7 +282,14 @@ object KafkaPersistenceModule {
     for {
       partitionDataCache <- Cache.loading[F, String, ByteVector]
       keysOf <- Resource.eval(
-        makeKeysOf(partitionDataCache, consumerOf, consumerConfig, snapshotTopicPartition, partitionMapper, stallTimeout)
+        makeKeysOf(
+          partitionDataCache,
+          consumerOf,
+          consumerConfig,
+          snapshotTopicPartition,
+          partitionMapper,
+          stallTimeout
+        )
       )
       persistenceOf <- Resource.eval(
         makeSnapshotPersistenceOf(keysOf, partitionDataCache, snapshotTopicPartition, metrics, writeDatabase)

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModule.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModule.scala
@@ -145,7 +145,6 @@ object KafkaPersistenceModule {
     snapshotTopicPartition: TopicPartition,
     metrics: FlowMetrics[F],
     partitionMapper: KafkaPersistencePartitionMapper = KafkaPersistencePartitionMapper.identity,
-    stallTimeout: FiniteDuration = KafkaPartitionPersistence.defaultStallTimeout,
   )(
     implicit fromBytesKey: FromBytes[F, String],
     fromBytesState: FromBytes[F, S],
@@ -159,7 +158,8 @@ object KafkaPersistenceModule {
       metrics                = metrics,
       partitionMapper        = partitionMapper,
       writeDatabase          = KafkaSnapshotWriteDatabase.of[F, S](snapshotTopicPartition, producer, partitionMapper),
-      stallTimeout           = stallTimeout,
+      // the non-transactional path is not configurable for this; transactional exposes TransactionalConfig.recoveryStallTimeout
+      stallTimeout           = KafkaPartitionPersistence.defaultStallTimeout,
     ).map {
       // non-transactional: offsets are committed the default way (by the consumer), see package.scala
       case (keysOf, persistenceOf) => module(keysOf, persistenceOf, commit = None)

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModule.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModule.scala
@@ -19,6 +19,7 @@ import scodec.bits.ByteVector
 import com.evolutiongaming.skafka.consumer.ConsumerRecord
 
 import java.util.UUID
+import scala.concurrent.duration.FiniteDuration
 
 /** A module, necessary to create a Kafka snapshot persistence.
   */
@@ -53,6 +54,12 @@ object KafkaPersistenceModule {
     * @param maxWritesPerTransaction
     *   upper bound of snapshot writes group committed in one per-partition, serialized transaction, see
     *   [[KafkaSnapshotWriteDatabase.transactional]]
+    * @param recoveryStallTimeout
+    *   how long a snapshot recovery read may make no progress before it fails with
+    *   [[KafkaPartitionPersistence.RecoveryReadStalledError]] instead of hanging (a hang on the poll thread is silently
+    *   evicted at `consumerConfig.maxPollInterval`). Keep it comfortably below `maxPollInterval` and above any
+    *   self-healing stall (a hung transaction aborts within the producer's `transaction.timeout.ms`). Defaults to
+    *   [[KafkaPartitionPersistence.defaultStallTimeout]].
     */
   final case class TransactionalConfig(
     consumerConfig: ConsumerConfig,
@@ -61,6 +68,7 @@ object KafkaPersistenceModule {
     snapshotTopic: Topic,
     inputTopic: Topic,
     maxWritesPerTransaction: Int = KafkaSnapshotWriteDatabase.DefaultMaxWritesPerTransaction,
+    recoveryStallTimeout: FiniteDuration = KafkaPartitionPersistence.defaultStallTimeout,
   )
 
   /** The per-assignment context [[cachingTransactional]] needs to fence stale writers.
@@ -137,6 +145,7 @@ object KafkaPersistenceModule {
     snapshotTopicPartition: TopicPartition,
     metrics: FlowMetrics[F],
     partitionMapper: KafkaPersistencePartitionMapper = KafkaPersistencePartitionMapper.identity,
+    stallTimeout: FiniteDuration = KafkaPartitionPersistence.defaultStallTimeout,
   )(
     implicit fromBytesKey: FromBytes[F, String],
     fromBytesState: FromBytes[F, S],
@@ -150,6 +159,7 @@ object KafkaPersistenceModule {
       metrics                = metrics,
       partitionMapper        = partitionMapper,
       writeDatabase          = KafkaSnapshotWriteDatabase.of[F, S](snapshotTopicPartition, producer, partitionMapper),
+      stallTimeout           = stallTimeout,
     ).map {
       // non-transactional: offsets are committed the default way (by the consumer), see package.scala
       case (keysOf, persistenceOf) => module(keysOf, persistenceOf, commit = None)
@@ -187,6 +197,7 @@ object KafkaPersistenceModule {
         metrics                = metrics,
         partitionMapper        = KafkaPersistencePartitionMapper.identity,
         writeDatabase          = transactional.writeDatabase,
+        stallTimeout           = config.recoveryStallTimeout,
       )
     } yield {
       val (keysOf, persistenceOf) = parts
@@ -251,6 +262,7 @@ object KafkaPersistenceModule {
     metrics: FlowMetrics[F],
     partitionMapper: KafkaPersistencePartitionMapper,
     writeDatabase: SnapshotWriteDatabase[F, KafkaKey, S],
+    stallTimeout: FiniteDuration,
   )(
     implicit fromBytesKey: FromBytes[F, String],
     fromBytesState: FromBytes[F, S],
@@ -258,7 +270,7 @@ object KafkaPersistenceModule {
     for {
       partitionDataCache <- Cache.loading[F, String, ByteVector]
       keysOf <- Resource.eval(
-        makeKeysOf(partitionDataCache, consumerOf, consumerConfig, snapshotTopicPartition, partitionMapper)
+        makeKeysOf(partitionDataCache, consumerOf, consumerConfig, snapshotTopicPartition, partitionMapper, stallTimeout)
       )
       persistenceOf <- Resource.eval(
         makeSnapshotPersistenceOf(keysOf, partitionDataCache, snapshotTopicPartition, metrics, writeDatabase)
@@ -285,6 +297,7 @@ object KafkaPersistenceModule {
     consumerConfig: ConsumerConfig,
     snapshotTopicPartition: TopicPartition,
     partitionMapper: KafkaPersistencePartitionMapper,
+    stallTimeout: FiniteDuration,
   )(implicit fromBytesKey: FromBytes[F, String]): F[KeysOf[F, KafkaKey]] =
     LogOf[F].apply(classOf[KeysOf[F, KafkaKey]]).map { implicit log =>
       def readPartitionData: F[BytesByKey] = {
@@ -295,6 +308,7 @@ object KafkaPersistenceModule {
             consumerConfig = consumerConfig,
             snapshotTopic  = snapshotTopicPartition.topic,
             partition      = targetPartition,
+            stallTimeout   = stallTimeout,
           )
           .map { snapshots =>
             snapshots

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModuleOf.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModuleOf.scala
@@ -1,7 +1,7 @@
 package com.evolutiongaming.kafka.flow.kafkapersistence
 
 import cats.Parallel
-import cats.effect.{Async, Concurrent, Resource}
+import cats.effect.{Async, Clock, Concurrent, Resource}
 import com.evolutiongaming.catshelper.{LogOf, Runtime}
 import com.evolutiongaming.kafka.flow.FlowMetrics
 import com.evolutiongaming.skafka.consumer.{ConsumerConfig, ConsumerGroupMetadata, ConsumerOf}
@@ -34,7 +34,7 @@ object KafkaPersistenceModuleOf {
     * @param metrics
     *   instance of `FlowMetrics` for [[KafkaPersistenceModule]]
     */
-  def caching[F[_]: LogOf: Concurrent: Parallel: Runtime, S](
+  def caching[F[_]: LogOf: Concurrent: Parallel: Runtime: Clock, S](
     consumerOf: ConsumerOf[F],
     producer: Producer[F],
     consumerConfig: ConsumerConfig,
@@ -58,7 +58,7 @@ object KafkaPersistenceModuleOf {
       )
   }
 
-  def caching[F[_]: LogOf: Concurrent: Parallel: Runtime, S](
+  def caching[F[_]: LogOf: Concurrent: Parallel: Runtime: Clock, S](
     consumerOf: ConsumerOf[F],
     producer: Producer[F],
     consumerConfig: ConsumerConfig,

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModuleOf.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModuleOf.scala
@@ -8,8 +8,6 @@ import com.evolutiongaming.skafka.consumer.{ConsumerConfig, ConsumerGroupMetadat
 import com.evolutiongaming.skafka.producer.{Producer, ProducerOf}
 import com.evolutiongaming.skafka.*
 
-import scala.concurrent.duration.FiniteDuration
-
 /** Convenience factory trait to create an instance of [[KafkaPersistenceModule]] for an assigned partition.
   * `assignedAt` is the offset the partition was assigned at; the transactional module seeds it as the initial
   * offset-to-commit (ignored by the non-transactional caching module).
@@ -43,7 +41,6 @@ object KafkaPersistenceModuleOf {
     snapshotTopic: Topic,
     metrics: FlowMetrics[F],
     partitionMapper: KafkaPersistencePartitionMapper = KafkaPersistencePartitionMapper.identity,
-    stallTimeout: FiniteDuration = KafkaPartitionPersistence.defaultStallTimeout,
   )(
     implicit fromBytesKey: FromBytes[F, String],
     fromBytesState: FromBytes[F, S],
@@ -58,7 +55,6 @@ object KafkaPersistenceModuleOf {
         snapshotTopicPartition = TopicPartition(snapshotTopic, partition),
         metrics                = metrics,
         partitionMapper        = partitionMapper,
-        stallTimeout           = stallTimeout,
       )
   }
 

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModuleOf.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModuleOf.scala
@@ -8,6 +8,8 @@ import com.evolutiongaming.skafka.consumer.{ConsumerConfig, ConsumerGroupMetadat
 import com.evolutiongaming.skafka.producer.{Producer, ProducerOf}
 import com.evolutiongaming.skafka.*
 
+import scala.concurrent.duration.FiniteDuration
+
 /** Convenience factory trait to create an instance of [[KafkaPersistenceModule]] for an assigned partition.
   * `assignedAt` is the offset the partition was assigned at; the transactional module seeds it as the initial
   * offset-to-commit (ignored by the non-transactional caching module).
@@ -41,6 +43,7 @@ object KafkaPersistenceModuleOf {
     snapshotTopic: Topic,
     metrics: FlowMetrics[F],
     partitionMapper: KafkaPersistencePartitionMapper = KafkaPersistencePartitionMapper.identity,
+    stallTimeout: FiniteDuration = KafkaPartitionPersistence.defaultStallTimeout,
   )(
     implicit fromBytesKey: FromBytes[F, String],
     fromBytesState: FromBytes[F, S],
@@ -55,6 +58,7 @@ object KafkaPersistenceModuleOf {
         snapshotTopicPartition = TopicPartition(snapshotTopic, partition),
         metrics                = metrics,
         partitionMapper        = partitionMapper,
+        stallTimeout           = stallTimeout,
       )
   }
 

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModuleOf.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModuleOf.scala
@@ -42,8 +42,7 @@ object KafkaPersistenceModuleOf {
     metrics: FlowMetrics[F],
     partitionMapper: KafkaPersistencePartitionMapper = KafkaPersistencePartitionMapper.identity,
   )(
-    implicit fromBytesKey: FromBytes[F, String],
-    fromBytesState: FromBytes[F, S],
+    implicit fromBytesState: FromBytes[F, S],
     toBytesState: ToBytes[F, S]
   ): KafkaPersistenceModuleOf[F, S] = new KafkaPersistenceModuleOf[F, S] {
     // assignedAt is unused: the non-transactional caching module does not commit offsets through a producer
@@ -64,8 +63,7 @@ object KafkaPersistenceModuleOf {
     consumerConfig: ConsumerConfig,
     snapshotTopic: Topic
   )(
-    implicit fromBytesKey: FromBytes[F, String],
-    fromBytesState: FromBytes[F, S],
+    implicit fromBytesState: FromBytes[F, S],
     toBytesState: ToBytes[F, S]
   ): KafkaPersistenceModuleOf[F, S] =
     caching(consumerOf, producer, consumerConfig, snapshotTopic, FlowMetrics.empty[F])
@@ -85,8 +83,7 @@ object KafkaPersistenceModuleOf {
     groupMetadata: F[Option[ConsumerGroupMetadata]],
     metrics: FlowMetrics[F] = FlowMetrics.empty[F],
   )(
-    implicit fromBytesKey: FromBytes[F, String],
-    fromBytesState: FromBytes[F, S],
+    implicit fromBytesState: FromBytes[F, S],
     toBytesState: ToBytes[F, S]
   ): KafkaPersistenceModuleOf[F, S] = new KafkaPersistenceModuleOf[F, S] {
     override def make(partition: Partition, assignedAt: Offset): Resource[F, KafkaPersistenceModule[F, S]] =

--- a/persistence-kafka/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/ReadSnapshotsSpec.scala
+++ b/persistence-kafka/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/ReadSnapshotsSpec.scala
@@ -67,10 +67,10 @@ class ReadSnapshotsSpec extends FunSuite {
       positionRef <- Ref.of[IO, Long](0L)
       result <- KafkaPartitionPersistence
         .readPartition[IO](
-          consumer     = consumer(endOffset = 3L, positionRef = positionRef, records = List(record(0, "k0"))),
+          consumer          = consumer(endOffset = 3L, positionRef = positionRef, records = List(record(0, "k0"))),
           snapshotPartition = tp,
-          targetOffset = Offset.unsafe(3),
-          stallTimeout = 200.millis.some,
+          targetOffset      = Offset.unsafe(3),
+          stallTimeout      = 200.millis.some,
         )
         .attempt
     } yield result match {
@@ -130,15 +130,17 @@ class ReadSnapshotsSpec extends FunSuite {
       override def position(partition: TopicPartition) = positionRef.get.map(Offset.unsafe(_))
 
       override def poll(timeout: FiniteDuration) =
-        positionRef.modify { pos =>
-          records.find(_.offset.value == pos) match {
-            case Some(record) => (pos + 1, record.some)
-            case None         => (pos, none[ConsumerRecord[String, ByteVector]])
+        positionRef
+          .modify { pos =>
+            records.find(_.offset.value == pos) match {
+              case Some(record) => (pos + 1, record.some)
+              case None         => (pos, none[ConsumerRecord[String, ByteVector]])
+            }
           }
-        }.flatMap {
-          case Some(record) => ConsumerRecords(Map(tp -> NonEmptyList.one(record))).pure[IO]
-          case None         => IO.sleep(timeout).as(ConsumerRecords.empty[String, ByteVector])
-        }
+          .flatMap {
+            case Some(record) => ConsumerRecords(Map(tp -> NonEmptyList.one(record))).pure[IO]
+            case None         => IO.sleep(timeout).as(ConsumerRecords.empty[String, ByteVector])
+          }
 
       def assign(partitions: NonEmptySet[TopicPartition])                         = delegate.assign(partitions)
       def assignment                                                              = delegate.assignment

--- a/persistence-kafka/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/ReadSnapshotsSpec.scala
+++ b/persistence-kafka/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/ReadSnapshotsSpec.scala
@@ -40,18 +40,6 @@ class ReadSnapshotsSpec extends FunSuite {
       value            = ByteVector.encodeUtf8(key).toOption.map(WithSize(_)),
     )
 
-  test("stallTimeoutFor derives the deadline from max.poll.interval.ms, floored, kept below eviction") {
-    // default (5m max.poll.interval.ms): the ~2m floor wins, comfortably below eviction
-    assertEquals(
-      KafkaPartitionPersistence.stallTimeoutFor(ConsumerConfig()),
-      KafkaPartitionPersistence.minStallTimeout,
-    )
-    // tight window: safety wins - the deadline drops below the floor so it still fires before eviction
-    val tight = KafkaPartitionPersistence.stallTimeoutFor(ConsumerConfig(maxPollInterval = 90.seconds))
-    assert(tight < 90.seconds, s"expected below max.poll.interval.ms, got $tight")
-    assert(tight < KafkaPartitionPersistence.minStallTimeout, s"expected below the floor when tight, got $tight")
-  }
-
   test("the read drains to the consumer's end offset and returns every record below it") {
     // the read target is captured once from the consumer's own endOffsets, then drained to
     val records = List(record(0, "k0"), record(1, "k1"), record(2, "k2"))
@@ -63,6 +51,7 @@ class ReadSnapshotsSpec extends FunSuite {
         consumerConfig = ConsumerConfig(isolationLevel = IsolationLevel.ReadCommitted),
         snapshotTopic  = topic,
         partition      = partition,
+        stallTimeout   = KafkaPartitionPersistence.defaultStallTimeout,
       )
     } yield assertEquals(stored.keys.toList.sorted, List("k0", "k1", "k2"))
 

--- a/persistence-kafka/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/ReadSnapshotsSpec.scala
+++ b/persistence-kafka/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/ReadSnapshotsSpec.scala
@@ -51,7 +51,7 @@ class ReadSnapshotsSpec extends FunSuite {
         consumerConfig = ConsumerConfig(isolationLevel = IsolationLevel.ReadCommitted),
         snapshotTopic  = topic,
         partition      = partition,
-        stallTimeout   = KafkaPartitionPersistence.defaultStallTimeout,
+        stallTimeout   = KafkaPartitionPersistence.defaultStallTimeout.some,
       )
     } yield assertEquals(stored.keys.toList.sorted, List("k0", "k1", "k2"))
 
@@ -70,7 +70,7 @@ class ReadSnapshotsSpec extends FunSuite {
           consumer     = consumer(endOffset = 3L, positionRef = positionRef, records = List(record(0, "k0"))),
           snapshotPartition = tp,
           targetOffset = Offset.unsafe(3),
-          stallTimeout = 200.millis,
+          stallTimeout = 200.millis.some,
         )
         .attempt
     } yield result match {
@@ -78,6 +78,29 @@ class ReadSnapshotsSpec extends FunSuite {
         assertEquals(e.position, Offset.unsafe(1))
         assertEquals(e.targetOffset, Offset.unsafe(3))
       case other => fail(s"expected RecoveryReadStalledError, got $other")
+    }
+
+    test.unsafeRunSync()
+  }
+
+  test("with no deadline the read keeps its original behaviour and does not fail on a stall") {
+    // the non-transactional path passes no deadline; a stalled read must keep waiting, as before, not fail
+    val test = for {
+      positionRef <- Ref.of[IO, Long](0L)
+      result <- KafkaPartitionPersistence
+        .readPartition[IO](
+          consumer          = consumer(endOffset = 3L, positionRef = positionRef, records = List(record(0, "k0"))),
+          snapshotPartition = tp,
+          targetOffset      = Offset.unsafe(3),
+          stallTimeout      = none,
+        )
+        .timeout(500.millis)
+        .attempt
+    } yield result match {
+      case Left(_: KafkaPartitionPersistence.RecoveryReadStalledError) =>
+        fail("expected no stall failure when no deadline is set")
+      case Left(_)  => () // timed out from the outside while still polling - i.e. it kept waiting, as before
+      case Right(_) => fail("expected the read to keep waiting, not to complete")
     }
 
     test.unsafeRunSync()

--- a/persistence-kafka/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/ReadSnapshotsSpec.scala
+++ b/persistence-kafka/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/ReadSnapshotsSpec.scala
@@ -1,0 +1,177 @@
+package com.evolutiongaming.kafka.flow.kafkapersistence
+
+import cats.data.{NonEmptyList, NonEmptyMap, NonEmptySet}
+import cats.effect.unsafe.implicits.global
+import cats.effect.{IO, Ref}
+import cats.syntax.all.*
+import com.evolutiongaming.catshelper.{FromTry, Log}
+import com.evolutiongaming.skafka.*
+import com.evolutiongaming.skafka.consumer.{
+  Consumer as SkafkaConsumer,
+  ConsumerConfig,
+  ConsumerOf,
+  ConsumerRecord,
+  ConsumerRecords,
+  IsolationLevel,
+  RebalanceListener1,
+  WithSize
+}
+import munit.FunSuite
+import scodec.bits.ByteVector
+
+import java.util.regex.Pattern
+import scala.concurrent.duration.*
+
+class ReadSnapshotsSpec extends FunSuite {
+
+  implicit val log: Log[IO]         = Log.empty[IO]
+  implicit val fromTry: FromTry[IO] = FromTry.lift
+
+  private val topic     = "state-topic"
+  private val partition = Partition.min
+  private val tp        = TopicPartition(topic, partition)
+
+  private def record(offset: Long, key: String): ConsumerRecord[String, ByteVector] =
+    ConsumerRecord(
+      topicPartition   = tp,
+      offset           = Offset.unsafe(offset),
+      timestampAndType = none,
+      key              = WithSize(key).some,
+      value            = ByteVector.encodeUtf8(key).toOption.map(WithSize(_)),
+    )
+
+  test("stallTimeoutFor derives the deadline from max.poll.interval.ms, floored, kept below eviction") {
+    // default (5m max.poll.interval.ms): the ~2m floor wins, comfortably below eviction
+    assertEquals(
+      KafkaPartitionPersistence.stallTimeoutFor(ConsumerConfig()),
+      KafkaPartitionPersistence.minStallTimeout,
+    )
+    // tight window: safety wins - the deadline drops below the floor so it still fires before eviction
+    val tight = KafkaPartitionPersistence.stallTimeoutFor(ConsumerConfig(maxPollInterval = 90.seconds))
+    assert(tight < 90.seconds, s"expected below max.poll.interval.ms, got $tight")
+    assert(tight < KafkaPartitionPersistence.minStallTimeout, s"expected below the floor when tight, got $tight")
+  }
+
+  test("the read drains to the consumer's end offset and returns every record below it") {
+    // the read target is captured once from the consumer's own endOffsets, then drained to
+    val records = List(record(0, "k0"), record(1, "k1"), record(2, "k2"))
+
+    val test = for {
+      positionRef <- Ref.of[IO, Long](0L)
+      stored <- KafkaPartitionPersistence.readSnapshots[IO](
+        consumerOf     = consumerOf(consumer(endOffset = 3L, positionRef = positionRef, records = records)),
+        consumerConfig = ConsumerConfig(isolationLevel = IsolationLevel.ReadCommitted),
+        snapshotTopic  = topic,
+        partition      = partition,
+      )
+    } yield assertEquals(stored.keys.toList.sorted, List("k0", "k1", "k2"))
+
+    test.unsafeRunSync()
+  }
+
+  test("a read stalled past the deadline fails loudly instead of hanging") {
+    // The target (3) was captured before a hypothetical log truncation; the log now ends at 1, so the position
+    // parks there and can never reach the target. Waiting cannot fix that - everything below the target is decided
+    // and fetchable. The deadline is measured by elapsed wall time (each empty poll blocks its 10ms timeout), so a
+    // small injected timeout trips quickly here while the production default stays ~2m; it is not a poll count.
+    val test = for {
+      positionRef <- Ref.of[IO, Long](0L)
+      result <- KafkaPartitionPersistence
+        .readPartition[IO](
+          consumer     = consumer(endOffset = 3L, positionRef = positionRef, records = List(record(0, "k0"))),
+          snapshotPartition = tp,
+          targetOffset = Offset.unsafe(3),
+          stallTimeout = 200.millis,
+        )
+        .attempt
+    } yield result match {
+      case Left(e: KafkaPartitionPersistence.RecoveryReadStalledError) =>
+        assertEquals(e.position, Offset.unsafe(1))
+        assertEquals(e.targetOffset, Offset.unsafe(3))
+      case other => fail(s"expected RecoveryReadStalledError, got $other")
+    }
+
+    test.unsafeRunSync()
+  }
+
+  private def consumerOf(stub: SkafkaConsumer[IO, String, ByteVector]): ConsumerOf[IO] = new ConsumerOf[IO] {
+    def apply[K, V](
+      config: ConsumerConfig
+    )(implicit fromBytesK: FromBytes[IO, K], fromBytesV: FromBytes[IO, V]) =
+      cats.effect.Resource.pure[IO, SkafkaConsumer[IO, K, V]](stub.asInstanceOf[SkafkaConsumer[IO, K, V]])
+  }
+
+  // serves `records` one per poll from `position`, advancing it; on an empty poll it sleeps the poll timeout, as a
+  // real blocking poll would, so elapsed wall time (the stall deadline) advances deterministically. endOffsets is
+  // fixed (the captured bound).
+  private def consumer(
+    endOffset: Long,
+    positionRef: Ref[IO, Long],
+    records: List[ConsumerRecord[String, ByteVector]],
+  ): SkafkaConsumer[IO, String, ByteVector] =
+    new SkafkaConsumer[IO, String, ByteVector] {
+      private val delegate = SkafkaConsumer.empty[IO, String, ByteVector]
+
+      override def endOffsets(partitions: NonEmptySet[TopicPartition]) =
+        Map(tp -> Offset.unsafe(endOffset)).pure[IO]
+
+      override def position(partition: TopicPartition) = positionRef.get.map(Offset.unsafe(_))
+
+      override def poll(timeout: FiniteDuration) =
+        positionRef.modify { pos =>
+          records.find(_.offset.value == pos) match {
+            case Some(record) => (pos + 1, record.some)
+            case None         => (pos, none[ConsumerRecord[String, ByteVector]])
+          }
+        }.flatMap {
+          case Some(record) => ConsumerRecords(Map(tp -> NonEmptyList.one(record))).pure[IO]
+          case None         => IO.sleep(timeout).as(ConsumerRecords.empty[String, ByteVector])
+        }
+
+      def assign(partitions: NonEmptySet[TopicPartition])                         = delegate.assign(partitions)
+      def assignment                                                              = delegate.assignment
+      def subscribe(topics: NonEmptySet[Topic], listener: RebalanceListener1[IO]) = delegate.subscribe(topics, listener)
+      def subscribe(topics: NonEmptySet[Topic])                                   = delegate.subscribe(topics)
+      def subscribe(pattern: Pattern, listener: RebalanceListener1[IO])   = delegate.subscribe(pattern, listener)
+      def subscribe(pattern: Pattern)                                     = delegate.subscribe(pattern)
+      def subscription                                                    = delegate.subscription
+      def unsubscribe                                                     = delegate.unsubscribe
+      def commit                                                          = delegate.commit
+      def commit(timeout: FiniteDuration)                                 = delegate.commit(timeout)
+      def commit(offsets: NonEmptyMap[TopicPartition, OffsetAndMetadata]) = delegate.commit(offsets)
+      def commit(offsets: NonEmptyMap[TopicPartition, OffsetAndMetadata], timeout: FiniteDuration) =
+        delegate.commit(offsets, timeout)
+      def commitLater                                                          = delegate.commitLater
+      def commitLater(offsets: NonEmptyMap[TopicPartition, OffsetAndMetadata]) = delegate.commitLater(offsets)
+      def seek(partition: TopicPartition, offset: Offset)                      = delegate.seek(partition, offset)
+      def seek(partition: TopicPartition, offsetAndMetadata: OffsetAndMetadata) =
+        delegate.seek(partition, offsetAndMetadata)
+      def seekToBeginning(partitions: NonEmptySet[TopicPartition])     = delegate.seekToBeginning(partitions)
+      def seekToEnd(partitions: NonEmptySet[TopicPartition])           = delegate.seekToEnd(partitions)
+      def position(partition: TopicPartition, timeout: FiniteDuration) = positionRef.get.map(Offset.unsafe(_))
+      def committed(partitions: NonEmptySet[TopicPartition])           = delegate.committed(partitions)
+      def committed(partitions: NonEmptySet[TopicPartition], timeout: FiniteDuration) =
+        delegate.committed(partitions, timeout)
+      def clientInstanceId(timeout: FiniteDuration)         = delegate.clientInstanceId(timeout)
+      def clientMetrics                                     = delegate.clientMetrics
+      def partitions(topic: Topic)                          = delegate.partitions(topic)
+      def partitions(topic: Topic, timeout: FiniteDuration) = delegate.partitions(topic, timeout)
+      def topics                                            = delegate.topics
+      def topics(timeout: FiniteDuration)                   = delegate.topics(timeout)
+      def paused                                            = delegate.paused
+      def pause(partitions: NonEmptySet[TopicPartition])    = delegate.pause(partitions)
+      def resume(partitions: NonEmptySet[TopicPartition])   = delegate.resume(partitions)
+      def offsetsForTimes(timestampsToSearch: Map[TopicPartition, Offset]) =
+        delegate.offsetsForTimes(timestampsToSearch)
+      def offsetsForTimes(timestampsToSearch: Map[TopicPartition, Offset], timeout: FiniteDuration) =
+        delegate.offsetsForTimes(timestampsToSearch, timeout)
+      def beginningOffsets(partitions: NonEmptySet[TopicPartition]) = delegate.beginningOffsets(partitions)
+      def beginningOffsets(partitions: NonEmptySet[TopicPartition], timeout: FiniteDuration) =
+        delegate.beginningOffsets(partitions, timeout)
+      def endOffsets(partitions: NonEmptySet[TopicPartition], timeout: FiniteDuration) = endOffsets(partitions)
+      def currentLag(partition: TopicPartition)                                        = delegate.currentLag(partition)
+      def groupMetadata                                                                = delegate.groupMetadata
+      def enforceRebalance                                                             = delegate.enforceRebalance
+      def wakeup                                                                       = delegate.wakeup
+    }
+}


### PR DESCRIPTION
## Problem

Fixes #849.

Snapshot recovery captures the consumer's `read_committed` end offset (the last
stable offset) and drains the snapshot partition up to it. This runs inside the
rebalance callback, on the poll thread. If the log end regresses below the
captured target — log truncation after an unclean leader election, i.e. the
cluster lost acknowledged snapshot records — the position can never reach the
target and the read loops forever.

Because it hangs on the poll thread, nothing crashes: `max.poll.interval.ms`
silently evicts the member from the group while the thread stays stuck, and the
partition migrates elsewhere. The process stays up and healthy to liveness
probes, so the failure is invisible to process-level monitoring.

## Approach

Detect a stalled recovery read and fail loudly with `RecoveryReadStalledError`
*before* the broker evicts the member, converting a silent, non-recovering
zombie into a visible crash-restart.

- **Wall-clock deadline, not a poll count.** The no-progress timeout is measured
  with `Clock[F].monotonic` from the last position advance and reset on every
  advance. The guarantee ("fail before `max.poll.interval.ms`") is a property of
  time, so it's enforced by measuring time — independent of how long each poll
  happens to block or of the (configurable) poll timeout.

- **Transactional mode only.** Only `cachingTransactional` arms a deadline: it
  captures a `read_committed` end offset that a truncation can strand the read
  below. The non-transactional `caching` path passes no deadline (`None`) and
  keeps its original behaviour — it waits indefinitely, no tripwire.

- **Explicit config, not a derived value.** The timeout is
  `TransactionalConfig.recoveryStallTimeout`, defaulting to
  `KafkaPartitionPersistence.defaultStallTimeout` (2 minutes). It's documented to
  sit below `max.poll.interval.ms` (the eviction bound) and above any
  self-healing stall (a hung transaction aborts within the producer's
  `transaction.timeout.ms`). 2 minutes sits between the 5-minute and 60-second
  defaults; retune it if you retune `max.poll.interval.ms`.

- **Misconfiguration guard.** `cachingTransactional` logs a warning when
  `recoveryStallTimeout` is not below the consumer's `max.poll.interval.ms`,
  since in that case the broker would evict the stuck member before the deadline
  could fire, silently defeating the tripwire.

## Changes

- `KafkaPartitionPersistence`: add `RecoveryReadStalledError` and
  `defaultStallTimeout`; `readPartition`/`readSnapshots` take
  `Option[FiniteDuration]` and fail only when a deadline is set; deadline tracked
  via a monotonic clock. `Clock` threaded through the recovery path.
- `KafkaPersistenceModule` / `KafkaPersistenceModuleOf`: add
  `TransactionalConfig.recoveryStallTimeout`; transactional passes `Some(...)`,
  non-transactional passes `None`; eviction-margin warning.

## Testing

New unit `ReadSnapshotsSpec`:
- drains to the consumer's end offset and returns every record below it;
- a truncated log (target beyond the log end) trips the deadline with
  `RecoveryReadStalledError` instead of hanging;
- with no deadline, a stalled read keeps waiting instead of failing.

Integration `readSnapshots` call sites updated. `persistence-kafka` and
`persistence-kafka-it-tests` compile; `ReadSnapshotsSpec` passes 3/3.

## Notes

- `RecoveryReadStalledError` is public so callers can catch/observe it as it
  propagates out of recovery — intentional; flag if it should be package-private.