### PR TITLE
Refresh consumer group metadata on poll

### DIFF
--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/TopicFlow.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/TopicFlow.scala
@@ -116,6 +116,9 @@ object TopicFlow {
         val topicPartitions = partitions map (TopicPartition(topic, _))
         val removeOffsets   = pendingCommits.remove(topicPartitions)
 
+        // `cache.remove(_).flatten` awaits each flow's teardown before returning; this runs in the
+        // revoked/lost callbacks, before the next poll, so no flow survives for a partition the consumer
+        // no longer owns.
         removePartitions *> removeOffsets *> {
           Log[F].info(s"removed offsets without commit for: $topicPartitions")
         }

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/kafka/Consumer.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/kafka/Consumer.scala
@@ -24,8 +24,8 @@ trait Consumer[F[_]] {
 
   def commit(offsets: NonEmptyMap[TopicPartition, OffsetAndMetadata]): F[Unit]
 
-  /** Last consumer group metadata observed on a rebalance, used to fence a stale owner by generation when binding
-    * offset commits into a producer transaction (KIP-447). `None` until the consumer has joined a group.
+  /** Group metadata used to fence a stale owner by generation when binding offset commits into a producer transaction
+    * (KIP-447). `None` until the consumer has joined a group; never an unknown (negative) generation.
     */
   def groupMetadata: F[Option[ConsumerGroupMetadata]]
 
@@ -37,37 +37,38 @@ object Consumer {
   def of[F[_]: Sync](
     consumer: KafkaConsumer[F, String, ByteVector]
   ): F[Consumer[F]] =
-    // capture the group metadata on assignment (on the poll thread, where it is safe to read) into a Ref so the
-    // transactional snapshot writer can read the current generation off-thread; None until the first assignment
-    Ref[F].of(none[ConsumerGroupMetadata]).map { groupMetadataRef =>
-      new Consumer[F] {
-        def subscribe(topics: NonEmptySet[Topic], listener: RebalanceListener1[F]): F[Unit] = {
-          val capturing = new RebalanceListener1WithConsumer[F] {
-            import com.evolutiongaming.skafka.consumer.RebalanceCallback.syntax.*
-            // capture before the listener: assignment establishes the generation the listener (recovery, then every
-            // later flush) is gated by, and on a freshly assigned consumer groupMetadata cannot fail
-            private def capture: RebalanceCallback[F, Unit] =
-              this.consumer.groupMetadata.flatMap(meta => groupMetadataRef.set(meta.some).lift)
-            def onPartitionsAssigned(partitions: NonEmptySet[TopicPartition]): RebalanceCallback[F, Unit] =
-              capture *> listener.onPartitionsAssigned(partitions)
-            // revoke/lost just delegate: the generation is unchanged until the next assignment (which re-captures), and
-            // a capture failure here could suppress the wrapped listener's flush/commit-on-revoke
-            def onPartitionsRevoked(partitions: NonEmptySet[TopicPartition]): RebalanceCallback[F, Unit] =
-              listener.onPartitionsRevoked(partitions)
-            def onPartitionsLost(partitions: NonEmptySet[TopicPartition]): RebalanceCallback[F, Unit] =
-              listener.onPartitionsLost(partitions)
-          }
-          consumer.subscribe(topics, capturing)
-        }
+    for {
+      groupMetadataRef <- Ref[F].of(none[ConsumerGroupMetadata])
+    } yield new Consumer[F] {
+      def subscribe(topics: NonEmptySet[Topic], listener: RebalanceListener1[F]): F[Unit] =
+        consumer.subscribe(topics, listener)
 
-        def poll(timeout: FiniteDuration): F[ConsumerRecords[String, ByteVector]] =
-          consumer.poll(timeout)
+      def poll(timeout: FiniteDuration): F[ConsumerRecords[String, ByteVector]] =
+        consumer.poll(timeout) <* refresh
 
-        def commit(offsets: NonEmptyMap[TopicPartition, OffsetAndMetadata]): F[Unit] =
-          consumer.commit(offsets)
+      // read the generation after every poll, not from a rebalance callback: a bump that assigns this member
+      // nothing new fires no callback at all under the consumer protocol (KIP-848), and under the classic
+      // cooperative assignor an empty one the typed listener drops (skafka#581), so only a read tracks it.
+      // The join round may span polls (KIP-266: poll(Duration) does not block on it), so the read converges
+      // on the poll after the round completes; the interim lag only self-fences. Revoked partitions were torn
+      // down inside the poll under the pre-rebalance generation, so every flow still alive is owned in the
+      // one just read. A failed read fails the poll itself; its records are uncommitted and simply re-polled.
+      private def refresh: F[Unit] =
+        consumer.groupMetadata.flatMap(publish)
 
-        def groupMetadata: F[Option[ConsumerGroupMetadata]] = groupMetadataRef.get
-      }
+      // never publish an unknown (negative) generation: paired with an empty member id it is indistinguishable
+      // from a pre-KIP-447 client's wire defaults, for which the coordinator SKIPS generation validation - a
+      // commit carrying it would land unfenced. The unknown value itself is just the client's not-yet-joined
+      // initial state, reported only before the first join; after falling out of the group the client keeps
+      // the last joined generation, so a fallen-out owner stays gated by the generation it held.
+      private def publish(meta: ConsumerGroupMetadata): F[Unit] =
+        groupMetadataRef.set(meta.some).whenA(meta.generationId >= 0)
+
+      def commit(offsets: NonEmptyMap[TopicPartition, OffsetAndMetadata]): F[Unit] =
+        consumer.commit(offsets)
+
+      def groupMetadata: F[Option[ConsumerGroupMetadata]] =
+        groupMetadataRef.get
     }
 
   /** Does not call Kafka, returns specified records on every poll */

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/TopicFlowSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/TopicFlowSpec.scala
@@ -1,8 +1,9 @@
 package com.evolutiongaming.kafka.flow
 
 import cats.data.{NonEmptyMap, NonEmptySet}
+import cats.effect.testkit.TestControl
 import cats.effect.unsafe.implicits.global
-import cats.effect.{IO, Ref, Resource}
+import cats.effect.{Deferred, IO, Ref, Resource}
 import cats.syntax.all.*
 import com.evolutiongaming.catshelper.{LogOf, Runtime}
 import com.evolutiongaming.kafka.flow.kafka.{Consumer, ScheduleCommit}
@@ -11,37 +12,39 @@ import com.evolutiongaming.skafka.consumer.{ConsumerGroupMetadata, ConsumerRecor
 import munit.FunSuite
 import scodec.bits.ByteVector
 
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration.*
 
 class TopicFlowSpec extends FunSuite {
 
   private implicit val logOf: LogOf[IO]     = LogOf.empty[IO]
   private implicit val runtime: Runtime[IO] = Runtime.lift[IO]
 
-  test("add threads the driving consumer's group metadata into the partition flow") {
+  test("add threads the driving consumer's group metadata into the partition flow as a live reader") {
     val topic     = "topic"
     val partition = Partition.min
     val offset    = Offset.min
-    val generation =
+    val generation1 =
       ConsumerGroupMetadata(groupId = "group", generationId = 42, memberId = "member", groupInstanceId = none)
-
-    // a consumer whose generation is a distinctive sentinel, so we can tell it apart from a `pure(none)` regression
-    val consumer = new Consumer[IO] {
-      def subscribe(topics: NonEmptySet[Topic], listener: RebalanceListener1[IO]): IO[Unit] = IO.unit
-      def poll(timeout: FiniteDuration): IO[ConsumerRecords[String, ByteVector]]    = ConsumerRecords.empty.pure[IO]
-      def commit(offsets: NonEmptyMap[TopicPartition, OffsetAndMetadata]): IO[Unit] = IO.unit
-      def groupMetadata: IO[Option[ConsumerGroupMetadata]]                          = generation.some.pure[IO]
-    }
+    val generation2 = generation1.copy(generationId = 43)
 
     val test = for {
-      captured <- Ref.of[IO, Option[ConsumerGroupMetadata]](none)
+      underlying <- Ref.of[IO, Option[ConsumerGroupMetadata]](generation1.some)
+      consumer = new Consumer[IO] {
+        def subscribe(topics: NonEmptySet[Topic], listener: RebalanceListener1[IO]): IO[Unit] = IO.unit
+        def poll(timeout: FiniteDuration): IO[ConsumerRecords[String, ByteVector]]    = ConsumerRecords.empty.pure[IO]
+        def commit(offsets: NonEmptyMap[TopicPartition, OffsetAndMetadata]): IO[Unit] = IO.unit
+        def groupMetadata: IO[Option[ConsumerGroupMetadata]]                          = underlying.get
+      }
+      // capture the reader itself, not its result: PartitionAssignment requires it be passed along unevaluated,
+      // so a later evaluation must observe a generation bump - a memoized (evaluate-once) regression fails here
+      captured <- Ref.of[IO, Option[IO[Option[ConsumerGroupMetadata]]]](none)
       partitionFlowOf = new PartitionFlowOf[IO] {
         def apply(
           assignment: PartitionAssignment[IO],
           scheduleCommit: ScheduleCommit[IO]
         ): Resource[IO, PartitionFlow[IO]] =
           Resource
-            .eval(assignment.groupMetadata.flatMap(captured.set))
+            .eval(captured.set(assignment.groupMetadata.some))
             .as(
               new PartitionFlow[IO] {
                 def apply(records: List[ConsumerRecord[String, ByteVector]]): IO[Unit] = IO.unit
@@ -49,10 +52,73 @@ class TopicFlowSpec extends FunSuite {
             )
       }
       result <- TopicFlow.of(consumer, topic, partitionFlowOf).use { topicFlow =>
-        topicFlow.add(NonEmptySet.of(partition -> offset)) *> captured.get
+        for {
+          _      <- topicFlow.add(NonEmptySet.of(partition -> offset))
+          reader <- captured.get.flatMap(IO.fromOption(_)(new NoSuchElementException("reader not captured")))
+          first  <- reader
+          _      <- underlying.set(generation2.some)
+          second <- reader
+        } yield (first, second)
       }
-    } yield assertEquals(result, generation.some)
+    } yield {
+      assertEquals(result._1, generation1.some)
+      assertEquals(result._2, generation2.some, "the reader must be live: a memoized value would miss the bump")
+    }
 
     test.unsafeRunSync()
+  }
+
+  test("remove awaits the flow teardown (no flow survives a revoke)") {
+    // `remove` must await each partition flow's teardown (its Resource release) before returning, so no
+    // flow is still alive for a revoked partition when the consumer proceeds. The teardown is gated on a
+    // latch: `remove` must not return while the latch is closed. Checking the Deferred after `remove`
+    // alone would not do - the cache starts the release on its own fiber, so a fire-and-forget `remove`
+    // still sees the teardown finished almost always. Under TestControl virtual time advances only when
+    // no fiber can make progress, so the sleep winning the race proves `remove` was blocked on the
+    // teardown (not merely slow), and a fire-and-forget teardown fails deterministically.
+    val topic     = "topic"
+    val partition = Partition.min
+    val offset    = Offset.min
+
+    val consumer = new Consumer[IO] {
+      def subscribe(topics: NonEmptySet[Topic], listener: RebalanceListener1[IO]): IO[Unit] = IO.unit
+      def poll(timeout: FiniteDuration): IO[ConsumerRecords[String, ByteVector]]    = ConsumerRecords.empty.pure[IO]
+      def commit(offsets: NonEmptyMap[TopicPartition, OffsetAndMetadata]): IO[Unit] = IO.unit
+      def groupMetadata: IO[Option[ConsumerGroupMetadata]] = none[ConsumerGroupMetadata].pure[IO]
+    }
+
+    val program = for {
+      gate     <- Deferred[IO, Unit]
+      released <- Deferred[IO, Unit]
+      partitionFlowOf = new PartitionFlowOf[IO] {
+        def apply(
+          assignment: PartitionAssignment[IO],
+          scheduleCommit: ScheduleCommit[IO]
+        ): Resource[IO, PartitionFlow[IO]] =
+          Resource
+            .onFinalize(gate.get *> released.complete(()).void)
+            .as(new PartitionFlow[IO] {
+              def apply(records: List[ConsumerRecord[String, ByteVector]]): IO[Unit] = IO.unit
+            })
+      }
+      result <- TopicFlow.of(consumer, topic, partitionFlowOf).use { topicFlow =>
+        for {
+          _            <- topicFlow.add(NonEmptySet.of(partition -> offset))
+          liveAfterAdd <- released.tryGet // flow is alive: its teardown has not run yet
+          removing     <- topicFlow.remove(NonEmptySet.of(partition)).start
+          // the teardown is blocked on the closed gate, so `remove` must still be running
+          stillRemoving <- IO.race(removing.joinWithNever, IO.sleep(1.hour)).map(_.isRight)
+          _             <- gate.complete(())
+          _             <- removing.joinWithNever
+          downAfterRm   <- released.tryGet
+        } yield (liveAfterAdd, stillRemoving, downAfterRm)
+      }
+    } yield {
+      assertEquals(result._1, none[Unit], "the flow must still be alive after add (teardown not yet run)")
+      assert(result._2, "remove must not return while the teardown has not finished")
+      assertEquals(result._3, ().some, "the teardown must have run by the time remove returned")
+    }
+
+    TestControl.executeEmbed(program).unsafeRunSync()
   }
 }

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/kafka/ConsumerSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/kafka/ConsumerSpec.scala
@@ -1,0 +1,153 @@
+package com.evolutiongaming.kafka.flow.kafka
+
+import cats.data.{NonEmptyMap, NonEmptySet}
+import cats.effect.unsafe.implicits.global
+import cats.effect.{IO, Ref}
+import cats.syntax.all.*
+import com.evolutiongaming.skafka.*
+import com.evolutiongaming.skafka.consumer.{Consumer as SkafkaConsumer, ConsumerGroupMetadata, RebalanceListener1}
+import munit.FunSuite
+import scodec.bits.ByteVector
+
+import java.util.regex.Pattern
+import scala.concurrent.duration.*
+
+class ConsumerSpec extends FunSuite {
+
+  // the pre-join unknown: negative generation, no member identity (the shape the publish guard must drop)
+  private val unknown =
+    ConsumerGroupMetadata(groupId = "group", generationId = -1, memberId = "", groupInstanceId = none)
+
+  private def joined(generationId: Int) =
+    ConsumerGroupMetadata(groupId = "group", generationId = generationId, memberId = "member", groupInstanceId = none)
+
+  test("groupMetadata is None until a poll observes a joined generation") {
+    val test = for {
+      underlying <- Ref.of[IO, ConsumerGroupMetadata](unknown)
+      consumer   <- Consumer.of[IO](kafkaConsumer(underlying))
+      initial    <- consumer.groupMetadata
+      _          <- consumer.poll(1.millis)
+      preJoin    <- consumer.groupMetadata
+      _          <- underlying.set(joined(1))
+      beforePoll <- consumer.groupMetadata
+      _          <- consumer.poll(1.millis)
+      afterPoll  <- consumer.groupMetadata
+    } yield {
+      assertEquals(initial, none[ConsumerGroupMetadata], "no metadata before any poll")
+      assertEquals(preJoin, none[ConsumerGroupMetadata], "the pre-join unknown generation must not be published")
+      assertEquals(beforePoll, none[ConsumerGroupMetadata], "the value is read after a poll, not live")
+      assertEquals(afterPoll, joined(1).some, "the poll after the join publishes the joined generation")
+    }
+    test.unsafeRunSync()
+  }
+
+  test("the refresh follows a generation bump that fires no callback") {
+    val test = for {
+      underlying <- Ref.of[IO, ConsumerGroupMetadata](joined(1))
+      consumer   <- Consumer.of[IO](kafkaConsumer(underlying))
+      _          <- consumer.poll(1.millis)
+      // the silent bump: the generation advances with no rebalance callback anywhere in sight
+      _     <- underlying.set(joined(2))
+      _     <- consumer.poll(1.millis)
+      after <- consumer.groupMetadata
+    } yield assertEquals(after, joined(2).some, "the post-poll read must observe the bump")
+    test.unsafeRunSync()
+  }
+
+  test("a negative generation is dropped, keeping the last joined one") {
+    val test = for {
+      underlying <- Ref.of[IO, ConsumerGroupMetadata](joined(3))
+      consumer   <- Consumer.of[IO](kafkaConsumer(underlying))
+      _          <- consumer.poll(1.millis)
+      _          <- underlying.set(unknown)
+      _          <- consumer.poll(1.millis)
+      after      <- consumer.groupMetadata
+    } yield assertEquals(after, joined(3).some, "a negative generation must not overwrite the last joined one")
+    test.unsafeRunSync()
+  }
+
+  test("the refresh reads after the poll, not before: a join completing inside poll is visible right after it") {
+    // pins the `poll <* refresh` order. The underlying metadata advances INSIDE poll (as a completing join
+    // does, on the poll thread) and must be visible immediately after that same poll - a pre-poll read
+    // (`refresh *> poll`) would still see the pre-join state and, on the first join, leave None published
+    val test = for {
+      underlying <- Ref.of[IO, ConsumerGroupMetadata](unknown)
+      consumer   <- Consumer.of[IO](kafkaConsumer(underlying, onPoll = underlying.set(joined(7))))
+      after      <- consumer.poll(1.millis) *> consumer.groupMetadata
+    } yield assertEquals(after, joined(7).some, "the read must follow the poll that completed the join")
+    test.unsafeRunSync()
+  }
+
+  test("generation 0 is published: the guard is a range check (>= 0), not a -1 test") {
+    // 0 is never a live classic generation, but it is inside the guarded range: the coordinator's
+    // compatibility skip fires only on negatives, so 0 reaches real validation and only self-fences
+    val test = for {
+      underlying <- Ref.of[IO, ConsumerGroupMetadata](joined(0))
+      consumer   <- Consumer.of[IO](kafkaConsumer(underlying))
+      _          <- consumer.poll(1.millis)
+      after      <- consumer.groupMetadata
+    } yield assertEquals(after, joined(0).some)
+    test.unsafeRunSync()
+  }
+
+  // only poll and groupMetadata matter to Consumer.of; everything else delegates to the empty consumer.
+  // `onPoll` runs inside poll, to simulate state (a join) advancing on the poll itself
+  private def kafkaConsumer(
+    meta: Ref[IO, ConsumerGroupMetadata],
+    onPoll: IO[Unit] = IO.unit,
+  ): SkafkaConsumer[IO, String, ByteVector] =
+    new SkafkaConsumer[IO, String, ByteVector] {
+      private val delegate = SkafkaConsumer.empty[IO, String, ByteVector]
+
+      def groupMetadata = meta.get
+
+      def assign(partitions: NonEmptySet[TopicPartition])                         = delegate.assign(partitions)
+      def assignment                                                              = delegate.assignment
+      def subscribe(topics: NonEmptySet[Topic], listener: RebalanceListener1[IO]) = delegate.subscribe(topics, listener)
+      def subscribe(topics: NonEmptySet[Topic])                                   = delegate.subscribe(topics)
+      def subscribe(pattern: Pattern, listener: RebalanceListener1[IO])   = delegate.subscribe(pattern, listener)
+      def subscribe(pattern: Pattern)                                     = delegate.subscribe(pattern)
+      def subscription                                                    = delegate.subscription
+      def unsubscribe                                                     = delegate.unsubscribe
+      def poll(timeout: FiniteDuration)                                   = onPoll *> delegate.poll(timeout)
+      def commit                                                          = delegate.commit
+      def commit(timeout: FiniteDuration)                                 = delegate.commit(timeout)
+      def commit(offsets: NonEmptyMap[TopicPartition, OffsetAndMetadata]) = delegate.commit(offsets)
+      def commit(offsets: NonEmptyMap[TopicPartition, OffsetAndMetadata], timeout: FiniteDuration) =
+        delegate.commit(offsets, timeout)
+      def commitLater                                                          = delegate.commitLater
+      def commitLater(offsets: NonEmptyMap[TopicPartition, OffsetAndMetadata]) = delegate.commitLater(offsets)
+      def seek(partition: TopicPartition, offset: Offset)                      = delegate.seek(partition, offset)
+      def seek(partition: TopicPartition, offsetAndMetadata: OffsetAndMetadata) =
+        delegate.seek(partition, offsetAndMetadata)
+      def seekToBeginning(partitions: NonEmptySet[TopicPartition])     = delegate.seekToBeginning(partitions)
+      def seekToEnd(partitions: NonEmptySet[TopicPartition])           = delegate.seekToEnd(partitions)
+      def position(partition: TopicPartition)                          = delegate.position(partition)
+      def position(partition: TopicPartition, timeout: FiniteDuration) = delegate.position(partition, timeout)
+      def committed(partitions: NonEmptySet[TopicPartition])           = delegate.committed(partitions)
+      def committed(partitions: NonEmptySet[TopicPartition], timeout: FiniteDuration) =
+        delegate.committed(partitions, timeout)
+      def clientInstanceId(timeout: FiniteDuration)         = delegate.clientInstanceId(timeout)
+      def clientMetrics                                     = delegate.clientMetrics
+      def partitions(topic: Topic)                          = delegate.partitions(topic)
+      def partitions(topic: Topic, timeout: FiniteDuration) = delegate.partitions(topic, timeout)
+      def topics                                            = delegate.topics
+      def topics(timeout: FiniteDuration)                   = delegate.topics(timeout)
+      def paused                                            = delegate.paused
+      def pause(partitions: NonEmptySet[TopicPartition])    = delegate.pause(partitions)
+      def resume(partitions: NonEmptySet[TopicPartition])   = delegate.resume(partitions)
+      def offsetsForTimes(timestampsToSearch: Map[TopicPartition, Offset]) =
+        delegate.offsetsForTimes(timestampsToSearch)
+      def offsetsForTimes(timestampsToSearch: Map[TopicPartition, Offset], timeout: FiniteDuration) =
+        delegate.offsetsForTimes(timestampsToSearch, timeout)
+      def beginningOffsets(partitions: NonEmptySet[TopicPartition]) = delegate.beginningOffsets(partitions)
+      def beginningOffsets(partitions: NonEmptySet[TopicPartition], timeout: FiniteDuration) =
+        delegate.beginningOffsets(partitions, timeout)
+      def endOffsets(partitions: NonEmptySet[TopicPartition]) = delegate.endOffsets(partitions)
+      def endOffsets(partitions: NonEmptySet[TopicPartition], timeout: FiniteDuration) =
+        delegate.endOffsets(partitions, timeout)
+      def currentLag(partition: TopicPartition) = delegate.currentLag(partition)
+      def enforceRebalance                      = delegate.enforceRebalance
+      def wakeup                                = delegate.wakeup
+    }
+}

--- a/docs/kafka-single-writer-design.md
+++ b/docs/kafka-single-writer-design.md
@@ -45,8 +45,7 @@ transaction** via
 the group coordinator validates the consumer **generation** and rejects a commit from a stale one
 (`ILLEGAL_GENERATION`, surfaced to the client as `CommitFailedException`).
 Since that commit and the snapshot writes share a transaction, the rejection aborts the writes too.
-The generation — authoritative for partition ownership — gates both, so a stale owner can neither
-advance offsets nor overwrite a newer snapshot.
+The generation gates both, so a stale owner can neither advance offsets nor overwrite a newer snapshot.
 
 Seen as a whole, the mechanism combines two ideas — a distributed lock, and a transactional snapshot
 write + offset commit. Kafka's consumer group is the lock, and it already provides both an ownership
@@ -97,28 +96,81 @@ Key points:
   the call itself drives the transaction and blocks on its outcome. That blocking is what lets a fence
   (`CommitFailedException`) propagate into the flow and crash a stale owner, rather than being lost on a
   fire-and-forget commit thread.
+- The fence is per **member + generation**, not per partition: the coordinator checks the committer's
+  generation, not which partitions it still owns, so a member still on the current generation cannot be
+  stopped from committing a partition it just lost. That is closed client-side: a revoked partition's
+  flows are torn down inside the synchronous revoke callback, and the broker does not reassign the
+  partition until that callback returns — so no new owner exists while a flow for the partition is
+  still alive. The one way out is eviction (teardown stalling past the rebalance timeout), which only
+  swaps the net: an evicted member's commits fail member validation (`UNKNOWN_MEMBER_ID`, the same
+  abortable `CommitFailedException`).
 
 The mechanism needs the input topic-partition and a reader of the driving consumer's group metadata
-(`Consumer.groupMetadata`, captured on each partition assignment on the poll thread). Both are supplied by
-the flow from the partition assignment — not configured by hand — so they always match the consumer that
-drives the flow. A fence surfaces as `CommitFailedException` on the failing snapshot write (or offset-only
+(`Consumer.groupMetadata`, refreshed after every poll on the poll thread). Both are supplied by the flow
+from the partition assignment — not configured by hand — so they always match the consumer that drives
+the flow. A fence surfaces as `CommitFailedException` on the failing snapshot write (or offset-only
 commit).
+
+A generation captured once at assignment would miss a routine case: a rebalance can advance the
+generation while leaving this member's partitions unchanged. The capture would go stale, and the
+retained partition's next transactional commit would be spuriously fenced though the member still owns
+it — crashing a still-valid owner: safe (a fenced commit writes nothing), but not stable. Refreshing
+after every poll avoids it: a post-poll read follows the silent bump a rebalance callback does not.
+The unknown (negative) pre-join generation is never published — the coordinator *skips* generation
+validation for a commit carrying it, so it would land unfenced; a flush before the first join instead
+fails loudly rather than committing ungated.
 
 ### No epoch fencing
 
 Generation fencing is the sole mechanism; there is deliberately no producer-epoch fencing. Each
 producer gets a unique `transactional.id` (`"{prefix}-{partition}-{uuid8}"`), so old and new owners
-never share one. A *stable* per-partition id would add cross-owner epoch fencing, which is both
-redundant and harmful: with a shared id each `initTransactions` bumps the epoch and fences the
-previous holder, so whichever owner inits *latest* wins — a race unrelated to who actually owns the
-partition. A slow stale owner that inits late therefore wins the epoch, its stale write lands (the
-fence fails), and the true owner is fenced instead.
+never share one. A *stable* per-partition id would add cross-owner epoch fencing: with a shared id
+each `initTransactions` bumps the epoch and fences the previous holder. That is redundant here — a
+stale owner's write is already rejected by the generation fence — and the epoch order can diverge from
+ownership order (whichever owner inits *latest* wins), spuriously fencing the true owner: a crash of a
+valid owner, never a stale write landing.
 
 The cost of unique ids — transaction-coordinator state expiring via `transactional.id.expiration.ms` —
-is accepted. A hard-crashed owner's in-flight transaction is, for the same reason, not fenced on the
-spot (a stable id would abort it through the new owner's `initTransactions`); the coordinator reclaims
-it only after `transaction.timeout.ms`, which bounds how long a `read_committed` reader (recovery, or a
-downstream consumer) can stall behind its last-stable-offset.
+is accepted. A hard-crashed owner's in-flight transaction is, for the same reason, not aborted at
+takeover (a stable id would abort it through the new owner's `initTransactions`); the coordinator
+reclaims it only after `transaction.timeout.ms`, which bounds how long it pins the snapshot topic's
+last-stable-offset — the offset `read_committed` readers of that topic (recovery included) cannot
+see past.
+
+## Consumer rebalance protocols
+
+The per-member fencing token is the **generation** under the classic protocol and the **member epoch**
+under the consumer protocol
+([KIP-848](https://cwiki.apache.org/confluence/display/KAFKA/KIP-848%3A+The+Next+Generation+of+the+Consumer+Rebalance+Protocol),
+GA in Kafka 4.0, selected by `group.protocol=consumer`); they play the same role, and *generation* below
+stands for both. The fence holds under both protocols and surfaces identically — a stale transactional
+commit is rejected as `ILLEGAL_GENERATION` under each (the coordinator maps the consumer protocol's
+internal stale-epoch error to the same wire error). The post-poll read (above) is what makes the
+tracking hold too: the bump that matters — one that changes nothing in this member's assignment — fires
+no callback at all under the consumer protocol (the epoch advances on the background heartbeat thread)
+and, under the classic **cooperative** assignor, only an empty-delta `onPartitionsAssigned` that the
+typed listener drops ([skafka#581](https://github.com/evolution-gaming/skafka/issues/581)); only the
+classic **eager** assignor — which revokes and reassigns the full set on every rebalance — fires a
+callback that could be acted on.
+
+What the read cannot close is a residual window in which a still-valid owner is spuriously fenced — a
+liveness cost, never a safety one (a lagging token only fences). Under the classic protocol the window
+is the in-flight join round: a round can span polls
+([KIP-266](https://cwiki.apache.org/confluence/display/KAFKA/KIP-266%3A+Fix+consumer+indefinite+blocking+behavior)),
+and a flush of a retained partition
+between the broker-side bump and this member completing the round still carries the previous
+generation. Under the consumer protocol the epoch also advances *between* polls, so even a fresh
+post-poll read can be stale by the time the commit reaches the broker.
+[KIP-1251](https://cwiki.apache.org/confluence/display/KAFKA/KIP-1251%3A+Assignment+epochs+for+consumer+groups)
+(brokers 4.3.0+) absorbs the consumer-protocol window — the coordinator accepts a lagging commit for a
+partition the member still owns, and a reassigned one stays fenced — hence the broker recommendation
+for `group.protocol=consumer`; no broker version absorbs the classic in-flight-round window.
+
+The revoke-time flush is the one place the combinations differ in outcome. Classic **eager** revokes
+before the member rejoins, and the consumer protocol keeps the member on its epoch until it
+acknowledges the revocation — under both, the flush commits. Classic **cooperative** has already moved
+the member to the new generation by revoke time, so its flush is always fenced (safe; the new owner
+replays). A member evicted before the flush is rejected under all three — the same safe direction.
 
 ## Write path: group-committed transactions
 
@@ -153,8 +205,8 @@ Entry point: `KafkaPersistenceModuleOf.cachingTransactional`. In the current cod
   persistence-kafka `package` object). That bypasses the default path, where offsets are normally staged
   through `PendingCommits` and committed by `TopicFlow.commitPending` via `consumer.commit`; with nothing
   staged, it commits nothing (a no-op).
-- **Generation capture** on each partition assignment — the `Consumer` wrapper, holding `groupMetadata`
-  in a `Ref` read off the poll thread.
+- **Generation currency** — the `Consumer` wrapper holds `groupMetadata` in a `Ref`, refreshed after every
+  poll.
 
 ## Measurements
 
@@ -207,15 +259,17 @@ with an *older consumer generation* and asserts the newer snapshot survives — 
 binding as the cause, not incidental fencing. Other cases covered: first-flush gating (the seed), a
 fenced writer fails its next flush, an open transaction neither blocks nor leaks into recovery,
 concurrent-write safety. The group commit is exercised in isolation by `GroupCommitSpec`, a unit test
-with a recording in-memory producer (no broker).
+with a recording in-memory producer (no broker). Two unit suites pin the client-side pieces the fence
+depends on: `TopicFlowSpec` that removing a partition awaits its flows' teardown, and `ConsumerSpec`
+the post-poll generation tracking and the negative-generation guard.
 
 ## Rejected alternatives
 
 - **Transactional snapshot read + snapshot write**: fence a stale writer with a compare-and-set on the
   stored offset. Kafka has no conditional produce primitive, so it cannot be atomic.
-- **Producer-epoch fencing (stable `transactional.id`)**: epoch order can diverge from ownership
-  order, so it does not fully close [#732](https://github.com/evolution-gaming/kafka-flow/issues/732)
-  and can false-positive-fence the true owner (above).
+- **Producer-epoch fencing (stable `transactional.id`)**: redundant with the generation fence, and
+  the epoch order can diverge from ownership order, spuriously fencing the true owner (see No epoch
+  fencing).
 - **Static partition assignment** (`assign()` instead of `subscribe()`): no consumer group, so no
   rebalance, no overlap window, no fence needed — but it gives up automatic failover and elastic
   reassignment, and safe *dynamic* assignment is the point of this design. (Static *membership*
@@ -226,6 +280,9 @@ with a recording in-memory producer (no broker).
 - **Unbounded batches**: ~7% faster, but transaction duration scales unbounded against the coordinator
   timeout.
 - **Transactional output produces (full exactly-once)**: out of scope; output stays at-least-once.
+- **Capturing the generation in a rebalance callback** (instead of the post-poll read): the bump that
+  matters fires no callback under two of the three protocol/assignor combinations (see Consumer
+  rebalance protocols).
 
 ## Forward-looking
 

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -100,8 +100,8 @@ discriminator (e.g. the input topic) — an `"<applicationId>*"` prefixed ACL st
 
 Snapshot writes and the input-offset commit run in one Kafka transaction per assigned partition; a
 write from a stale consumer generation is fenced by the broker
-([KIP-447](https://cwiki.apache.org/confluence/display/KAFKA/KIP-447%3A+Producer+scalability+for+exactly+once+semantics))
-and surfaces as
+([KIP-447](https://cwiki.apache.org/confluence/display/KAFKA/KIP-447%3A+Producer+scalability+for+exactly+once+semantics),
+brokers 2.5+) and surfaces as
 `CommitFailedException`. Recovery reads `read_committed`, so a fenced writer's aborted records are
 never recovered.
 
@@ -113,7 +113,7 @@ never recovered.
 - **Tuning for transaction time** — a transaction must commit within `transaction.timeout.ms` (a
   producer config, default 1 min, ≤ the broker's `transaction.max.timeout.ms`). Large snapshots lengthen
   it with the batch — lower `maxWritesPerTransaction` (at a throughput cost) or raise the timeout. A
-  higher timeout lengthens the post-crash stall (below).
+  higher timeout widens the post-crash window (below).
 - **Output is at-least-once** — output produces stay outside the snapshot transaction, so a replayed
   batch re-emits them; the consuming side must tolerate duplicates. Only the snapshot store and the
   input-offset commit are kept consistent (corruption prevention, not exactly-once).
@@ -125,12 +125,21 @@ never recovered.
 Limitations:
 - A batch shares its transaction's outcome: if the transaction fails, every write in it fails.
 - An old owner can be fenced while flushing on revoke; its last state delta is then neither persisted
-  nor committed, so the new owner replays those events — noise, not loss.
+  nor committed, so the new owner replays those events — noise, not loss. Under the classic
+  **cooperative** assignor this is every revocation: the revoke-time flush is always fenced, so
+  `flushOnRevoke` does not shrink the replay window there.
 - After a hard crash, the broker reclaims the failed owner's in-flight transaction only after
-  `transaction.timeout.ms`; until then a `read_committed` reader — recovery of that partition, or a
-  downstream consumer of your output — can stall behind its last-stable-offset.
+  `transaction.timeout.ms`; until then that open transaction pins the snapshot topic's
+  last-stable-offset, and a recovery in that window silently misses records beyond it — even committed
+  ones — while input offsets are not held back the same way, so a second handover inside the window
+  can recover stale state
+  ([kafka-flow#850](https://github.com/evolution-gaming/kafka-flow/issues/850)).
 - The mode always uses the identity `KafkaPersistencePartitionMapper` (fencing is per input partition);
   a non-identity mapper is not supported here.
+- The fence works under both the **classic** and the **consumer** group protocols
+  (`group.protocol=classic|consumer`). With `consumer`, use **brokers 4.3.0+** — below that a still-valid
+  owner can be spuriously fenced during a rebalance and crash; the restart converges, but any later
+  rebalance can fence again (safe, never corruption, but not stable).
 
 ### Custom snapshot storage
 

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModule.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModule.scala
@@ -41,7 +41,7 @@ object KafkaPersistenceModule {
     *   config for the snapshot-reading consumer; recovery forces `read_committed` regardless of this value
     * @param producerConfig
     *   base config for the snapshot producer; `transactionalId` and `idempotence` are overridden per producer and
-    *   `clientId` is suffixed with it
+    *   `clientId` is suffixed with `-snapshot-<partition>`
     * @param transactionalIdPrefix
     *   prefix for `transactional.id` (partition number and a unique per-producer suffix are appended). It does not
     *   affect fencing (that is by consumer generation), so its only roles are a readable label and, on an ACL-secured

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaSnapshotWriteDatabase.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaSnapshotWriteDatabase.scala
@@ -38,7 +38,8 @@ object KafkaSnapshotWriteDatabase {
     *
     * @param groupMetadata
     *   current consumer group metadata (generation); see `Consumer.groupMetadata`. `None` (consumer not yet joined) is
-    *   unreachable on the flow path and fails loudly rather than committing ungated.
+    *   reachable only by a teardown flush racing the join poll's refresh; it fails loudly rather than committing
+    *   ungated.
     * @param assignedOffset
     *   seeds the offset-to-commit so even the first write is gated; committing it is a no-op.
     * @param maxWritesPerTransaction
@@ -168,8 +169,8 @@ object KafkaSnapshotWriteDatabase {
           case Some(meta) =>
             producer.sendOffsetsToTransaction(NonEmptyMap.of(inputTopicPartition -> OffsetAndMetadata(offset)), meta)
           case None =>
-            // invariant: the consumer joins (capturing metadata) before any flush, so None is unreachable; fail loud
-            // rather than commit ungated
+            // the join poll's refresh publishes before any normal flush; None is reachable only by a teardown
+            // flush racing that refresh (its failure or cancellation) - fail loud rather than commit ungated
             new IllegalStateException(
               s"cannot bind input offset $offset: the driving consumer has not joined a group " +
                 "(group metadata is None); transactional snapshot mode requires the flow's own consumer"


### PR DESCRIPTION
**Stacked on (merge first):** #842

### Problem

A rebalance can bump the consumer generation while leaving this member's partitions unchanged, and no usable callback fires for that: none at all under KIP-848, and under the classic cooperative assignor only an empty delta the typed listener drops (evolution-gaming/skafka#581). The generation captured at assignment then goes stale, and the next transactional flush of a retained partition is spuriously fenced — safe, but not stable.

### Fix

Track the generation with a read after every poll instead of capturing it at assignment. The pre-join unknown (negative) generation is never published: the coordinator skips generation validation for it, so a commit carrying it would land unfenced.

### Tests and docs

New unit tests pin the post-poll tracking and the guard (`ConsumerSpec`) plus the teardown-await the fence relies on (`TopicFlowSpec`). Design doc and persistence docs updated.

### Found along the way

Scrutiny of this design (research conducted under #835) surfaced two recovery-read defects in the transactional mode as merged:

- #849
- #850

Candidate fixes: #851 for the hang, #852 and #853 as alternative remedies for the under-read. Deliberately kept out of this PR.