### PR TITLE
Recovery must not complete short of an open transaction on the snapshot topic (draft — alternative A)

### DIFF
--- a/persistence-kafka-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/TransactionalKafkaPersistenceSpec.scala
+++ b/persistence-kafka-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/TransactionalKafkaPersistenceSpec.scala
@@ -5,6 +5,7 @@ import cats.effect.unsafe.IORuntime
 import cats.effect.{IO, Ref, Resource}
 import cats.syntax.all.*
 import com.evolutiongaming.catshelper.{FromTry, Log, LogOf}
+import com.evolutiongaming.kafka.flow.kafka.Codecs.*
 import com.evolutiongaming.kafka.flow.kafka.ScheduleCommit
 import com.evolutiongaming.kafka.flow.registry.EntityRegistry
 import com.evolutiongaming.kafka.flow.snapshot.SnapshotWriteDatabase
@@ -441,26 +442,67 @@ class TransactionalKafkaPersistenceSpec extends ForAllKafkaSuite {
     }
   }
 
-  test("an open transaction of a fenced writer neither blocks nor leaks into recovery") {
+  test("recovery waits out an open transaction and reads committed snapshots beyond it") {
+    // A hard-crashed writer leaves its transaction open for up to transaction.timeout.ms, pinning the
+    // snapshot topic's last-stable-offset below anything committed after it. Recovery must not complete
+    // bounded by that pin (it would silently miss the newer owner's committed snapshots and recover stale
+    // state); it must wait the open transaction out, then include the committed records and exclude the
+    // timed-out (aborted) ones. The open transaction here is genuinely open during the read: a unique
+    // second transactional.id is used, so nothing aborts it early - only the broker's timeout does. (The
+    // previous version of this test reused the crashed producer's id, so the second initTransactions
+    // aborted the transaction before the read ran - it never exercised the open case.)
     val stateTopic = "tx-open-state-topic"
 
-    val record = new ProducerRecord(
+    def record(key: String, value: String) = new ProducerRecord(
       topic     = stateTopic,
       partition = Partition.min.some,
-      key       = "key-uncommitted".some,
-      value     = "uncommitted".some,
+      key       = key.some,
+      value     = value.some,
     )
 
+    def endOffset(isolation: IsolationLevel): IO[Offset] = {
+      val tp = TopicPartition(stateTopic, Partition.min)
+      consumerOf
+        .apply[String, ByteVector](consumerConfig.copy(isolationLevel = isolation))
+        .use(_.endOffsets(cats.data.NonEmptySet.of(tp)).map(_.getOrElse(tp, Offset.min)))
+    }
+
+    // short transaction.timeout.ms so the broker aborts the "crashed" writer quickly (abort scan runs
+    // every transaction.abort.timed.out.transaction.cleanup.interval.ms, default 10s)
+    val crashedProducer =
+      producerOf(
+        producerConfig.copy(
+          transactionalId    = "tx-open-crashed".some,
+          idempotence        = true,
+          transactionTimeout = 5.seconds,
+        )
+      )
+
     val test = createTopic(stateTopic, 1) *>
-      transactionalProducer("tx-open").use { producerA =>
+      crashedProducer.use { producerA =>
         for {
           _ <- producerA.initTransactions
           _ <- producerA.beginTransaction
-          _ <- producerA.send(record).flatten
-          // producerA's transaction is left open: initTransactions of the new producer aborts it
-          _      <- transactionalProducer("tx-open").use(_.initTransactions)
-          stored <- readSnapshots(stateTopic).timeout(30.seconds)
-        } yield assertEquals(clue(stored.get("key-uncommitted")), none[ByteVector])
+          _ <- producerA.send(record("key-uncommitted", "uncommitted")).flatten
+          // the next owner commits a NEWER snapshot above A's still-open transaction
+          _ <- transactionalProducer("tx-open-next").use { producerB =>
+            producerB.initTransactions *>
+              producerB.beginTransaction *>
+              producerB.send(record("key-committed", "committed")).flatten *>
+              producerB.commitTransaction
+          }
+          // the pin must be active when the read starts: without this check, a slow runner where the
+          // broker has already timed A out degrades the test to the aborted case, silently not
+          // exercising the wait
+          lso <- endOffset(IsolationLevel.ReadCommitted)
+          hw  <- endOffset(IsolationLevel.ReadUncommitted)
+          _    = assert(clue(lso.value) < clue(hw.value), "expected an open-transaction pin at read start")
+          // A's transaction is still open here; the read must wait for the broker to time it out
+          stored <- readSnapshots(stateTopic).timeout(60.seconds)
+        } yield {
+          assertEquals(clue(stored.get("key-committed")), utf8("committed"))
+          assertEquals(clue(stored.get("key-uncommitted")), none[ByteVector])
+        }
       }
 
     test.unsafeRunSync()

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPartitionPersistence.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPartitionPersistence.scala
@@ -11,6 +11,7 @@ import com.evolutiongaming.skafka.consumer.{
   ConsumerConfig,
   ConsumerOf,
   ConsumerRecord,
+  IsolationLevel,
   WithSize
 }
 import scodec.bits.ByteVector
@@ -63,36 +64,58 @@ object KafkaPartitionPersistence {
     snapshotTopic: Topic,
     partition: Partition,
   )(implicit fromBytes: FromBytes[F, String]): F[BytesByKey] = {
-    consumerOf
-      .apply[String, ByteVector](
-        consumerConfig.copy(
-          autoOffsetReset = Earliest,
-          common = consumerConfig
-            .common
-            .copy(clientId = consumerConfig.common.clientId.map(cid => s"$cid-snapshot-$partition"))
-        )
-      )
-      .use { consumer =>
-        val snapshotsPartition =
-          TopicPartition(topic = snapshotTopic, partition = partition)
+    val snapshotsPartition         = TopicPartition(topic = snapshotTopic, partition = partition)
+    val snapshotPartitionSingleton = data.NonEmptySet.of(snapshotsPartition)
 
-        val snapshotPartitionSingleton = data.NonEmptySet.of(snapshotsPartition)
-        for {
-          _          <- consumer.assign(snapshotPartitionSingleton)
-          endOffsets <- consumer.endOffsets(snapshotPartitionSingleton)
-          targetOffset <- BracketThrowable[F].fromOption(
-            endOffsets.get(snapshotsPartition),
-            MissingOffsetError(snapshotsPartition)
-          )
-          bytesByKey <- readPartition(
-            consumer,
-            snapshotsPartition,
-            targetOffset
-          )
-          _ <- Log[F].info(
-            s"Snapshot topic $snapshotTopic partition $partition read complete at offset $targetOffset, ${bytesByKey.size} keys read"
-          )
-        } yield bytesByKey
+    def suffixed(suffix: String): ConsumerConfig =
+      consumerConfig.copy(
+        autoOffsetReset = Earliest,
+        common = consumerConfig.common.copy(clientId = consumerConfig.common.clientId.map(cid => s"$cid-$suffix"))
+      )
+
+    def endOffset(consumer: SkafkaConsumer[F, String, ByteVector]): F[Offset] =
+      consumer.endOffsets(snapshotPartitionSingleton).flatMap { endOffsets =>
+        BracketThrowable[F].fromOption(endOffsets.get(snapshotsPartition), MissingOffsetError(snapshotsPartition))
       }
+
+    // The read target must be the high watermark. Under read_committed this consumer's own end offset is
+    // the last-stable-offset, which an open transaction (e.g. of a hard-crashed previous owner, for up to
+    // its transaction.timeout.ms plus the broker's abort-scan interval, default 10s) pins BELOW records
+    // committed after it - a read bounded by it completes silently missing those committed snapshots. So
+    // for a read_committed config the target is captured up front by a short-lived read_uncommitted
+    // consumer, which makes the read wait such transactions out: the read_committed position cannot pass
+    // the last-stable-offset until the broker resolves them, so the read completes only once everything
+    // below the target is decided - committed records included, aborted ones filtered. (Kafka Streams'
+    // restore does the same for the same reason - KAFKA-10167.) Under read_uncommitted the consumer's own
+    // end offset already is the high watermark, so no extra capture is needed.
+    val capturedHighWatermark: F[Option[Offset]] =
+      if (consumerConfig.isolationLevel == IsolationLevel.ReadCommitted)
+        consumerOf
+          .apply[String, ByteVector](
+            suffixed(s"snapshot-$partition-hw").copy(isolationLevel = IsolationLevel.ReadUncommitted)
+          )
+          .use(endOffset)
+          .map(_.some)
+      else
+        none[Offset].pure[F]
+
+    capturedHighWatermark.flatMap { captured =>
+      consumerOf
+        .apply[String, ByteVector](suffixed(s"snapshot-$partition"))
+        .use { consumer =>
+          for {
+            _            <- consumer.assign(snapshotPartitionSingleton)
+            targetOffset <- captured.fold(endOffset(consumer))(_.pure[F])
+            bytesByKey <- readPartition(
+              consumer,
+              snapshotsPartition,
+              targetOffset
+            )
+            _ <- Log[F].info(
+              s"Snapshot topic $snapshotTopic partition $partition read complete at offset $targetOffset, ${bytesByKey.size} keys read"
+            )
+          } yield bytesByKey
+        }
+    }
   }
 }

--- a/persistence-kafka/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/ReadSnapshotsSpec.scala
+++ b/persistence-kafka/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/ReadSnapshotsSpec.scala
@@ -1,0 +1,152 @@
+package com.evolutiongaming.kafka.flow.kafkapersistence
+
+import cats.data.{NonEmptyList, NonEmptyMap, NonEmptySet}
+import cats.effect.unsafe.implicits.global
+import cats.effect.{IO, Ref}
+import cats.syntax.all.*
+import com.evolutiongaming.catshelper.{FromTry, Log}
+import com.evolutiongaming.skafka.*
+import com.evolutiongaming.skafka.consumer.{
+  Consumer as SkafkaConsumer,
+  ConsumerConfig,
+  ConsumerOf,
+  ConsumerRecord,
+  ConsumerRecords,
+  IsolationLevel,
+  RebalanceListener1,
+  WithSize
+}
+import munit.FunSuite
+import scodec.bits.ByteVector
+
+import java.util.regex.Pattern
+import scala.concurrent.duration.FiniteDuration
+
+class ReadSnapshotsSpec extends FunSuite {
+
+  implicit val log: Log[IO]         = Log.empty[IO]
+  implicit val fromTry: FromTry[IO] = FromTry.lift
+
+  private val topic     = "state-topic"
+  private val partition = Partition.min
+  private val tp        = TopicPartition(topic, partition)
+
+  private def record(offset: Long, key: String): ConsumerRecord[String, ByteVector] =
+    ConsumerRecord(
+      topicPartition   = tp,
+      offset           = Offset.unsafe(offset),
+      timestampAndType = none,
+      key              = WithSize(key).some,
+      value            = ByteVector.encodeUtf8(key).toOption.map(WithSize(_)),
+    )
+
+  test("a read_committed read drains to the read_uncommitted end offset, not its own") {
+    // The read consumer's own endOffsets is the last-stable-offset: an open transaction pins it below
+    // committed records written after it (here: LSO = 1, records up to the high watermark 3). The read
+    // must take its target from a read_uncommitted view and keep polling past its own end offset - a
+    // target from the read consumer would stop after one record, silently missing the rest.
+    val lso           = 1L
+    val highWatermark = 3L
+    val records       = List(record(0, "k0"), record(1, "k1"), record(2, "k2"))
+
+    val test = for {
+      positionRef <- Ref.of[IO, Long](0L)
+      readConsumer = consumer(endOffset = lso, positionRef = positionRef, records = records)
+      hwConsumer   = consumer(endOffset = highWatermark, positionRef = positionRef, records = Nil)
+      stored <- KafkaPartitionPersistence.readSnapshots[IO](
+        consumerOf     = consumerOf(readConsumer = readConsumer, hwConsumer = hwConsumer),
+        consumerConfig = ConsumerConfig(isolationLevel = IsolationLevel.ReadCommitted),
+        snapshotTopic  = topic,
+        partition      = partition,
+      )
+    } yield assertEquals(stored.keys.toList.sorted, List("k0", "k1", "k2"), "the read must drain past its own LSO")
+
+    test.unsafeRunSync()
+  }
+
+  // dispatches by isolation level: the read consumer for read_committed, the HW consumer for read_uncommitted
+  private def consumerOf(
+    readConsumer: SkafkaConsumer[IO, String, ByteVector],
+    hwConsumer: SkafkaConsumer[IO, String, ByteVector],
+  ): ConsumerOf[IO] = new ConsumerOf[IO] {
+    def apply[K, V](
+      config: ConsumerConfig
+    )(implicit fromBytesK: FromBytes[IO, K], fromBytesV: FromBytes[IO, V]) =
+      cats
+        .effect
+        .Resource
+        .pure[IO, SkafkaConsumer[IO, K, V]](
+          (if (config.isolationLevel == IsolationLevel.ReadUncommitted) hwConsumer else readConsumer)
+            .asInstanceOf[SkafkaConsumer[IO, K, V]]
+        )
+  }
+
+  // serves `records` one per poll from `position`, advancing it; endOffsets is fixed (the isolation-dependent bound)
+  private def consumer(
+    endOffset: Long,
+    positionRef: Ref[IO, Long],
+    records: List[ConsumerRecord[String, ByteVector]],
+  ): SkafkaConsumer[IO, String, ByteVector] =
+    new SkafkaConsumer[IO, String, ByteVector] {
+      private val delegate = SkafkaConsumer.empty[IO, String, ByteVector]
+
+      override def endOffsets(partitions: NonEmptySet[TopicPartition]) =
+        Map(tp -> Offset.unsafe(endOffset)).pure[IO]
+
+      override def position(partition: TopicPartition) = positionRef.get.map(Offset.unsafe(_))
+
+      override def poll(timeout: FiniteDuration) =
+        positionRef.modify { pos =>
+          records.find(_.offset.value == pos) match {
+            case Some(record) => (pos + 1, ConsumerRecords(Map(tp -> NonEmptyList.one(record))))
+            case None         => (pos, ConsumerRecords.empty[String, ByteVector])
+          }
+        }
+
+      def assign(partitions: NonEmptySet[TopicPartition])                         = delegate.assign(partitions)
+      def assignment                                                              = delegate.assignment
+      def subscribe(topics: NonEmptySet[Topic], listener: RebalanceListener1[IO]) = delegate.subscribe(topics, listener)
+      def subscribe(topics: NonEmptySet[Topic])                                   = delegate.subscribe(topics)
+      def subscribe(pattern: Pattern, listener: RebalanceListener1[IO])   = delegate.subscribe(pattern, listener)
+      def subscribe(pattern: Pattern)                                     = delegate.subscribe(pattern)
+      def subscription                                                    = delegate.subscription
+      def unsubscribe                                                     = delegate.unsubscribe
+      def commit                                                          = delegate.commit
+      def commit(timeout: FiniteDuration)                                 = delegate.commit(timeout)
+      def commit(offsets: NonEmptyMap[TopicPartition, OffsetAndMetadata]) = delegate.commit(offsets)
+      def commit(offsets: NonEmptyMap[TopicPartition, OffsetAndMetadata], timeout: FiniteDuration) =
+        delegate.commit(offsets, timeout)
+      def commitLater                                                          = delegate.commitLater
+      def commitLater(offsets: NonEmptyMap[TopicPartition, OffsetAndMetadata]) = delegate.commitLater(offsets)
+      def seek(partition: TopicPartition, offset: Offset)                      = delegate.seek(partition, offset)
+      def seek(partition: TopicPartition, offsetAndMetadata: OffsetAndMetadata) =
+        delegate.seek(partition, offsetAndMetadata)
+      def seekToBeginning(partitions: NonEmptySet[TopicPartition])     = delegate.seekToBeginning(partitions)
+      def seekToEnd(partitions: NonEmptySet[TopicPartition])           = delegate.seekToEnd(partitions)
+      def position(partition: TopicPartition, timeout: FiniteDuration) = positionRef.get.map(Offset.unsafe(_))
+      def committed(partitions: NonEmptySet[TopicPartition])           = delegate.committed(partitions)
+      def committed(partitions: NonEmptySet[TopicPartition], timeout: FiniteDuration) =
+        delegate.committed(partitions, timeout)
+      def clientInstanceId(timeout: FiniteDuration)         = delegate.clientInstanceId(timeout)
+      def clientMetrics                                     = delegate.clientMetrics
+      def partitions(topic: Topic)                          = delegate.partitions(topic)
+      def partitions(topic: Topic, timeout: FiniteDuration) = delegate.partitions(topic, timeout)
+      def topics                                            = delegate.topics
+      def topics(timeout: FiniteDuration)                   = delegate.topics(timeout)
+      def paused                                            = delegate.paused
+      def pause(partitions: NonEmptySet[TopicPartition])    = delegate.pause(partitions)
+      def resume(partitions: NonEmptySet[TopicPartition])   = delegate.resume(partitions)
+      def offsetsForTimes(timestampsToSearch: Map[TopicPartition, Offset]) =
+        delegate.offsetsForTimes(timestampsToSearch)
+      def offsetsForTimes(timestampsToSearch: Map[TopicPartition, Offset], timeout: FiniteDuration) =
+        delegate.offsetsForTimes(timestampsToSearch, timeout)
+      def beginningOffsets(partitions: NonEmptySet[TopicPartition]) = delegate.beginningOffsets(partitions)
+      def beginningOffsets(partitions: NonEmptySet[TopicPartition], timeout: FiniteDuration) =
+        delegate.beginningOffsets(partitions, timeout)
+      def endOffsets(partitions: NonEmptySet[TopicPartition], timeout: FiniteDuration) = endOffsets(partitions)
+      def currentLag(partition: TopicPartition)                                        = delegate.currentLag(partition)
+      def groupMetadata                                                                = delegate.groupMetadata
+      def enforceRebalance                                                             = delegate.enforceRebalance
+      def wakeup                                                                       = delegate.wakeup
+    }
+}


### PR DESCRIPTION
Fixes #850. Alternative to #853 — pick one.

### Problem

`readSnapshots` bounds the recovery read by its own `read_committed` consumer's `endOffsets` — the last stable offset. A hard-crashed writer's open transaction pins the LSO below snapshots committed after it, and with per-assignment `transactional.id`s nothing aborts that transaction before its timeout. A recovery inside that window completes "successfully" while silently missing the newer committed snapshots; a second handover inside the window then resumes from the newer committed input offset with stale state — the #732 corruption shape, with no fencing violated.

### Fix

Bound the read by the high watermark instead, captured up front by a short-lived `read_uncommitted` consumer (only when the read is `read_committed`; under `read_uncommitted` nothing changes). The `read_committed` position cannot pass the LSO until the broker resolves the open transaction, so the read genuinely waits it out and completes only once everything below the target is decided: committed records included, aborted ones filtered. This is the bound Kafka Streams uses for its EOS restore, for the same reason (KAFKA-10167).

### Trade-off vs #853

Keeps per-assignment `transactional.id`s: no naming discipline on `transactionalIdPrefix`, no risk of applications fencing each other. In exchange, recovery after an ungraceful shutdown (e.g. a JVM crash) is not immediate — the read waits for the broker to time the transaction out, bounded by `transaction.timeout.ms` plus the abort scan (~70 s at defaults, typically less since crash detection consumes most of it). #853 makes the same takeover sub-second.

### Tests and docs

The existing "open transaction" IT never exercised an open transaction (reusing the crashed producer's id aborted it before the read ran); it now keeps the transaction genuinely open through the read and asserts the read waits, includes the committed record, and excludes the timed-out one. A new unit test (`ReadSnapshotsSpec`) pins the high-watermark bound. Docs updates are deferred until #854 is merged.