### PR TITLE
Stable per-partition transactional.id — a takeover aborts a crashed owner's transaction (draft — alternative B)

### DIFF
--- a/persistence-kafka-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/TransactionalKafkaPersistenceSpec.scala
+++ b/persistence-kafka-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/TransactionalKafkaPersistenceSpec.scala
@@ -5,6 +5,7 @@ import cats.effect.unsafe.IORuntime
 import cats.effect.{IO, Ref, Resource}
 import cats.syntax.all.*
 import com.evolutiongaming.catshelper.{FromTry, Log, LogOf}
+import com.evolutiongaming.kafka.flow.kafka.Codecs.*
 import com.evolutiongaming.kafka.flow.kafka.ScheduleCommit
 import com.evolutiongaming.kafka.flow.registry.EntityRegistry
 import com.evolutiongaming.kafka.flow.snapshot.SnapshotWriteDatabase
@@ -439,6 +440,95 @@ class TransactionalKafkaPersistenceSpec extends ForAllKafkaSuite {
 
       test.unsafeRunSync()
     }
+  }
+
+  test("a takeover aborts the crashed owner's dangling transaction (stable transactional.id)") {
+    // Every writer of a partition shares the stable transactional.id, and its mandatory initTransactions
+    // aborts the predecessor's open transaction before it may write - so a hard-crashed owner's dangling
+    // transaction does not outlive the handover, and no committed snapshot can sit above an open
+    // transaction on the topic. This test pins that at the handover: acquiring the module runs
+    // initTransactions on the partition's own id, fencing the crashed producer and aborting its dangling
+    // transaction; the abort markers are written and replicated before initTransactions returns, so the
+    // last-stable-offset is back at the high watermark before recovery reads. The crashed producer's
+    // transaction.timeout.ms is deliberately long: the pin-resolved assertion right after module
+    // acquisition can only pass through the takeover-abort, never the broker's timeout. This also pins
+    // the "<prefix>-<partition>" id shape - under a per-assignment unique id the crashed transaction
+    // would stay open and the assertion would fail.
+    val stateTopic = "tx-takeover-abort-state-topic"
+    val inputTopic = s"input-$stateTopic"
+
+    def record(key: String, value: String) = new ProducerRecord(
+      topic     = stateTopic,
+      partition = Partition.min.some,
+      key       = key.some,
+      value     = value.some,
+    )
+
+    def endOffset(isolation: IsolationLevel): IO[Offset] = {
+      val tp = TopicPartition(stateTopic, Partition.min)
+      consumerOf
+        .apply[String, ByteVector](consumerConfig.copy(isolationLevel = isolation))
+        .use(_.endOffsets(cats.data.NonEmptySet.of(tp)).map(_.getOrElse(tp, Offset.min)))
+    }
+
+    // the id the module derives for this partition: the crashed owner is what a previous incarnation of
+    // the module's own producer would have been
+    val crashedProducer =
+      producerOf(
+        producerConfig.copy(
+          transactionalId = s"$appId-${Partition.min.value}".some,
+          idempotence     = true,
+        )
+      )
+
+    val module = KafkaPersistenceModule.cachingTransactional[IO, String](
+      consumerOf = consumerOf,
+      producerOf = producerOf,
+      config = KafkaPersistenceModule.TransactionalConfig(
+        consumerConfig        = consumerConfig,
+        producerConfig        = producerConfig,
+        transactionalIdPrefix = appId,
+        snapshotTopic         = stateTopic,
+        inputTopic            = inputTopic,
+      ),
+      assignment = KafkaPersistenceModule.PartitionAssignment[IO](
+        partition     = Partition.min,
+        assignedAt    = Offset.min,
+        groupMetadata = IO.pure(none[ConsumerGroupMetadata]),
+      ),
+    )
+
+    val test = createTopic(stateTopic, 1) *>
+      crashedProducer.use { crashed =>
+        for {
+          _ <- crashed.initTransactions
+          // a committed snapshot, so recovery has something real to return
+          _ <- crashed.beginTransaction
+          _ <- crashed.send(record("key-committed", "committed")).flatten
+          _ <- crashed.commitTransaction
+          // the crash: a transaction left open - never committed, aborted or closed
+          _    <- crashed.beginTransaction
+          _    <- crashed.send(record("key-dangling", "dangling")).flatten
+          lso0 <- endOffset(IsolationLevel.ReadCommitted)
+          hw0  <- endOffset(IsolationLevel.ReadUncommitted)
+          _     = assert(clue(lso0.value) < clue(hw0.value), "expected the dangling transaction to pin the LSO")
+          // the takeover: acquiring the module runs initTransactions on the partition's stable id
+          stored <- module.use { _ =>
+            for {
+              lso1 <- endOffset(IsolationLevel.ReadCommitted)
+              hw1  <- endOffset(IsolationLevel.ReadUncommitted)
+              // the pin is resolved by the init itself - recovery starts unpinned, nothing to wait out
+              _ = assertEquals(clue(lso1), clue(hw1), "expected the takeover's init to abort the dangling transaction")
+              stored <- readSnapshots(stateTopic)
+            } yield stored
+          }
+        } yield {
+          assertEquals(clue(stored.get("key-committed")), utf8("committed"))
+          assertEquals(clue(stored.get("key-dangling")), none[ByteVector])
+        }
+      }
+
+    test.unsafeRunSync()
   }
 
   test("an open transaction of a fenced writer neither blocks nor leaks into recovery") {

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModule.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModule.scala
@@ -18,8 +18,6 @@ import com.evolutiongaming.sstream.Stream
 import scodec.bits.ByteVector
 import com.evolutiongaming.skafka.consumer.ConsumerRecord
 
-import java.util.UUID
-
 /** A module, necessary to create a Kafka snapshot persistence.
   */
 trait KafkaPersistenceModule[F[_], S] {
@@ -43,8 +41,11 @@ object KafkaPersistenceModule {
     *   base config for the snapshot producer; `transactionalId` and `idempotence` are overridden per producer and
     *   `clientId` is suffixed with it
     * @param transactionalIdPrefix
-    *   prefix for `transactional.id` (partition number and a unique per-producer suffix are appended). Fencing is by
-    *   consumer generation, not this id, so it is just a readable label (e.g. a `"<groupId>-<inputTopic>"` string).
+    *   prefix for `transactional.id` (the partition number is appended - the id is stable per partition, so a
+    *   takeover's `initTransactions` fences the previous owner's producer and aborts any transaction it left open).
+    *   Fencing of stale writers stays with the consumer generation, but the takeover-abort makes a crashed owner's
+    *   leftovers not outlive the handover - so treat the prefix like a group id: unique per application on the cluster
+    *   (e.g. a `"<groupId>-<inputTopic>"` string), or applications fence each other's producers.
     * @param snapshotTopic
     *   snapshot topic name (should be configured as a 'compacted' topic) to read/write snapshots
     * @param inputTopic
@@ -215,9 +216,13 @@ object KafkaPersistenceModule {
     val inputTopicPartition = TopicPartition(inputTopic, partition)
 
     for {
-      // unique per producer: fencing is by consumer generation, not this id, so a fresh id per assignment is fine
-      shortId        <- Resource.eval(Async[F].delay(UUID.randomUUID().toString.take(8)))
-      transactionalId = s"$transactionalIdPrefix-${partition.value}-$shortId"
+      // stable per partition (the eos-v1 Kafka Streams model): this producer's initTransactions fences the
+      // previous owner's producer and aborts any transaction a hard-crashed owner left open, so its leftovers
+      // (an open transaction pinning the topic's last-stable-offset; pending transactional offsets blocking
+      // requireStable offset fetches) do not outlive the handover. Fencing of stale writers stays with the
+      // consumer generation bound into every commit, never with producer-epoch order (a late-initing stale
+      // owner can win the epoch; that inversion costs availability, not safety)
+      transactionalId <- Resource.pure[F, String](s"$transactionalIdPrefix-${partition.value}")
       transactionalProducerConfig = producerConfig.copy(
         transactionalId = transactionalId.some,
         idempotence     = true,

--- a/persistence-kafka/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModuleSpec.scala
+++ b/persistence-kafka/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModuleSpec.scala
@@ -1,0 +1,65 @@
+package com.evolutiongaming.kafka.flow.kafkapersistence
+
+import cats.effect.unsafe.implicits.global
+import cats.effect.{IO, Ref, Resource}
+import cats.syntax.all.*
+import com.evolutiongaming.catshelper.LogOf
+import com.evolutiongaming.skafka.consumer.{
+  Consumer as SkafkaConsumer,
+  ConsumerConfig,
+  ConsumerGroupMetadata,
+  ConsumerOf
+}
+import com.evolutiongaming.skafka.producer.{Producer, ProducerConfig, ProducerOf}
+import com.evolutiongaming.skafka.{CommonConfig, FromBytes, Offset, Partition}
+import munit.FunSuite
+
+/** The transactional module owns the producer settings that carry its design: the stable per-partition
+  * `transactional.id` (a takeover must abort a crashed owner's dangling transaction) and idempotence - applied over
+  * whatever `producerConfig` carries.
+  */
+class KafkaPersistenceModuleSpec extends FunSuite {
+
+  implicit val logOf: LogOf[IO] = LogOf.empty[IO]
+
+  test("the module applies the stable per-partition id, idempotence and the suffixed client id") {
+    val test = for {
+      captured <- Ref.of[IO, Option[ProducerConfig]](none)
+      producerOf = new ProducerOf[IO] {
+        def apply(config: ProducerConfig): Resource[IO, Producer[IO]] =
+          Resource.eval(captured.set(config.some)).as(Producer.empty[IO])
+      }
+      // recovery reads lazily (keysOf.all); module acquisition itself must not open a consumer
+      consumerOf = new ConsumerOf[IO] {
+        def apply[K, V](
+          config: ConsumerConfig
+        )(implicit fromBytesK: FromBytes[IO, K], fromBytesV: FromBytes[IO, V]) =
+          Resource.eval(
+            IO.raiseError[SkafkaConsumer[IO, K, V]](new IllegalStateException("consumer opened at acquisition"))
+          )
+      }
+      config = KafkaPersistenceModule.TransactionalConfig(
+        consumerConfig        = ConsumerConfig(),
+        producerConfig        = ProducerConfig(common = CommonConfig(clientId = "client".some)),
+        transactionalIdPrefix = "app",
+        snapshotTopic         = "state-topic",
+        inputTopic            = "input-topic",
+      )
+      assignment = KafkaPersistenceModule.PartitionAssignment[IO](
+        partition     = Partition.min,
+        assignedAt    = Offset.min,
+        groupMetadata = IO.pure(none[ConsumerGroupMetadata]),
+      )
+      _ <- KafkaPersistenceModule
+        .cachingTransactional[IO, String](consumerOf, producerOf, config, assignment)
+        .use_
+      config <- captured.get
+    } yield {
+      val produced = config.getOrElse(fail("no producer was created at module acquisition"))
+      assertEquals(produced.transactionalId, "app-0".some)
+      assertEquals(produced.idempotence, true)
+      assertEquals(produced.common.clientId, "client-snapshot-0".some)
+    }
+    test.unsafeRunSync()
+  }
+}


### PR DESCRIPTION
Fixes #850. Alternative to #852 — pick one.

### Problem

`readSnapshots` bounds the recovery read by the last stable offset, and with per-assignment `transactional.id`s (`{prefix}-{partition}-{uuid8}`) nothing aborts a hard-crashed writer's open transaction before its timeout. The open transaction pins the LSO below snapshots committed after it, so a recovery inside that window completes "successfully" while silently missing them — the #732 corruption shape on a double handover, with no fencing violated.

### Fix

Make the `transactional.id` stable per partition (`{prefix}-{partition}`) — the eos-v1 Kafka Streams model, affordable here because transactional mode already runs a producer per partition. Every owner of a partition shares its id, so the new owner's mandatory `initTransactions` aborts the predecessor's open transaction before it may write. That closes the under-read by construction: the partition's transactions are serialized, so a committed snapshot never sits above an open one and the existing read bound is complete — no wait, no second consumer. The same init resolves the crashed owner's pending transactional offsets, so the `requireStable` offset fetch is equally unaffected, and coordinator state becomes bounded by partition count instead of growing per assignment.

Fencing is untouched: stale-writer safety stays with the consumer generation bound into every commit (KIP-447), never producer-epoch order. The epoch fence only adds fail-fast — a wedged stale owner dies on `ProducerFencedException` at its next produce instead of at the offset-commit fence.

### Trade-off vs #852

Recovery after an ungraceful shutdown (e.g. a JVM crash) is immediate: the takeover abort clears the pin at module acquisition — sub-second in live testing, where per-assignment ids waited out the transaction timeout (6.8–12.5 s with a 5 s timeout; up to ~70 s at defaults). The cost is a naming discipline: `transactionalIdPrefix` must be unique per application on the cluster, like a group id (a PREFIXED ACL on it covers the per-partition suffixes) — otherwise applications fence each other's producers.

### Tests and docs

A new IT crashes an owner mid-transaction under the partition's own id with a deliberately long transaction timeout and asserts the LSO is back at the high watermark immediately after module acquisition — only the takeover abort can pass that, never the broker timeout — then that recovery returns the committed snapshot and excludes the dangling record. A new unit test pins the module-owned producer settings (stable id shape, idempotence, timeout). Docs updates are deferred until #854 is merged.