### PR TITLE
Recover transactional snapshots completely, with a bounded read

### DIFF
--- a/docs/kafka-single-writer-design.md
+++ b/docs/kafka-single-writer-design.md
@@ -11,11 +11,12 @@ Design notes for the transactional snapshot mode of `kafka-flow-persistence-kafk
 
 [kafka-flow#732](https://github.com/evolution-gaming/kafka-flow/issues/732): consumer-group
 ownership of the input topic does not extend to the snapshot topic. During a rebalance a previous
-owner that has not yet observed the revocation (network issue, GC pause, slow poll loop) keeps
-writing snapshots alongside the new owner — overlaps of tens of seconds have been observed in
-production. The snapshot topic is compacted (last-write-wins), so a stale snapshot can overwrite a
-newer one; the next recovery then loads stale state but resumes from the committed offset, so the
-events between the two snapshots are never re-folded — corrupting the state.
+owner that has not yet observed the revocation (a network issue, a GC pause, a slow poll loop —
+typical during broker maintenance or high-load restarts) keeps writing snapshots alongside the new
+owner — overlaps of tens of seconds have been observed in production. The snapshot topic is
+compacted (last-write-wins), so a stale snapshot can overwrite a newer one; the next recovery then
+loads stale state but resumes from the committed offset, so the events between the two snapshots
+are never re-folded — corrupting the state.
 
 ```mermaid
 sequenceDiagram
@@ -34,14 +35,23 @@ sequenceDiagram
     Note over ST,B: next recovery folds from 151<br/>onto stale @100 — corruption
 ```
 
-## Mechanism: generation fencing
+## Mechanism
+
+Two mechanisms carry the design: the generation fence stops a stale owner's write from landing, and
+the high-watermark-bounded recovery read keeps recovery complete where no fence is violated. The
+stable `transactional.id` keeps that read's ordinary wait sub-second, and the stall deadline bounds
+a wait that never resolves; the remaining sections trace the fence across rebalance protocols and
+detail the write path's group commit.
+
+### Generation fencing
 
 In the default (non-transactional) mode the input offsets are committed through the **Kafka consumer**
 (the ordinary consumer-group offset commit). In this mode they are committed through the snapshot
 **producer** instead, with the consumer-side commit disabled — the offset moves **into the producer's
 transaction** via
 `sendOffsetsToTransaction(offsets, consumerGroupMetadata)`
-([KIP-447](https://cwiki.apache.org/confluence/display/KAFKA/KIP-447%3A+Producer+scalability+for+exactly+once+semantics)):
+([KIP-447](https://cwiki.apache.org/confluence/display/KAFKA/KIP-447%3A+Producer+scalability+for+exactly+once+semantics),
+brokers 2.5+):
 the group coordinator validates the consumer **generation** and rejects a commit from a stale one
 (`ILLEGAL_GENERATION`, surfaced to the client as `CommitFailedException`).
 Since that commit and the snapshot writes share a transaction, the rejection aborts the writes too.
@@ -56,15 +66,15 @@ commit. Binding them in one transaction is the link.
 
 ```mermaid
 sequenceDiagram
-    participant B as Stale owner<br/>(old generation)
+    participant S as Stale owner<br/>(old generation)
     participant TC as Broker<br/>(txn + group coordinator)
     participant ST as Snapshot topic
 
-    B->>TC: beginTransaction
-    B->>ST: send stale snapshot (buffered in txn)
-    B->>TC: sendOffsetsToTransaction(offset, gen=old)
-    TC-->>B: ILLEGAL_GENERATION (partition reassigned)
-    B->>TC: abort — stale snapshot never committed
+    S->>TC: beginTransaction
+    S->>ST: send stale snapshot (buffered in txn)
+    S->>TC: sendOffsetsToTransaction(offset, gen=old)
+    TC-->>S: ILLEGAL_GENERATION (partition reassigned)
+    S->>TC: abort — stale snapshot never committed
     Note over ST: newer snapshot (new owner's) survives
 ```
 
@@ -80,13 +90,15 @@ Key points:
 
 - **Every** transaction commits the partition's current committable offset, so every write is gated. The
   offset itself advances only on the periodic offset-commit interval (`commitOffsetsInterval`, separate
-  from the snapshot-flush interval `persistEvery`) or on revoke; a snapshot write never advances it, it
-  just re-commits the current value to stay gated. That advance is committed in a transaction — batching
-  in any snapshot writes queued at that moment, or committing the offset alone (an *offset-only*
-  transaction) when there are none.
+  from the snapshot-flush interval `persistEvery`) or on revoke; a snapshot write never advances it —
+  the write just re-commits the current value to stay gated. That advance is committed in a
+  transaction — batching in any snapshot writes queued at that moment, or committing the offset
+  alone (an *offset-only* transaction) when there are none.
 - The offset-to-commit is **seeded with the assigned offset**, so even the first snapshot flush (before
   the first commit tick) carries an offset and is gated.
-- Recovery is forced to `read_committed` so a fenced writer's aborted records are invisible.
+- Recovery is forced to `read_committed` so a fenced writer's aborted records are invisible, and its
+  read targets the high watermark, so an open transaction on the snapshot topic delays the read
+  instead of silently under-reading (see Recovery read below).
 - The ordinary consumer-group offset commit is **replaced**, not run alongside. In the default mode the
   committable offset is staged and the **consumer** commits it; in this mode that same offset-scheduling
   step is rerouted to the **producer**, so the offset is committed only inside the transaction (above).
@@ -108,36 +120,123 @@ Key points:
 The mechanism needs the input topic-partition and a reader of the driving consumer's group metadata
 (`Consumer.groupMetadata`, refreshed after every poll on the poll thread). Both are supplied by the flow
 from the partition assignment — not configured by hand — so they always match the consumer that drives
-the flow. A fence surfaces as `CommitFailedException` on the failing snapshot write (or offset-only
-commit).
+the flow.
 
 A generation captured once at assignment would miss a routine case: a rebalance can advance the
 generation while leaving this member's partitions unchanged. The capture would go stale, and the
 retained partition's next transactional commit would be spuriously fenced though the member still owns
-it — crashing a still-valid owner: safe (a fenced commit writes nothing), but not stable. Refreshing
+it, crashing a still-valid owner — safe (a fenced commit writes nothing), but not stable. Refreshing
 after every poll avoids it: a post-poll read follows the silent bump a rebalance callback does not.
-The unknown (negative) pre-join generation is never published — the coordinator *skips* generation
-validation for a commit carrying it, so it would land unfenced; a flush before the first join instead
-fails loudly rather than committing ungated.
+The unknown (negative) pre-join generation is never published — for a commit carrying it against an
+empty group (exactly the pre-join case) the coordinator *skips* generation validation, so it would
+land unfenced; a flush before the first join instead fails loudly rather than committing ungated.
 
-### No epoch fencing
+### Recovery read: bounded by the high watermark
 
-Generation fencing is the sole mechanism; there is deliberately no producer-epoch fencing. Each
-producer gets a unique `transactional.id` (`"{prefix}-{partition}-{uuid8}"`), so old and new owners
-never share one. A *stable* per-partition id would add cross-owner epoch fencing: with a shared id
-each `initTransactions` bumps the epoch and fences the previous holder. That is redundant here — a
-stale owner's write is already rejected by the generation fence — and the epoch order can diverge from
-ownership order (whichever owner inits *latest* wins), spuriously fencing the true owner: a crash of a
-valid owner, never a stale write landing.
+An open transaction on the snapshot topic distorts what a `read_committed` reader may see: the
+consumer's own `endOffsets` is the **last-stable-offset** (LSO) — the minimum of the high watermark and
+the first offset of any open transaction — so a read bounded by it completes while silently missing
+committed snapshots above the pin. With a second handover inside the window the next owner recovers
+stale state yet resumes from the newer committed input offset — the corruption shape of
+[#732](https://github.com/evolution-gaming/kafka-flow/issues/732) with no fence violated.
 
-The cost of unique ids — transaction-coordinator state expiring via `transactional.id.expiration.ms` —
-is accepted. A hard-crashed owner's in-flight transaction is, for the same reason, not aborted at
-takeover (a stable id would abort it through the new owner's `initTransactions`); the coordinator
-reclaims it only after `transaction.timeout.ms`, which bounds how long it pins the snapshot topic's
-last-stable-offset — the offset `read_committed` readers of that topic (recovery included) cannot
-see past.
+So the read target is the **high watermark**, captured up front by a short-lived `read_uncommitted`
+consumer, whose `endOffsets` returns it rather than the last-stable-offset. The `read_committed`
+position cannot pass the LSO until the broker resolves the open transaction, so the read genuinely
+waits it out. Kafka Streams' exactly-once changelog restore settled on the same shape after its
+LSO-derived end offset was found to under-read ([KAFKA-10167](https://issues.apache.org/jira/browse/KAFKA-10167)).
 
-## Consumer rebalance protocols
+On the ordinary path the bound is free: the partition's own unfinished transactions are aborted at
+takeover by the shared `transactional.id`, before recovery reads (next section), so the captured
+target equals the LSO and the read never waits. It waits only for a transaction no takeover aborts —
+a previous `transactional.id` prefix's unfinished transactions while a prefix change rolls out, or
+a producer misdirected at the snapshot topic — and there, waiting is the only correct behavior,
+bounded by the *pinning* producer's `transaction.timeout.ms` plus the broker's abort scan
+(`transaction.abort.timed.out.transaction.cleanup.interval.ms`, default 10 s): ~70 s at Kafka's
+default timeout.
+
+### Stable transactional.id: the takeover aborts unfinished transactions
+
+Each partition's producer uses a **stable** `transactional.id`, `"<prefix>-<partition>"` — a scheme
+whose cost, a producer per partition, this mode pays anyway. Every owner of a partition shares its
+id, so a new owner's mandatory `initTransactions` fences the previous owner's producer and aborts
+any transaction it left open, before the new owner may write.
+
+Sharing the id serializes the partition's own writes: a committed snapshot never sits above an open
+transaction of the same id, so the recovery read's wait (previous section) never engages for the
+module's own transactions. Takeover after a hard crash is immediate — nothing waits for
+`transaction.timeout.ms`.
+
+The shared id is deliberately **not** the fence. Fencing of stale writers stays with the consumer
+generation bound into every commit, never with producer-epoch order, for two reasons. The epoch fence
+does not exist until the new owner's init: a stale flush racing ahead of it meets no epoch check at
+all, while the generation was already bumped when the rebalance completed — the takeover window is
+covered by the generation fence alone. And the epoch order can diverge from ownership order
+(whichever owner inits *latest* wins), so a late-initing stale owner can win the epoch and fence the
+partition's valid owner — one crash of a valid owner (availability, not safety); the stale
+owner's write still dies at the generation fence. What the stable id buys is only the takeover-abort above.
+
+The cost is a naming discipline: the prefix becomes cluster-scoped, like a group id — one prefix per
+flow, unique on the cluster, or colliding applications fence each other's producers, loudly; on an
+ACL-secured cluster the prefix is what the producer principal must be authorized for.
+`transaction.timeout.ms` remains only the backstop for unfinished transactions no takeover reaches —
+e.g. a stalled but live producer's — and skafka's default (1 min) is kept, since a group-committed
+batch typically commits in well under a second.
+
+The completeness of recovery does not depend on any naming assumption: the id discipline buys the sub-second
+common case; the read bound (previous section) holds regardless.
+
+### Stalled read: a deadline instead of a silent hang
+
+The recovery read waits by design: it keeps polling until its `read_committed` position reaches the
+captured high-watermark target (Recovery read, above). Two known Kafka failure modes can keep that
+position from ever reaching it. The first is **truncation**: the log end regresses below the captured
+target — a leader election lost acknowledged snapshot records — so the target is permanently
+unreachable. That regression takes an opted-in unclean election or a genuine disaster: rare, but no
+broker version or configuration removes the risk entirely — replication only sizes the disaster.
+With `min.insync.replicas` ≥ 2, an acknowledged snapshot (the transactional producer forces
+`acks=all`) sits on at least two replicas and survives any single broker failure; at the broker
+default of 1, the in-sync set may shrink to the leader alone and one lost disk suffices.
+Recomputing the target would unblock the read at the price of re-admitting the silent under-read
+the capture exists to prevent, so the target deliberately stays put.
+
+The second is a **hanging transaction**: an LSO pin that no timeout ever clears
+([KIP-664](https://cwiki.apache.org/confluence/display/KAFKA/KIP-664%3A+Provide+tooling+to+detect+and+abort+hanging+transactions)
+added the `kafka-transactions.sh` tool to detect and abort it);
+[KIP-890](https://cwiki.apache.org/confluence/display/KAFKA/KIP-890%3A+Transactions+Server-Side+Defense)
+broker-side verification, on by default since Kafka 3.6, prevents the class, confining this cause to
+older or opted-out brokers.
+
+Both are rare, and silent when they hit: the unbounded read hangs the poll thread inside the
+rebalance callback, nothing crashes, and `max.poll.interval.ms` evicts the member while
+process-level health checks stay green.
+
+When the read's position stops advancing, a no-progress deadline (`recoveryStallTimeout`, default 3
+min, reset by every position advance) fails the read loudly. The wait it must outlast is
+bounded — an open transaction resolves within ~70 s at defaults, which the takeover-abort collapses
+to sub-second for the partition's own — so the deadline sits above that wait and below
+`max.poll.interval.ms`: high enough not to fire during a legitimate wait, low enough to fire before
+the member is evicted. It is the fallback for a wait that never resolves. Failing also heals: the
+reading consumer is group-less, so eviction never unwinds the stuck thread but the error frees it,
+and the restarted recovery captures a fresh target. After a truncation that restart completes, but
+over the shortened log, so the loss stands until an operator acts (below); behind a hanging
+transaction it fails loudly again until the pin is cleared.
+
+The failure is diagnosed by re-reading the log end, because the two causes need opposite responses:
+below the captured target names truncation — the records are gone, so recovery becomes an
+offset-reset or restore decision for an operator; at or above it names an open transaction that
+outlived the deadline — a hanging one, or one whose timeout simply exceeds the deadline and will
+heal on its own. The deadline flags a truncation only while a read is in flight, and reads run
+only at recovery — so a truncation usually lands between reads and is adopted silently: the next
+read captures its fresh target from the already-shortened log and completes, folding onward input
+onto the older surviving state — the Problem's corruption shape, from broker-side loss instead of a
+stale writer. The guard against losing records is the replication above, not the deadline.
+
+Only the transactional mode enables the deadline, because only it forces the `read_committed`
+read that carries the designed wait. A non-transactional module configured with `read_committed`
+inherits the same bounded target and its wait, without the deadline.
+
+### Consumer rebalance protocols
 
 The per-member fencing token is the **generation** under the classic protocol and the **member epoch**
 under the consumer protocol
@@ -163,8 +262,9 @@ generation. Under the consumer protocol the epoch also advances *between* polls,
 post-poll read can be stale by the time the commit reaches the broker.
 [KIP-1251](https://cwiki.apache.org/confluence/display/KAFKA/KIP-1251%3A+Assignment+epochs+for+consumer+groups)
 (brokers 4.3.0+) absorbs the consumer-protocol window — the coordinator accepts a lagging commit for a
-partition the member still owns, and a reassigned one stays fenced — hence the broker recommendation
-for `group.protocol=consumer`; no broker version absorbs the classic in-flight-round window.
+partition the member still owns, and a reassigned one stays fenced — hence `group.protocol=consumer`
+is recommended only with such brokers (below 4.3.0 its window is the wider one); no broker version
+absorbs the classic in-flight-round window.
 
 The revoke-time flush is the one place the combinations differ in outcome. Classic **eager** revokes
 before the member rejoins, and the consumer protocol keeps the member on its epoch until it
@@ -172,7 +272,7 @@ acknowledges the revocation — under both, the flush commits. Classic **coopera
 the member to the new generation by revoke time, so its flush is always fenced (safe; the new owner
 replays). A member evicted before the flush is rejected under all three — the same safe direction.
 
-## Write path: group-committed transactions
+### Write path: group-committed transactions
 
 A producer allows one transaction at a time, while kafka-flow flushes a partition's keys in
 parallel — and after a fresh assignment most of the active key population flushes in one wave per
@@ -207,6 +307,10 @@ Entry point: `KafkaPersistenceModuleOf.cachingTransactional`. In the current cod
   staged, it commits nothing (a no-op).
 - **Generation currency** — the `Consumer` wrapper holds `groupMetadata` in a `Ref`, refreshed after every
   poll.
+- **Recovery read** — `KafkaPartitionPersistence.readSnapshots` (the high-watermark capture, the
+  drain to target, the start-of-read wait warn — logged when the captured target sits above the LSO).
+- **Stall deadline** — the read loop `KafkaPartitionPersistence.readPartitionWithDeadline`, failing
+  with `RecoveryReadStalledError` at `recoveryStallTimeout`.
 
 ## Measurements
 
@@ -226,9 +330,10 @@ thing that varies is whether the writes are issued one at a time (sequentially) 
 
 This isolates one variable: group commit only pays off when writes are issued together. Issued one at a
 time, nothing batches, so transactions run one per write — several times slower than the plain producer;
-issued all at once, they collapse into a few transactions and that cost is gone. The plain producer is
-measured one-at-a-time only as a reference point — not a fair head-to-head, since nothing makes it batch
-here. The fair comparison, both issued concurrently against realistic payloads, is Experiment B.
+issued all at once, the writes collapse into a few transactions and that cost is gone. The plain
+producer is measured one-at-a-time only as a reference point — not a fair head-to-head, since
+nothing makes it batch here. The fair comparison, both issued concurrently against realistic
+payloads, is Experiment B.
 
 **Experiment B** — 2000 keys, 10 KiB snapshots, flushed **concurrently** (the *post-assignment wave*: a
 new owner recovers all its keys, so they fall due together, and the timer tick fans the per-key flushes
@@ -252,24 +357,67 @@ Reproduce: `KAFKA_FLOW_PERF=1 sbt "persistence-kafka-it-tests/testOnly *Transact
 
 ## Testing
 
-Integration tests (`TransactionalKafkaPersistenceSpec`, in persistence-kafka-it-tests) run through the
-real eager-recovery (every key recovered on assignment) and flush-on-revoke machinery. The reproduction
-shows corruption with the plain shared producer (no offset binding); the prevention drives a stale owner
-with an *older consumer generation* and asserts the newer snapshot survives — isolating the offset
-binding as the cause, not incidental fencing. Other cases covered: first-flush gating (the seed), a
-fenced writer fails its next flush, an open transaction neither blocks nor leaks into recovery,
-concurrent-write safety. The group commit is exercised in isolation by `GroupCommitSpec`, a unit test
-with a recording in-memory producer (no broker). Two unit suites pin the client-side pieces the fence
-depends on: `TopicFlowSpec` that removing a partition awaits its flows' teardown, and `ConsumerSpec`
-the post-poll generation tracking and the negative-generation guard.
+Integration tests (`TransactionalKafkaPersistenceSpec`, in persistence-kafka-it-tests) run against a
+real broker:
+
+- **Reproduction and prevention** — the corruption pair runs the real recovery and flush-on-revoke
+  machinery (`kafkaEagerRecovery` — every key recovered on assignment): corruption reproduced with
+  the plain shared producer (no offset binding); prevention drives a stale owner with an *older
+  consumer generation* and asserts the newer snapshot survives.
+- **Generation fence, isolated** — under the stable id a stale flush dies at the epoch fence first
+  (Stable transactional.id, above), so these tests drive a live, unfenced producer whose generation
+  alone is stale: the next periodic flush fails fast, the first flush is gated by the offset seeded
+  at assignment, and a transactional offset commit is rejected.
+- **Concurrent writes** — a partition's keys flush in parallel against the one shared producer
+  (Write path, above); asserted safe for distinct keys.
+- **Unfinished transactions, both resolutions** — the takeover-abort at the handover: the
+  last-stable-offset is back at the high watermark immediately after module acquisition, a state
+  only the abort produces, never the broker's timeout; the same test pins the
+  `"<prefix>-<partition>"` id shape. And the wait for a transaction no takeover aborts (Recovery
+  read, above): a foreign transaction held open through the read, its LSO pin asserted active, then
+  waited out under a deadline set above the wait — the read completes, the deadline never fires.
+
+The suites drive flows with explicit consumer generations rather than live rebalances; the
+protocol/assignor matrix (Consumer rebalance protocols, above) rests on broker semantics, not on
+tests here.
+
+Unit suites pin the client-side pieces the mechanism depends on:
+
+- **`ConsumerSpec`** (core) — the post-poll generation tracking and the negative-generation guard.
+- **`TopicFlowSpec`** (core) — `TopicFlow.remove` returns only after the partition's flows tear
+  down — the client-side close of the fence's per-partition gap (Generation fencing, above) — and
+  a partition flow's group metadata is a live reader, never a cached copy.
+- **`GroupCommitSpec`** (persistence-kafka) — the group commit against a recording producer,
+  broker-free (the fence itself is the integration suite's job): the committed offset never leads
+  the writes it covers; offset-only commits ride free of the cap; a missing generation fails loudly
+  instead of committing ungated; and the generation is read live per transaction, never cached.
+- **`KafkaPersistenceModuleSpec`** (persistence-kafka) — the module's wiring: the producer settings,
+  the `read_committed`-from-earliest read with the deadline enabled.
+- **`ReadSnapshotsSpec`** (persistence-kafka) — the read itself: the high-watermark target (a read
+  bounded at the reader's own `endOffsets`, the LSO, would silently under-read), the deadline with
+  its diagnosis (a failing re-read never masks the stall), a progressing read outliving the
+  deadline, and the control (with no deadline the read stays unbounded).
 
 ## Rejected alternatives
 
 - **Transactional snapshot read + snapshot write**: fence a stale writer with a compare-and-set on the
-  stored offset. Kafka has no conditional produce primitive, so it cannot be atomic.
-- **Producer-epoch fencing (stable `transactional.id`)**: redundant with the generation fence, and
-  the epoch order can diverge from ownership order, spuriously fencing the true owner (see No epoch
-  fencing).
+  stored offset instead of the group generation. Kafka has no conditional produce primitive, so it
+  cannot be atomic.
+- **Offset tracking in snapshot**: store each key's offset inside its snapshot and, on recovery,
+  resume the partition from the minimum offset across its keys. Damage limitation, not prevention —
+  the stale write still lands (the topic stays last-write-wins), and healing replays the whole
+  partition from the oldest surviving key. The generation fence prevents the write from landing at
+  all.
+- **Producer-epoch order as the fence**: epoch order can diverge from ownership order, spuriously
+  fencing the true owner — the stable id is kept for the takeover-abort, never as the fence (see
+  Stable transactional.id).
+- **Unique per-assignment `transactional.id`s** (`"<prefix>-<partition>-<uuid8>"`): with no shared
+  id a late-initing stale owner cannot win the epoch and spuriously fence the valid owner (see
+  Stable transactional.id) — but nothing ever aborts a crashed owner's unfinished transaction, so
+  every post-crash recovery waits out the full transaction timeout the stable id resolves at init,
+  and coordinator state accumulates per assignment until `transactional.id.expiration.ms`. Either
+  choice is sound (the read bound holds under both); the sub-second takeover was judged worth the
+  spurious-fence cost.
 - **Static partition assignment** (`assign()` instead of `subscribe()`): no consumer group, so no
   rebalance, no overlap window, no fence needed — but it gives up automatic failover and elastic
   reassignment, and safe *dynamic* assignment is the point of this design. (Static *membership*

--- a/docs/kafka-single-writer-design.md
+++ b/docs/kafka-single-writer-design.md
@@ -392,7 +392,9 @@ Unit suites pin the client-side pieces the mechanism depends on:
   the writes it covers; offset-only commits ride free of the cap; a missing generation fails loudly
   instead of committing ungated; and the generation is read live per transaction, never cached.
 - **`KafkaPersistenceModuleSpec`** (persistence-kafka) — the module's wiring: the producer settings,
-  the `read_committed`-from-earliest read with the deadline enabled.
+  the `read_committed`-from-earliest read with the deadline enabled and the offset side cleared
+  (group-less, no auto-commit — a committed offset would override the earliest reset on the next
+  recovery and silently shorten it).
 - **`ReadSnapshotsSpec`** (persistence-kafka) — the read itself: the high-watermark target (a read
   bounded at the reader's own `endOffsets`, the LSO, would silently under-read), the deadline with
   its diagnosis (a failing re-read never masks the stall), a progressing read outliving the

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -22,15 +22,18 @@ backends are provided:
 Both backends recover state per key during partition assignment, relying on Kafka's guarantee that a
 partition is owned by a single consumer in the group. The [stale-writer
 protections](#protecting-against-stale-snapshot-writes) below cover the one case where that ownership
-guarantee is not enough.
+guarantee is not enough for the **Kafka** backend. The Cassandra backend writes snapshots
+unconditionally (last write wins, no offset check), so it stays exposed to the stale-writer
+overwrite, like a custom store (see [Custom snapshot storage](#custom-snapshot-storage)).
 
 ## Protecting against stale snapshot writes
 
 Consumer-group ownership of the input topic does **not** extend to the snapshot store. During a
-rebalance a previous owner that has not yet observed the revocation (network issue, GC pause, slow
-poll loop) keeps folding events and flushing snapshots alongside the new owner; with the default
-last-write-wins persistence a stale snapshot overwrites a newer one, and the next recovery loads stale
-state — losing the events between the two snapshots even though their offsets were committed. See
+rebalance a previous owner that has not yet observed the revocation (a network issue, a GC pause, a
+slow poll loop — typical during broker maintenance or high-load restarts) keeps folding events and
+flushing snapshots alongside the new owner; with the default last-write-wins persistence a stale
+snapshot overwrites a newer one, and the next recovery loads stale state — losing the events
+between the two snapshots even though their offsets were committed. See
 [kafka-flow#732](https://github.com/evolution-gaming/kafka-flow/issues/732); overlaps of tens of
 seconds have been seen in production.
 
@@ -78,6 +81,7 @@ val moduleOf = KafkaPersistenceModuleOf.cachingTransactional[F, State](
     producerConfig        = snapshotProducerConfig,
     transactionalIdPrefix = applicationId,
     snapshotTopic         = stateTopic,
+    // also tunable: maxWritesPerTransaction, recoveryStallTimeout (both below)
   ),
 )
 // wire it into the flow as usual:
@@ -86,24 +90,34 @@ val moduleOf = KafkaPersistenceModuleOf.cachingTransactional[F, State](
 
 `idempotence` and the per-partition `transactional.id` are set for you — don't configure them in
 `producerConfig` — and the snapshot `consumerConfig`'s isolation level is forced to `read_committed`.
-The id is regenerated per assignment, not stable per partition. The input topic whose offsets are
-committed transactionally, and the consumer generation used to fence stale writers, are both supplied
+The id is stable per partition (`"<prefix>-<partition>"`): every owner of a partition shares it, so a
+takeover's `initTransactions` fences the previous owner's producer and aborts any transaction it left
+open. The input topic whose offsets are committed transactionally, and the consumer generation used
+to fence stale writers, are both supplied
 by the flow (from the assigned partition and the driving consumer), so neither is part of
 `TransactionalConfig`. One module serves one flow: snapshots are keyed by partition *number* alone, so
 each input topic needs its own module with its own `snapshotTopic` — sharing a snapshot topic between
 flows would mix their state on recovery.
 
-`transactionalIdPrefix` does not affect fencing (that is by consumer generation) — it is a readable
-label and, on an ACL-secured cluster, the `transactional.id` prefix your producer principal must be
-authorized for. Use your `applicationId`; an application running several flows can append any per-flow
-discriminator (e.g. the input topic) — an `"<applicationId>*"` prefixed ACL still covers it.
+`transactionalIdPrefix` does not affect fencing of stale writers (that is by consumer generation) —
+it is a readable label and, on an ACL-secured cluster, the `transactional.id` prefix your producer
+principal must be authorized for. Because the id is stable per partition, the prefix must be unique
+per flow: use your `applicationId`, and an application running several flows must append a per-flow
+discriminator (e.g. the input topic) or the flows share ids and fence each other — an
+`"<applicationId>*"` prefixed ACL still covers it.
 
 Snapshot writes and the input-offset commit run in one Kafka transaction per assigned partition; a
 write from a stale consumer generation is fenced by the broker
 ([KIP-447](https://cwiki.apache.org/confluence/display/KAFKA/KIP-447%3A+Producer+scalability+for+exactly+once+semantics),
 brokers 2.5+) and surfaces as
-`CommitFailedException`. Recovery reads `read_committed`, so a fenced writer's aborted records are
-never recovered.
+`CommitFailedException` — or as a producer-epoch error (`ProducerFencedException` or
+`InvalidProducerEpochException`, by transaction protocol version) when a new owner's `initTransactions` has
+already fenced the stale producer; rejected either way. Recovery reads `read_committed`, so a
+fenced writer's aborted records are
+never recovered. After a hard crash the new owner takes over immediately (aborting the crashed
+owner's unfinished transaction) and recovers everything that was committed. If an unfinished
+transaction belongs to some other `transactional.id` (see the limitations for when that happens),
+recovery waits until the broker aborts it instead — slower, but nothing committed is ever missed.
 
 - **Cost** — snapshot writes commit in Kafka transactions (a few ms each on real brokers), and cost
   tracks the *number* of transactions more than their size. Concurrent key flushes are group-committed,
@@ -112,8 +126,9 @@ never recovered.
   own producer and transaction-coordinator state on the brokers.
 - **Tuning for transaction time** — a transaction must commit within `transaction.timeout.ms` (a
   producer config, default 1 min, ≤ the broker's `transaction.max.timeout.ms`). Large snapshots lengthen
-  it with the batch — lower `maxWritesPerTransaction` (at a throughput cost) or raise the timeout. A
-  higher timeout widens the post-crash window (below).
+  it with the batch — lower `maxWritesPerTransaction` (at a throughput cost) or raise the timeout.
+  Raising it does not slow normal recovery (a takeover aborts this id's unfinished transactions
+  immediately); it only lengthens the prefix-change wait (below).
 - **Output is at-least-once** — output produces stay outside the snapshot transaction, so a replayed
   batch re-emits them; the consuming side must tolerate duplicates. Only the snapshot store and the
   input-offset commit are kept consistent (corruption prevention, not exactly-once).
@@ -121,6 +136,33 @@ never recovered.
   records). A rolling deploy is safe; while the two modes coexist a non-transactional instance is not
   fenced — the same exposure you already have without this mode, gone once every instance is
   transactional.
+- **Recovery fails loudly rather than hangs** — a recovery read that makes no progress for
+  `recoveryStallTimeout` (default 3 min) fails with `RecoveryReadStalledError` instead of hanging the
+  rebalance until the member is silently evicted at `max.poll.interval.ms`. The error names its
+  diagnosed cause. Truncation: the snapshot log lost acknowledged records under the read (an
+  unclean leader election or an equivalent disaster) — the records are gone, an offset-reset or
+  restore decision. An outlived transaction: one whose producer's `transaction.timeout.ms` merely
+  exceeds the deadline heals on its own once the broker aborts it; a *hanging* transaction,
+  whose last-stable-offset pin never clears, is detected and aborted with the `kafka-transactions.sh` tool
+  ([KIP-664](https://cwiki.apache.org/confluence/display/KAFKA/KIP-664%3A+Provide+tooling+to+detect+and+abort+hanging+transactions));
+  brokers 3.6+ prevent it from arising by default
+  ([KIP-890](https://cwiki.apache.org/confluence/display/KAFKA/KIP-890%3A+Transactions+Server-Side+Defense)).
+  If the diagnosis comes back undetermined (the high-watermark re-read itself failed), fall back to
+  the broker alerts that follow.
+  Cluster-side, the matching broker alerts are `UncleanLeaderElectionsPerSec > 0` (truncation risk)
+  and `PartitionsWithLateTransactionsCount > 0` (hanging transactions). Consumer lag metrics read
+  zero during the wait or stall (lag is measured to the last-stable-offset, where the read parks),
+  so alert on this mode's log signals, not on lag. Keep the value well below `max.poll.interval.ms` and above
+  the legitimate wait for an unfinished transaction (`transaction.timeout.ms` plus the broker's
+  abort scan).
+- **Reducing truncation risk** — the deadline only *flags* lost records; it cannot recover them, and it
+  catches truncation only while a recovery read is in flight. Reads run only at partition assignment,
+  so a truncation usually lands between them and is adopted silently by the next recovery. So guard
+  against it at the broker: keep the snapshot topic durable with
+  `unclean.leader.election.enable=false` (the default), `min.insync.replicas` ≥ 2, and a replication
+  factor ≥ 3 — the transactional producer already forces `acks=all`. An acknowledged snapshot then
+  survives any single broker failure; truncation requires an opted-in unclean election or a disaster
+  beyond the replication factor.
 
 Limitations:
 - A batch shares its transaction's outcome: if the transaction fails, every write in it fails.
@@ -128,12 +170,17 @@ Limitations:
   nor committed, so the new owner replays those events — noise, not loss. Under the classic
   **cooperative** assignor this is every revocation: the revoke-time flush is always fenced, so
   `flushOnRevoke` does not shrink the replay window there.
-- After a hard crash, the broker reclaims the failed owner's in-flight transaction only after
-  `transaction.timeout.ms`; until then that open transaction pins the snapshot topic's
-  last-stable-offset, and a recovery in that window silently misses records beyond it — even committed
-  ones — while input offsets are not held back the same way, so a second handover inside the window
-  can recover stale state
-  ([kafka-flow#850](https://github.com/evolution-gaming/kafka-flow/issues/850)).
+- A stale owner's late `initTransactions` can fence the current owner's producer: the current owner's flow
+  fails once and recovers (rebalance and replay); no wrong write can land. Rare, and a different
+  fence — the producer epoch (its errors above), not the group generation (`CommitFailedException`).
+- A `transactionalIdPrefix` change can cost recovery a wait: an old-prefix instance that dies
+  mid-transaction during the rollout (any unclean death — a crash, an OOM kill, a forced pod
+  delete) leaves that transaction under an id no new instance will ever init, so recovery waits
+  until the broker times the transaction out — up to ~70 s at the defaults
+  (`transaction.timeout.ms` plus the broker's abort scan), never a wrong read. A transaction is
+  open only during a synchronous flush or offset commit, so a graceful rollout leaves nothing open.
+  (A foreign producer's transaction on the snapshot topic is waited out the same way — but the
+  topic must be exclusive to the flow regardless.)
 - The mode always uses the identity `KafkaPersistencePartitionMapper` (fencing is per input partition);
   a non-identity mapper is not supported here.
 - The fence works under both the **classic** and the **consumer** group protocols

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -56,8 +56,9 @@ You do not catch the rejection yourself; it is handled for you:
 - **Periodic flush** — the conflict fails the stale instance's flow. That is safe (it no longer owns
   the partition), unless you set `persistPeriodically(ignorePersistErrors = true)`, in which case it
   is logged and swallowed.
-- **Flush-on-revoke** — the conflict surfaces as a cache-entry release error that scache logs and
-  swallows (`scache: failed to release cache entry: ...`), so the partition hands off cleanly.
+- **Flush-on-revoke** — the conflict surfaces as a cache-entry release error that scache prints to
+  `System.err` — not via the logging framework — and swallows
+  (`scache: failed to release cache entry: ...`), so the partition hands off cleanly.
 
 Either way the rejected write does not land and no offset is committed for it, so the new owner
 replays the affected events.
@@ -89,7 +90,8 @@ val moduleOf = KafkaPersistenceModuleOf.cachingTransactional[F, State](
 ```
 
 `idempotence` and the per-partition `transactional.id` are set for you — don't configure them in
-`producerConfig` — and the snapshot `consumerConfig`'s isolation level is forced to `read_committed`.
+`producerConfig` — and the snapshot `consumerConfig` is forced to `read_committed`, with `groupId`
+cleared and `autoCommit` off: the recovery readers never join a group or commit offsets.
 The id is stable per partition (`"<prefix>-<partition>"`): every owner of a partition shares it, so a
 takeover's `initTransactions` fences the previous owner's producer and aborts any transaction it left
 open. The input topic whose offsets are committed transactionally, and the consumer generation used

--- a/persistence-kafka-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/ForAllKafkaSuite.scala
+++ b/persistence-kafka-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/ForAllKafkaSuite.scala
@@ -22,6 +22,8 @@ import scala.jdk.CollectionConverters.*
 abstract class ForAllKafkaSuite extends FunSuite with TestContainersFixtures {
   import cats.effect.unsafe.implicits.global
 
+  // deliberately unpinned - tracking the testcontainers default lets CI surface broker changes that may
+  // warrant code or doc updates; the transactional tests tolerate protocol-version differences
   val kafka = ForAllContainerFixture(KafkaContainer())
 
   def createTopic(topic: String, partitions: Int): IO[Unit] = {

--- a/persistence-kafka-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/TransactionalKafkaPersistenceSpec.scala
+++ b/persistence-kafka-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/TransactionalKafkaPersistenceSpec.scala
@@ -5,6 +5,7 @@ import cats.effect.unsafe.IORuntime
 import cats.effect.{IO, Ref, Resource}
 import cats.syntax.all.*
 import com.evolutiongaming.catshelper.{FromTry, Log, LogOf}
+import com.evolutiongaming.kafka.flow.kafka.Codecs.*
 import com.evolutiongaming.kafka.flow.kafka.ScheduleCommit
 import com.evolutiongaming.kafka.flow.registry.EntityRegistry
 import com.evolutiongaming.kafka.flow.snapshot.SnapshotWriteDatabase
@@ -43,6 +44,12 @@ import scala.concurrent.duration.*
   * first is still alive.
   */
 class TransactionalKafkaPersistenceSpec extends ForAllKafkaSuite {
+
+  // the wait-out test legitimately runs tens of seconds (a 15s transaction timeout plus the broker's abort
+  // scan); munit's 30s default would race it, so keep munit's bound above the test's own
+  // 45s stall deadline and 60s outer timeout - those fail first, with diagnostics
+  override def munitTimeout: Duration = 3.minutes
+
   implicit val ioRuntime: IORuntime = IORuntime.global
   implicit val logOf: LogOf[IO]     = LogOf.slf4j[IO].unsafeRunSync()
   implicit val log: Log[IO]         = logOf(this.getClass).unsafeRunSync()
@@ -71,13 +78,24 @@ class TransactionalKafkaPersistenceSpec extends ForAllKafkaSuite {
     * `read_committed` matches the transactional mode; it is equally correct for reading topics written without
     * transactions, where it behaves the same as `read_uncommitted`.
     */
-  private def readSnapshots(stateTopic: String): IO[BytesByKey] =
+  private def readSnapshots(
+    stateTopic: String,
+    stallTimeout: Option[FiniteDuration] = KafkaPersistenceModule.TransactionalConfig.DefaultRecoveryStallTimeout.some,
+  ): IO[BytesByKey] =
     KafkaPartitionPersistence.readSnapshots[IO](
       consumerOf     = consumerOf,
       consumerConfig = consumerConfig.copy(isolationLevel = IsolationLevel.ReadCommitted),
       snapshotTopic  = stateTopic,
       partition      = Partition.min,
+      stall          = stallTimeout.map(KafkaPartitionPersistence.Stall(_, IO.monotonic)),
     )
+
+  private def endOffset(stateTopic: String, isolation: IsolationLevel): IO[Offset] = {
+    val tp = TopicPartition(stateTopic, Partition.min)
+    consumerOf
+      .apply[String, ByteVector](consumerConfig.copy(isolationLevel = isolation))
+      .use(_.endOffsets(cats.data.NonEmptySet.of(tp)).map(_.getOrElse(tp, Offset.min)))
+  }
 
   private def utf8(value: String): Option[ByteVector] = ByteVector.encodeUtf8(value).toOption
 
@@ -156,7 +174,7 @@ class TransactionalKafkaPersistenceSpec extends ForAllKafkaSuite {
     val eventsA    = (1 to 5).toList.map(i => s"e$i")
     val eventsB    = (1 to 10).toList.map(i => s"e$i")
 
-    // each flow gets its own generation: flow A (the previous owner) a stale one, flow B (the new owner) the current one
+    // each flow gets its own generation: flow A (previous owner) a stale one, flow B (new owner) the current one
     def allocateFlow(
       moduleOf: KafkaPersistenceModuleOf[IO, String],
       groupMetadata: IO[Option[ConsumerGroupMetadata]],
@@ -170,14 +188,20 @@ class TransactionalKafkaPersistenceSpec extends ForAllKafkaSuite {
       // the previous owner: folds events, snapshots stay buffered in memory
       flowA             <- allocateFlow(moduleOfA, groupMetadataA)
       (flowA_, releaseA) = flowA
-      _                 <- flowA_(inputRecords(inputTopic, key, eventsA))
-      // the new owner: eagerly recovers (finds nothing), folds all events, flushes on release
-      flowB             <- allocateFlow(moduleOfB, groupMetadataB)
-      (flowB_, releaseB) = flowB
-      _                 <- flowB_(inputRecords(inputTopic, key, eventsB))
-      _                 <- releaseB
-      newOwnerWrote     <- readSnapshots(stateTopic)
-      _                  = assertEquals(clue(newOwnerWrote.get(key)), utf8(eventsB.mkString(",")))
+      // a failed step must not leak flow A past the test (its release is the stale flush under test,
+      // so it cannot be Resource.use-scoped); same for flow B until its deliberate release. Guard only
+      // up to flow A's release - after it runs there is nothing left to leak, and guarding further would
+      // re-run it if a trailing step failed.
+      _ <- (for {
+        _ <- flowA_(inputRecords(inputTopic, key, eventsA))
+        // the new owner: eagerly recovers (finds nothing), folds all events, flushes on release
+        flowB             <- allocateFlow(moduleOfB, groupMetadataB)
+        (flowB_, releaseB) = flowB
+        _                 <- flowB_(inputRecords(inputTopic, key, eventsB)).onError(_ => releaseB.attempt.void)
+        _                 <- releaseB
+        newOwnerWrote     <- readSnapshots(stateTopic)
+      } yield assertEquals(clue(newOwnerWrote.get(key)), utf8(eventsB.mkString(","))))
+        .onError(_ => releaseA.attempt.void)
       // the previous owner flushes its stale state on revoke
       staleFlush <- releaseA.attempt
       stored     <- readSnapshots(stateTopic)
@@ -237,9 +261,12 @@ class TransactionalKafkaPersistenceSpec extends ForAllKafkaSuite {
       val stale = staleGeneration(current)
       staleFlushScenario(moduleOf, IO.pure(stale.some), moduleOf, IO.pure(current.some), stateTopic, key).map {
         case (staleFlush, stored) =>
-          // the release itself succeeds: the rejected write surfaces as a logged-and-swallowed cache entry release
-          // error ("scache: failed to release cache entry: ... CommitFailedException"), which is the desired
-          // outcome for a partition that is being given away anyway
+          // the release itself succeeds: the rejected write surfaces as a logged-and-swallowed cache entry
+          // release error ("scache: failed to release cache entry: ..."). Under the shared stable id, B's init
+          // has already epoch-fenced A, so the broker rejects A's flush for its stale producer epoch (raised
+          // client-side as InvalidProducerEpochException or ProducerFencedException, depending on the
+          // transaction protocol version) before the flush ever reaches the offset commit - so it is not the
+          // generation fence's CommitFailedException; that fence is pinned by the fail-fast and offset-commit tests
           assertEquals(clue(staleFlush), Right(()))
           // the protection: the stale (older-generation) write did not land, the new owner's snapshot survived
           assertEquals(clue(stored.get(key)), utf8((1 to 10).map(i => s"e$i").mkString(",")))
@@ -291,7 +318,7 @@ class TransactionalKafkaPersistenceSpec extends ForAllKafkaSuite {
           _ <- gmRef.set(staleGeneration(current))
           // the next periodic flush must fail fast with the conflict
           staleResult <- flow_(inputRecords(inputTopic, key, List("e1", "e2", "e3", "e4")).drop(3)).attempt
-          _           <- release.attempt // the fenced writer's flush-on-revoke error is logged and swallowed
+          _           <- release.attempt // cleanup only: nothing flushes on revoke in this flow's configuration
         } yield staleResult match {
           case Left(e) =>
             assert(
@@ -322,11 +349,12 @@ class TransactionalKafkaPersistenceSpec extends ForAllKafkaSuite {
           for {
             _ <- producer.initTransactions
             tx <- KafkaSnapshotWriteDatabase.transactional[IO, String](
-              snapshotTopicPartition = TopicPartition(stateTopic, Partition.min),
-              producer               = producer,
-              inputTopicPartition    = tp,
-              groupMetadata          = IO.pure(stale.some),
-              assignedOffset         = Offset.min,
+              snapshotTopicPartition  = TopicPartition(stateTopic, Partition.min),
+              producer                = producer,
+              inputTopicPartition     = tp,
+              groupMetadata           = IO.pure(stale.some),
+              assignedOffset          = Offset.min,
+              maxWritesPerTransaction = KafkaPersistenceModule.TransactionalConfig.DefaultMaxWritesPerTransaction,
             )
             attempt <- tx.scheduleCommit.schedule(Offset.unsafe(5)).attempt
           } yield attempt
@@ -375,7 +403,8 @@ class TransactionalKafkaPersistenceSpec extends ForAllKafkaSuite {
               // seeded: so even the FIRST write (below, with no prior scheduleCommit) carries the offset and is
               // generation-gated. Without the seed this would be the ungated "None window" and the stale write
               // would land.
-              assignedOffset = Offset.unsafe(3),
+              assignedOffset          = Offset.unsafe(3),
+              maxWritesPerTransaction = KafkaPersistenceModule.TransactionalConfig.DefaultMaxWritesPerTransaction,
             )
             // the very first write, no scheduleCommit beforehand - relies entirely on the seed for gating
             attempt <- tx.writeDatabase.persist(key, "stale-state").attempt
@@ -386,7 +415,7 @@ class TransactionalKafkaPersistenceSpec extends ForAllKafkaSuite {
     } yield {
       result match {
         case Left(e) =>
-          // even the first write carries the seeded offset, so the stale generation is rejected with CommitFailedException
+          // even the first write carries the seeded offset, so the stale generation is rejected (CommitFailedException)
           val chain = causeChain(e)
           assert(
             chain.exists(_.isInstanceOf[CommitFailedException]),
@@ -406,74 +435,183 @@ class TransactionalKafkaPersistenceSpec extends ForAllKafkaSuite {
   // the assertions cover safety (all writes land), not grouping - grouping is opportunistic and its effect is
   // demonstrated by TransactionalWriteThroughputSpec; also exercised with maxWritesPerTransaction = 1, where the
   // group commit degenerates to a transaction per write
-  List(KafkaSnapshotWriteDatabase.DefaultMaxWritesPerTransaction, 1).foreach { maxWritesPerTransaction =>
-    test(
-      s"concurrent writes of different keys are safe on the shared transactional producer " +
-        s"(maxWritesPerTransaction = $maxWritesPerTransaction)"
-    ) {
-      val stateTopic = s"tx-concurrent-$maxWritesPerTransaction-state-topic"
-      val inputTopic = s"input-$stateTopic"
-      val group      = s"$groupId-concurrent-$maxWritesPerTransaction"
-      val keys       = (1 to 10).toList.map(i => s"key$i")
+  List(KafkaPersistenceModule.TransactionalConfig.DefaultMaxWritesPerTransaction, 1).foreach {
+    maxWritesPerTransaction =>
+      test(
+        s"concurrent writes of different keys are safe on the shared transactional producer " +
+          s"(maxWritesPerTransaction = $maxWritesPerTransaction)"
+      ) {
+        val stateTopic = s"tx-concurrent-$maxWritesPerTransaction-state-topic"
+        val inputTopic = s"input-$stateTopic"
+        val group      = s"$groupId-concurrent-$maxWritesPerTransaction"
+        val keys       = (1 to 10).toList.map(i => s"key$i")
 
-      def kafkaKey(key: String): KafkaKey =
-        KafkaKey(appId, groupId, TopicPartition(inputTopic, Partition.min), key)
+        def kafkaKey(key: String): KafkaKey =
+          KafkaKey(appId, groupId, TopicPartition(inputTopic, Partition.min), key)
 
-      def writeDatabase(
-        producer: Producer[IO],
-        gm: ConsumerGroupMetadata
-      ): IO[SnapshotWriteDatabase[IO, KafkaKey, String]] =
-        KafkaSnapshotWriteDatabase
-          .transactional[IO, String](
-            snapshotTopicPartition  = TopicPartition(stateTopic, Partition.min),
-            producer                = producer,
-            inputTopicPartition     = TopicPartition(inputTopic, Partition.min),
-            groupMetadata           = IO.pure(gm.some),
-            assignedOffset          = Offset.min,
-            maxWritesPerTransaction = maxWritesPerTransaction,
-          )
-          .map(_.writeDatabase)
+        def writeDatabase(
+          producer: Producer[IO],
+          gm: ConsumerGroupMetadata
+        ): IO[SnapshotWriteDatabase[IO, KafkaKey, String]] =
+          KafkaSnapshotWriteDatabase
+            .transactional[IO, String](
+              snapshotTopicPartition  = TopicPartition(stateTopic, Partition.min),
+              producer                = producer,
+              inputTopicPartition     = TopicPartition(inputTopic, Partition.min),
+              groupMetadata           = IO.pure(gm.some),
+              assignedOffset          = Offset.min,
+              maxWritesPerTransaction = maxWritesPerTransaction,
+            )
+            .map(_.writeDatabase)
 
-      // a real generation is needed because every transaction commits the (seeded) offset
-      val test = createTopic(stateTopic, 1) *> createTopic(inputTopic, 1) *>
-        withJoinedConsumer(group, inputTopic) { current =>
-          transactionalProducer(s"tx-concurrent-$maxWritesPerTransaction").use { producer =>
-            for {
-              _        <- producer.initTransactions
-              database <- writeDatabase(producer, current)
-              // kafka-flow flushes keys of a partition in parallel by default: this must not corrupt or crash
-              _      <- keys.parTraverse_(key => database.persist(kafkaKey(key), s"state-of-$key"))
-              stored <- readSnapshots(stateTopic)
-            } yield keys.foreach { key =>
-              assertEquals(clue(stored.get(key)), utf8(s"state-of-$key"))
+        // a real generation is needed because every transaction commits the (seeded) offset
+        val test = createTopic(stateTopic, 1) *> createTopic(inputTopic, 1) *>
+          withJoinedConsumer(group, inputTopic) { current =>
+            transactionalProducer(s"tx-concurrent-$maxWritesPerTransaction").use { producer =>
+              for {
+                _        <- producer.initTransactions
+                database <- writeDatabase(producer, current)
+                // kafka-flow flushes keys of a partition in parallel by default: this must not corrupt or crash
+                _      <- keys.parTraverse_(key => database.persist(kafkaKey(key), s"state-of-$key"))
+                stored <- readSnapshots(stateTopic)
+              } yield keys.foreach { key =>
+                assertEquals(clue(stored.get(key)), utf8(s"state-of-$key"))
+              }
             }
           }
-        }
 
-      test.unsafeRunSync()
-    }
+        test.unsafeRunSync()
+      }
   }
 
-  test("an open transaction of a fenced writer neither blocks nor leaks into recovery") {
-    val stateTopic = "tx-open-state-topic"
+  test("a takeover aborts the crashed owner's unfinished transaction (stable transactional.id)") {
+    // The crashed producer's transaction.timeout.ms is deliberately long (10 minutes): the
+    // last-stable-offset can be back at the high watermark right after module acquisition only through
+    // the takeover-abort of the stable "<prefix>-<partition>" id, never the broker's timeout - a
+    // unique-suffix id would leave the transaction open and fail the assertion.
+    val stateTopic = "tx-takeover-abort-state-topic"
+    val inputTopic = s"input-$stateTopic"
 
-    val record = new ProducerRecord(
+    def record(key: String, value: String) = new ProducerRecord(
       topic     = stateTopic,
       partition = Partition.min.some,
-      key       = "key-uncommitted".some,
-      value     = "uncommitted".some,
+      key       = key.some,
+      value     = value.some,
+    )
+
+    // the module's own id for this partition - the crashed owner is a previous incarnation of its producer
+    val crashedProducer =
+      producerOf(
+        producerConfig.copy(
+          transactionalId    = s"$appId-${Partition.min.value}".some,
+          idempotence        = true,
+          transactionTimeout = 10.minutes,
+        )
+      )
+
+    val module = KafkaPersistenceModule.cachingTransactional[IO, String](
+      consumerOf = consumerOf,
+      producerOf = producerOf,
+      config = KafkaPersistenceModule.TransactionalConfig(
+        consumerConfig        = consumerConfig,
+        producerConfig        = producerConfig,
+        transactionalIdPrefix = appId,
+        snapshotTopic         = stateTopic,
+      ),
+      assignment = PartitionAssignment[IO](
+        topicPartition = TopicPartition(inputTopic, Partition.min),
+        assignedAt     = Offset.min,
+        groupMetadata  = IO.pure(none[ConsumerGroupMetadata]),
+      ),
     )
 
     val test = createTopic(stateTopic, 1) *>
-      transactionalProducer("tx-open").use { producerA =>
+      crashedProducer.use { crashed =>
+        for {
+          _ <- crashed.initTransactions
+          // a committed snapshot, so recovery has something real to return
+          _ <- crashed.beginTransaction
+          _ <- crashed.send(record("key-committed", "committed")).flatten
+          _ <- crashed.commitTransaction
+          // the crash: the transaction is left open
+          _    <- crashed.beginTransaction
+          _    <- crashed.send(record("key-unfinished", "unfinished")).flatten
+          lso0 <- endOffset(stateTopic, IsolationLevel.ReadCommitted)
+          hw0  <- endOffset(stateTopic, IsolationLevel.ReadUncommitted)
+          _     = assert(clue(lso0.value) < clue(hw0.value), "expected the unfinished transaction to pin the LSO")
+          // the takeover: acquiring the module runs initTransactions on the partition's stable id
+          stored <- module.use { _ =>
+            for {
+              lso1 <- endOffset(stateTopic, IsolationLevel.ReadCommitted)
+              hw1  <- endOffset(stateTopic, IsolationLevel.ReadUncommitted)
+              // the pin is resolved by the init itself - recovery starts unpinned, nothing to wait out
+              _ = assertEquals(
+                clue(lso1),
+                clue(hw1),
+                "expected the takeover's init to abort the unfinished transaction"
+              )
+              stored <- readSnapshots(stateTopic)
+            } yield stored
+          }
+        } yield {
+          assertEquals(clue(stored.get("key-committed")), utf8("committed"))
+          assertEquals(clue(stored.get("key-unfinished")), none[ByteVector])
+        }
+      }
+
+    test.unsafeRunSync()
+  }
+
+  test("recovery waits out an open transaction outside the id lineage") {
+    // An out-of-lineage transaction (a unique transactional.id no takeover ever inits) is aborted only by
+    // the broker's timeout, so it is genuinely open when the read starts: the read must wait it out, then
+    // include the committed record and exclude the timed-out one.
+    val stateTopic = "tx-open-state-topic"
+
+    def record(key: String, value: String) = new ProducerRecord(
+      topic     = stateTopic,
+      partition = Partition.min.some,
+      key       = key.some,
+      value     = value.some,
+    )
+
+    // short transaction.timeout.ms so the broker times the "crashed" writer out quickly (plus its abort
+    // scan, up to ~10s)
+    val crashedProducer =
+      producerOf(
+        producerConfig.copy(
+          transactionalId    = "tx-open-crashed".some,
+          idempotence        = true,
+          transactionTimeout = 15.seconds,
+        )
+      )
+
+    val test = createTopic(stateTopic, 1) *>
+      crashedProducer.use { producerA =>
         for {
           _ <- producerA.initTransactions
           _ <- producerA.beginTransaction
-          _ <- producerA.send(record).flatten
-          // producerA's transaction is left open: initTransactions of the new producer aborts it
-          _      <- transactionalProducer("tx-open").use(_.initTransactions)
-          stored <- readSnapshots(stateTopic).timeout(30.seconds)
-        } yield assertEquals(clue(stored.get("key-uncommitted")), none[ByteVector])
+          _ <- producerA.send(record("key-uncommitted", "uncommitted")).flatten
+          // the next owner commits a NEWER snapshot above A's still-open transaction
+          _ <- transactionalProducer("tx-open-next").use { producerB =>
+            producerB.initTransactions *>
+              producerB.beginTransaction *>
+              producerB.send(record("key-committed", "committed")).flatten *>
+              producerB.commitTransaction
+          }
+          // the pin must still be active when the read starts, else a slow runner degrades this to the
+          // aborted case, so the wait is never exercised
+          lso <- endOffset(stateTopic, IsolationLevel.ReadCommitted)
+          hw  <- endOffset(stateTopic, IsolationLevel.ReadUncommitted)
+          _    = assert(clue(lso.value) < clue(hw.value), "expected an open-transaction pin at read start")
+          // A's transaction is still open here; the read must wait for the broker to time it out. The stall
+          // deadline is set above the wait's self-healing bound (15s transaction timeout plus up to 10s
+          // abort scan): a legitimate wait must complete with the deadline enabled, without firing it
+          stored <- readSnapshots(stateTopic, stallTimeout = 45.seconds.some).timeout(60.seconds)
+        } yield {
+          assertEquals(clue(stored.get("key-committed")), utf8("committed"))
+          assertEquals(clue(stored.get("key-uncommitted")), none[ByteVector])
+        }
       }
 
     test.unsafeRunSync()

--- a/persistence-kafka-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/TransactionalWriteThroughputSpec.scala
+++ b/persistence-kafka-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/TransactionalWriteThroughputSpec.scala
@@ -63,6 +63,9 @@ class TransactionalWriteThroughputSpec extends ForAllKafkaSuite {
       ),
       snapshotTopic = stateTopic,
       partition     = Partition.min,
+      stall = KafkaPartitionPersistence
+        .Stall(KafkaPersistenceModule.TransactionalConfig.DefaultRecoveryStallTimeout, IO.monotonic)
+        .some,
     )
 
   private def timed(io: IO[Unit]): IO[FiniteDuration] =
@@ -254,11 +257,12 @@ class TransactionalWriteThroughputSpec extends ForAllKafkaSuite {
             _ <- producer.initTransactions
             database <- KafkaSnapshotWriteDatabase
               .transactional[IO, String](
-                snapshotTopicPartition = TopicPartition(stateTopic, Partition.min),
-                producer               = producer,
-                inputTopicPartition    = TopicPartition(sharedInput, Partition.min),
-                groupMetadata          = IO.pure(current.some),
-                assignedOffset         = Offset.min,
+                snapshotTopicPartition  = TopicPartition(stateTopic, Partition.min),
+                producer                = producer,
+                inputTopicPartition     = TopicPartition(sharedInput, Partition.min),
+                groupMetadata           = IO.pure(current.some),
+                assignedOffset          = Offset.min,
+                maxWritesPerTransaction = KafkaPersistenceModule.TransactionalConfig.DefaultMaxWritesPerTransaction,
               )
               .map(_.writeDatabase)
             _       <- database.persist(kafkaKey(stateTopic, "warm-up"), "warm-up")

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPartitionPersistence.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPartitionPersistence.scala
@@ -1,7 +1,7 @@
 package com.evolutiongaming.kafka.flow.kafkapersistence
 
 import cats.implicits.*
-import cats.{FlatMap, Monad, data}
+import cats.{data, FlatMap, Monad, MonadThrow}
 import com.evolutiongaming.catshelper.{BracketThrowable, Log}
 import com.evolutiongaming.kafka.flow.kafka.Codecs.*
 import com.evolutiongaming.skafka.*
@@ -11,6 +11,7 @@ import com.evolutiongaming.skafka.consumer.{
   ConsumerConfig,
   ConsumerOf,
   ConsumerRecord,
+  IsolationLevel,
   WithSize
 }
 import scodec.bits.ByteVector
@@ -22,31 +23,94 @@ object KafkaPartitionPersistence {
 
   private case class MissingOffsetError(topicPartition: TopicPartition) extends NoStackTrace
 
+  private[kafkapersistence] final case class RecoveryReadStalledError(
+    topicPartition: TopicPartition,
+    position: Offset,
+    targetOffset: Offset,
+    diagnosis: String,
+  ) extends RuntimeException(
+        s"recovery read of $topicPartition made no progress at offset $position, short of target $targetOffset, " +
+          s"past the stall deadline - failing rather than hanging or silently recovering possibly " +
+          s"incomplete state; $diagnosis"
+      )
+      with NoStackTrace
+
+  // "no progress" is logged only once the pause has lasted 5s, then every 5s: a shorter pause is routine at the
+  // 10ms poll cadence (a fetch in flight), while a genuine stall stays visible long before the deadline
+  private val logStallEvery: FiniteDuration = 5.seconds
+
+  private[kafkapersistence] final case class Stall[F[_]](timeout: FiniteDuration, monotonic: F[FiniteDuration])
+
+  // one poll (blocking up to the poll timeout), folding the batch into the accumulator
+  private def pollFold[F[_]: FlatMap](
+    consumer: SkafkaConsumer[F, String, ByteVector],
+    acc: BytesByKey,
+  ): F[BytesByKey] =
+    consumer
+      .poll(10.millis) // TODO: make poll timeout configurable
+      .map(_.values.values.flatMap(_.toIterable).foldLeft(acc)(processRecord))
+
+  // non-transactional read: drain to the target, waiting as long as it takes (the long-shipped behaviour)
   private[kafkapersistence] def readPartition[F[_]: Monad: Log](
     consumer: SkafkaConsumer[F, String, ByteVector],
     snapshotPartition: TopicPartition,
-    targetOffset: Offset
+    targetOffset: Offset,
   ): F[BytesByKey] =
     Log[F].info(s"Snapshot topic read started up to offset $targetOffset") *>
-      FlatMap[F]
-        .tailRecM[BytesByKey, BytesByKey](BytesByKey.empty) { acc =>
-          consumer
-            .position(snapshotPartition)
-            .flatMap {
-              case offset if offset >= targetOffset =>
-                acc.asRight[BytesByKey].pure[F]
-              case _ =>
-                consumer
-                  .poll(10.millis) // TODO: make poll timeout configurable
-                  .map(
-                    _.values
-                      .values
-                      .flatMap(_.toIterable)
-                      .foldLeft(acc)(processRecord)
-                      .asLeft
-                  )
-            }
+      FlatMap[F].tailRecM(BytesByKey.empty) { acc =>
+        consumer.position(snapshotPartition).flatMap {
+          case offset if offset >= targetOffset => acc.asRight[BytesByKey].pure[F]
+          case _                                => pollFold(consumer, acc).map(_.asLeft[BytesByKey])
         }
+      }
+
+  private final case class Last(position: Offset, progressAt: FiniteDuration, logAt: FiniteDuration)
+  private final case class ReadState(acc: BytesByKey, last: Option[Last])
+
+  // transactional read: the same drain, but fails loudly once no progress has been made for the whole deadline
+  private[kafkapersistence] def readPartitionWithDeadline[F[_]: MonadThrow: Log](
+    consumer: SkafkaConsumer[F, String, ByteVector],
+    snapshotPartition: TopicPartition,
+    targetOffset: Offset,
+    stall: Stall[F],
+    diagnoseStall: F[String],
+  ): F[BytesByKey] =
+    Log[F].info(s"Snapshot topic read started up to offset $targetOffset") *>
+      FlatMap[F].tailRecM(ReadState(BytesByKey.empty, none)) {
+        case ReadState(acc, last) =>
+          consumer.position(snapshotPartition).flatMap {
+            case offset if offset >= targetOffset =>
+              acc.asRight[ReadState].pure[F]
+            case offset =>
+              stall.monotonic.flatMap { now =>
+                last.filter(_.position == offset) match {
+                  case None =>
+                    // first poll, or advanced to a new offset: (re)start the stall clock and the log throttle
+                    pollFold(consumer, acc)
+                      .map(read => ReadState(read, Last(offset, now, now).some).asLeft[BytesByKey])
+                  case Some(stuck) =>
+                    // still at the same offset: fail once the deadline has passed, else log at the throttle
+                    val stalledFor = now - stuck.progressAt
+                    val logDue     = now - stuck.logAt >= logStallEvery
+                    val failOrLog =
+                      diagnoseStall
+                        .flatMap(d =>
+                          RecoveryReadStalledError(snapshotPartition, offset, targetOffset, d).raiseError[F, Unit]
+                        )
+                        .whenA(stalledFor >= stall.timeout) *>
+                        Log[F]
+                          .info(
+                            s"Snapshot topic read making no progress at offset $offset, target $targetOffset, " +
+                              s"stalled for ${stalledFor.toSeconds}s"
+                          )
+                          .whenA(logDue)
+                    failOrLog *> pollFold(consumer, acc).map { read =>
+                      ReadState(read, stuck.copy(logAt = if (logDue) now else stuck.logAt).some).asLeft[BytesByKey]
+                    }
+                }
+              }
+          }
+      }
 
   private[kafkapersistence] def processRecord(
     map: BytesByKey,
@@ -62,37 +126,82 @@ object KafkaPartitionPersistence {
     consumerConfig: ConsumerConfig,
     snapshotTopic: Topic,
     partition: Partition,
+    stall: Option[Stall[F]],
   )(implicit fromBytes: FromBytes[F, String]): F[BytesByKey] = {
-    consumerOf
-      .apply[String, ByteVector](
-        consumerConfig.copy(
-          autoOffsetReset = Earliest,
-          common = consumerConfig
-            .common
-            .copy(clientId = consumerConfig.common.clientId.map(cid => s"$cid-snapshot-$partition"))
-        )
-      )
-      .use { consumer =>
-        val snapshotsPartition =
-          TopicPartition(topic = snapshotTopic, partition = partition)
+    val snapshotsPartition         = TopicPartition(topic = snapshotTopic, partition = partition)
+    val snapshotPartitionSingleton = data.NonEmptySet.of(snapshotsPartition)
 
-        val snapshotPartitionSingleton = data.NonEmptySet.of(snapshotsPartition)
-        for {
-          _          <- consumer.assign(snapshotPartitionSingleton)
-          endOffsets <- consumer.endOffsets(snapshotPartitionSingleton)
-          targetOffset <- BracketThrowable[F].fromOption(
-            endOffsets.get(snapshotsPartition),
-            MissingOffsetError(snapshotsPartition)
-          )
-          bytesByKey <- readPartition(
-            consumer,
-            snapshotsPartition,
-            targetOffset
-          )
-          _ <- Log[F].info(
-            s"Snapshot topic $snapshotTopic partition $partition read complete at offset $targetOffset, ${bytesByKey.size} keys read"
-          )
-        } yield bytesByKey
+    def suffixed(suffix: String): ConsumerConfig =
+      consumerConfig.copy(
+        common = consumerConfig.common.copy(clientId = consumerConfig.common.clientId.map(cid => s"$cid-$suffix"))
+      )
+
+    def endOffset(consumer: SkafkaConsumer[F, String, ByteVector]): F[Offset] =
+      consumer.endOffsets(snapshotPartitionSingleton).flatMap { endOffsets =>
+        BracketThrowable[F].fromOption(endOffsets.get(snapshotsPartition), MissingOffsetError(snapshotsPartition))
       }
+
+    // the true log end through a short-lived read_uncommitted view: the read consumer's own read_committed
+    // endOffsets is the last-stable-offset, which an open transaction pins below records committed after it began -
+    // a target there silently under-reads, while the high-watermark target waits the transaction out
+    // (see the design doc's "Recovery read")
+    val highWatermark: F[Offset] =
+      consumerOf
+        .apply[String, ByteVector](
+          suffixed(s"snapshot-$partition-hw").copy(isolationLevel = IsolationLevel.ReadUncommitted)
+        )
+        .use(endOffset)
+
+    // under read_uncommitted the consumer's own end offset already is the high watermark
+    val capturedHighWatermark: F[Option[Offset]] =
+      if (consumerConfig.isolationLevel == IsolationLevel.ReadCommitted) highWatermark.map(_.some)
+      else none[Offset].pure[F]
+
+    capturedHighWatermark.flatMap { captured =>
+      consumerOf
+        .apply[String, ByteVector](suffixed(s"snapshot-$partition").copy(autoOffsetReset = Earliest))
+        .use { consumer =>
+          for {
+            _ <- consumer.assign(snapshotPartitionSingleton)
+            targetOffset <- captured match {
+              case None => endOffset(consumer)
+              case Some(capturedTarget) =>
+                endOffset(consumer).flatMap { lastStableOffset =>
+                  Log[F]
+                    .warn(
+                      s"Snapshot topic $snapshotTopic partition $partition recovery waits for open transaction(s): " +
+                        s"last-stable-offset $lastStableOffset below captured target $capturedTarget; " +
+                        s"normally resolves within the pinning producer's transaction.timeout.ms " +
+                        s"plus the broker's abort scan"
+                    )
+                    .whenA(lastStableOffset.value < capturedTarget.value)
+                    .as(capturedTarget)
+                }
+            }
+            bytesByKey <- stall match {
+              case None        => readPartition(consumer, snapshotsPartition, targetOffset)
+              case Some(stall) =>
+                // a stall's cause, re-read lazily only if the deadline fires; best-effort - a re-read that
+                // itself fails leaves the cause undetermined rather than masking the stall
+                val diagnoseStall = highWatermark
+                  .map { logEnd =>
+                    if (logEnd.value < targetOffset.value)
+                      s"the log end regressed to $logEnd, below the captured target: log truncation after an " +
+                        "unclean leader election or an equivalent disaster - acknowledged snapshot records are lost"
+                    else
+                      s"the log end $logEnd still covers the captured target: an open transaction outlived " +
+                        "the deadline - a pinning producer whose transaction.timeout.ms exceeds the deadline " +
+                        "resolves on its own; a hanging transaction does not - detect and abort it with " +
+                        "kafka-transactions.sh"
+                  }
+                  .handleError(_ => "the cause could not be determined: the high-watermark re-read failed")
+                readPartitionWithDeadline(consumer, snapshotsPartition, targetOffset, stall, diagnoseStall)
+            }
+            _ <- Log[F].info(
+              s"Snapshot topic $snapshotTopic partition $partition read complete at offset $targetOffset, ${bytesByKey.size} keys read"
+            )
+          } yield bytesByKey
+        }
+    }
   }
 }

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPartitionPersistence.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPartitionPersistence.scala
@@ -131,9 +131,13 @@ object KafkaPartitionPersistence {
     val snapshotsPartition         = TopicPartition(topic = snapshotTopic, partition = partition)
     val snapshotPartitionSingleton = data.NonEmptySet.of(snapshotsPartition)
 
+    // ephemeral assign-based readers: never group members, never committing offsets - a committed offset
+    // would override the earliest reset on the next recovery and silently shorten the read
     def suffixed(suffix: String): ConsumerConfig =
       consumerConfig.copy(
-        common = consumerConfig.common.copy(clientId = consumerConfig.common.clientId.map(cid => s"$cid-$suffix"))
+        groupId    = none,
+        autoCommit = false,
+        common     = consumerConfig.common.copy(clientId = consumerConfig.common.clientId.map(cid => s"$cid-$suffix")),
       )
 
     def endOffset(consumer: SkafkaConsumer[F, String, ByteVector]): F[Offset] =

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModule.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModule.scala
@@ -1,10 +1,10 @@
 package com.evolutiongaming.kafka.flow.kafkapersistence
 
 import cats.Parallel
-import cats.effect.{Async, Concurrent, Resource}
+import cats.effect.{Async, Clock, Concurrent, Resource}
 import cats.syntax.all.*
 import com.evolution.scache.Cache
-import com.evolutiongaming.catshelper.{FromTry, LogOf, Runtime}
+import com.evolutiongaming.catshelper.{FromTry, Log, LogOf, Runtime}
 import com.evolutiongaming.kafka.flow.kafka.ScheduleCommit
 import com.evolutiongaming.kafka.flow.key.{Keys, KeysOf}
 import com.evolutiongaming.kafka.flow.metrics.syntax.*
@@ -18,7 +18,7 @@ import com.evolutiongaming.sstream.Stream
 import scodec.bits.ByteVector
 import com.evolutiongaming.skafka.consumer.ConsumerRecord
 
-import java.util.UUID
+import scala.concurrent.duration.*
 
 /** A module, necessary to create a Kafka snapshot persistence.
   */
@@ -43,24 +43,42 @@ object KafkaPersistenceModule {
     *   base config for the snapshot producer; `transactionalId` and `idempotence` are overridden per producer and
     *   `clientId` is suffixed with `-snapshot-<partition>`
     * @param transactionalIdPrefix
-    *   prefix for `transactional.id` (partition number and a unique per-producer suffix are appended). It does not
-    *   affect fencing (that is by consumer generation), so its only roles are a readable label and, on an ACL-secured
-    *   cluster, the `transactional.id` prefix the producer principal must be authorized for. Use your `applicationId`;
-    *   an application running several flows can append any per-flow discriminator (e.g. the input topic), which an
-    *   `"<applicationId>*"` prefixed ACL still covers.
+    *   prefix for `transactional.id` (the partition number is appended; stable per partition). It does not affect
+    *   fencing of stale writers (that is by consumer generation) - it is a readable label and, on an ACL-secured
+    *   cluster, the `transactional.id` prefix the producer principal must be authorized for. Because the id is stable
+    *   per partition, the prefix must be unique per flow: use your `applicationId`, and an application running several
+    *   flows must append a per-flow discriminator (e.g. the input topic) or the flows share ids and fence each other's
+    *   producers - an `"<applicationId>*"` prefixed ACL still covers it.
     * @param snapshotTopic
     *   snapshot topic name (should be configured as a 'compacted' topic) to read/write snapshots
     * @param maxWritesPerTransaction
     *   upper bound of snapshot writes group committed in one per-partition, serialized transaction, see
     *   [[KafkaSnapshotWriteDatabase.transactional]]
+    * @param recoveryStallTimeout
+    *   how long a snapshot recovery read may make no progress before it fails with `RecoveryReadStalledError` instead
+    *   of hanging. Keep it below the driving consumer's `max.poll.interval.ms` and above the open-transaction wait.
     */
   final case class TransactionalConfig(
     consumerConfig: ConsumerConfig,
     producerConfig: ProducerConfig,
     transactionalIdPrefix: String,
     snapshotTopic: Topic,
-    maxWritesPerTransaction: Int = KafkaSnapshotWriteDatabase.DefaultMaxWritesPerTransaction,
+    maxWritesPerTransaction: Int         = TransactionalConfig.DefaultMaxWritesPerTransaction,
+    recoveryStallTimeout: FiniteDuration = TransactionalConfig.DefaultRecoveryStallTimeout,
   )
+
+  object TransactionalConfig {
+
+    /** Default for [[TransactionalConfig.maxWritesPerTransaction]] - group-committed snapshot writes per transaction,
+      * see [[KafkaSnapshotWriteDatabase.transactional]].
+      */
+    private[kafkapersistence] val DefaultMaxWritesPerTransaction: Int = 256
+
+    /** Default for [[TransactionalConfig.recoveryStallTimeout]] - the recovery read's no-progress deadline; 3 minutes
+      * clears both configuration bounds at Kafka defaults.
+      */
+    private[kafkapersistence] val DefaultRecoveryStallTimeout: FiniteDuration = 3.minutes
+  }
 
   def caching[F[_]: LogOf: Concurrent: Parallel: Runtime, S](
     consumerOf: ConsumerOf[F],
@@ -133,6 +151,7 @@ object KafkaPersistenceModule {
       metrics                = metrics,
       partitionMapper        = partitionMapper,
       writeDatabase          = KafkaSnapshotWriteDatabase.of[F, S](snapshotTopicPartition, producer, partitionMapper),
+      stall                  = none, // transactional only
     ).map {
       // non-transactional: offsets are committed the default way (by the consumer), see package.scala
       case (keysOf, persistenceOf) => module(keysOf, persistenceOf, commit = None)
@@ -144,13 +163,15 @@ object KafkaPersistenceModule {
     * without deprecation.
     *
     * Variant of `caching` protecting the snapshot topic from stale writers by binding the input-offset commit into the
-    * snapshot transaction. Each assigned partition gets a transactional producer with a unique `transactional.id`;
-    * snapshot writes run in group-committed transactions (see [[KafkaSnapshotWriteDatabase.transactional]]) that also
-    * commit the input offset. A stale consumer generation is rejected by the broker (KIP-447), aborting the
-    * transaction, so a stale owner can neither advance offsets nor overwrite a newer snapshot. Recovery reads with
-    * `read_committed`, and unlike `caching` the identity partition mapping is always used; output stays at-least-once.
-    * See the "Protecting against stale snapshot writes" persistence docs for guarantees, limitations, costs and
-    * rollout, and `docs/kafka-single-writer-design.md` for the mechanism.
+    * snapshot transaction. Each assigned partition gets a transactional producer with a stable per-partition
+    * `transactional.id`, whose `initTransactions` aborts any transaction a crashed previous owner left open; snapshot
+    * writes run in group-committed transactions (see [[KafkaSnapshotWriteDatabase.transactional]]) that also commit the
+    * input offset. A stale consumer generation is rejected by the broker (KIP-447), aborting the transaction, so a
+    * stale owner can neither advance offsets nor overwrite a newer snapshot. Recovery reads with `read_committed`,
+    * bounded by the high watermark so an open transaction the takeover does not reach is waited out, and unlike
+    * `caching` the identity partition mapping is always used; output stays at-least-once. See the "Protecting against
+    * stale snapshot writes" persistence docs for guarantees, limitations, costs and rollout, and
+    * `docs/kafka-single-writer-design.md` for the mechanism.
     *
     * The `assignment` must describe the input partition of the SAME consumer that drives this flow (its `groupMetadata`
     * generation is what fences a stale owner); `assignedAt` seeds the offset-to-commit so even the first write is
@@ -169,7 +190,8 @@ object KafkaPersistenceModule {
   ): Resource[F, KafkaPersistenceModule[F, S]] = {
     val snapshotTopicPartition = TopicPartition(config.snapshotTopic, assignment.topicPartition.partition)
     for {
-      transactional <- transactionalWriteDatabase[F, S](producerOf, config, assignment, snapshotTopicPartition)
+      log           <- Resource.eval(LogOf[F].apply(KafkaPersistenceModule.getClass))
+      transactional <- transactionalWriteDatabase[F, S](producerOf, config, assignment, snapshotTopicPartition, log)
       // records of aborted transactions (e.g. of a fenced previous owner) must not be recovered as snapshots
       parts <- of(
         consumerOf             = consumerOf,
@@ -178,6 +200,7 @@ object KafkaPersistenceModule {
         metrics                = metrics,
         partitionMapper        = KafkaPersistencePartitionMapper.identity,
         writeDatabase          = transactional.writeDatabase,
+        stall                  = KafkaPartitionPersistence.Stall(config.recoveryStallTimeout, Clock[F].monotonic).some,
       )
     } yield {
       val (keysOf, persistenceOf) = parts
@@ -186,14 +209,15 @@ object KafkaPersistenceModule {
     }
   }
 
-  /** Builds the per-assignment transactional producer (unique `transactional.id`) and the group-committing write
-    * database that binds the input-offset commit into each snapshot transaction. See [[cachingTransactional]].
+  /** Builds the partition's transactional producer (stable per-partition `transactional.id`) and the group-committing
+    * write database that binds the input-offset commit into each snapshot transaction. See [[cachingTransactional]].
     */
   private def transactionalWriteDatabase[F[_]: Async, S](
     producerOf: ProducerOf[F],
     config: TransactionalConfig,
     assignment: PartitionAssignment[F],
     snapshotTopicPartition: TopicPartition,
+    log: Log[F],
   )(
     implicit toBytesState: ToBytes[F, S]
   ): Resource[F, KafkaSnapshotWriteDatabase.Transactional[F, S]] = {
@@ -201,22 +225,24 @@ object KafkaPersistenceModule {
     import config.{maxWritesPerTransaction, producerConfig, transactionalIdPrefix}
     import assignment.{assignedAt, groupMetadata, topicPartition as inputTopicPartition}
 
-    val partition = inputTopicPartition.partition
+    val partition       = inputTopicPartition.partition
+    val transactionalId = s"$transactionalIdPrefix-${partition.value}"
+    val transactionalProducerConfig = producerConfig.copy(
+      transactionalId = transactionalId.some,
+      idempotence     = true,
+      common = producerConfig
+        .common
+        .copy(clientId = producerConfig.common.clientId.map(cid => s"$cid-snapshot-${partition.value}"))
+    )
 
     for {
-      // unique per producer: fencing is by consumer generation, not this id, so a fresh id per assignment is fine
-      shortId        <- Resource.eval(Async[F].delay(UUID.randomUUID().toString.take(8)))
-      transactionalId = s"$transactionalIdPrefix-${partition.value}-$shortId"
-      transactionalProducerConfig = producerConfig.copy(
-        transactionalId = transactionalId.some,
-        idempotence     = true,
-        common = producerConfig
-          .common
-          .copy(clientId = producerConfig.common.clientId.map(cid => s"$cid-snapshot-${partition.value}"))
-      )
       producer <- producerOf(transactionalProducerConfig)
-      // required to open transactions; the guard is the per-transaction offset commit (see transactional)
-      _ <- Resource.eval(producer.initTransactions)
+      // required before KafkaSnapshotWriteDatabase.transactional (below) can open transactions; it also aborts any
+      // transaction a crashed predecessor left open (no client-visible signal - the logged duration is the
+      // abort's only trace)
+      _ <- Resource.eval(Clock[F].timed(producer.initTransactions).flatMap {
+        case (took, _) => log.info(s"transactional producer $transactionalId initialized in ${took.toMillis} ms")
+      })
       transactional <- Resource.eval(
         KafkaSnapshotWriteDatabase.transactional[F, S](
           snapshotTopicPartition  = snapshotTopicPartition,
@@ -240,6 +266,7 @@ object KafkaPersistenceModule {
     metrics: FlowMetrics[F],
     partitionMapper: KafkaPersistencePartitionMapper,
     writeDatabase: SnapshotWriteDatabase[F, KafkaKey, S],
+    stall: Option[KafkaPartitionPersistence.Stall[F]],
   )(
     implicit fromBytesKey: FromBytes[F, String],
     fromBytesState: FromBytes[F, S],
@@ -247,7 +274,14 @@ object KafkaPersistenceModule {
     for {
       partitionDataCache <- Cache.loading[F, String, ByteVector]
       keysOf <- Resource.eval(
-        makeKeysOf(partitionDataCache, consumerOf, consumerConfig, snapshotTopicPartition, partitionMapper)
+        makeKeysOf(
+          partitionDataCache,
+          consumerOf,
+          consumerConfig,
+          snapshotTopicPartition,
+          partitionMapper,
+          stall,
+        )
       )
       persistenceOf <- Resource.eval(
         makeSnapshotPersistenceOf(keysOf, partitionDataCache, snapshotTopicPartition, metrics, writeDatabase)
@@ -274,6 +308,7 @@ object KafkaPersistenceModule {
     consumerConfig: ConsumerConfig,
     snapshotTopicPartition: TopicPartition,
     partitionMapper: KafkaPersistencePartitionMapper,
+    stall: Option[KafkaPartitionPersistence.Stall[F]],
   )(implicit fromBytesKey: FromBytes[F, String]): F[KeysOf[F, KafkaKey]] =
     LogOf[F].apply(classOf[KeysOf[F, KafkaKey]]).map { implicit log =>
       def readPartitionData: F[BytesByKey] = {
@@ -284,6 +319,7 @@ object KafkaPersistenceModule {
             consumerConfig = consumerConfig,
             snapshotTopic  = snapshotTopicPartition.topic,
             partition      = targetPartition,
+            stall          = stall,
           )
           .map { snapshots =>
             snapshots

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModule.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModule.scala
@@ -38,7 +38,8 @@ object KafkaPersistenceModule {
   /** Settings for [[cachingTransactional]].
     *
     * @param consumerConfig
-    *   config for the snapshot-reading consumer; recovery forces `read_committed` regardless of this value
+    *   config for the snapshot-reading consumers; recovery forces `read_committed` and clears `groupId` and
+    *   `autoCommit` (the ephemeral readers never join a group or commit offsets) regardless of this value
     * @param producerConfig
     *   base config for the snapshot producer; `transactionalId` and `idempotence` are overridden per producer and
     *   `clientId` is suffixed with `-snapshot-<partition>`
@@ -56,7 +57,8 @@ object KafkaPersistenceModule {
     *   [[KafkaSnapshotWriteDatabase.transactional]]
     * @param recoveryStallTimeout
     *   how long a snapshot recovery read may make no progress before it fails with `RecoveryReadStalledError` instead
-    *   of hanging. Keep it below the driving consumer's `max.poll.interval.ms` and above the open-transaction wait.
+    *   of hanging. Keep it below the driving consumer's `max.poll.interval.ms` - including one diagnostic re-read on
+    *   failure, bounded by the snapshot consumer's `default.api.timeout.ms` - and above the open-transaction wait.
     */
   final case class TransactionalConfig(
     consumerConfig: ConsumerConfig,

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaSnapshotWriteDatabase.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaSnapshotWriteDatabase.scala
@@ -52,7 +52,7 @@ object KafkaSnapshotWriteDatabase {
     inputTopicPartition: TopicPartition,
     groupMetadata: F[Option[ConsumerGroupMetadata]],
     assignedOffset: Offset,
-    maxWritesPerTransaction: Int = DefaultMaxWritesPerTransaction,
+    maxWritesPerTransaction: Int,
   ): F[Transactional[F, S]] =
     for {
       _ <- new IllegalArgumentException(s"maxWritesPerTransaction must be positive, got $maxWritesPerTransaction")
@@ -178,9 +178,6 @@ object KafkaSnapshotWriteDatabase {
         }
       } yield ()
   }
-
-  /** Default upper bound of snapshot writes committed in one transaction, see [[transactional]]. */
-  val DefaultMaxWritesPerTransaction: Int = 256
 
   // a write carries its record; an offset-only marker carries None (see scheduleCommit)
   private final case class Pending[F[_], S](

--- a/persistence-kafka/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/FakeConsumers.scala
+++ b/persistence-kafka/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/FakeConsumers.scala
@@ -1,0 +1,124 @@
+package com.evolutiongaming.kafka.flow.kafkapersistence
+
+import cats.data.{NonEmptyList, NonEmptyMap, NonEmptySet}
+import cats.effect.{IO, Ref, Resource}
+import cats.syntax.all.*
+import com.evolutiongaming.skafka.*
+import com.evolutiongaming.skafka.consumer.{
+  Consumer as SkafkaConsumer,
+  ConsumerConfig,
+  ConsumerOf,
+  ConsumerRecord,
+  ConsumerRecords,
+  IsolationLevel,
+  RebalanceListener1
+}
+import scodec.bits.ByteVector
+
+import java.util.regex.Pattern
+import scala.concurrent.duration.FiniteDuration
+
+/** Fake consumers for the recovery-read specs, all over one topic-partition `tp`. */
+private[kafkapersistence] final class FakeConsumers(tp: TopicPartition) {
+
+  // dispatches by isolation level: the read consumer for read_committed, the HW consumer for read_uncommitted
+  def consumerOf(
+    readConsumer: SkafkaConsumer[IO, String, ByteVector],
+    hwConsumer: SkafkaConsumer[IO, String, ByteVector],
+  ): ConsumerOf[IO] = new ConsumerOf[IO] {
+    def apply[K, V](
+      config: ConsumerConfig
+    )(implicit fromBytesK: FromBytes[IO, K], fromBytesV: FromBytes[IO, V]) =
+      Resource.pure[IO, SkafkaConsumer[IO, K, V]](
+        (if (config.isolationLevel == IsolationLevel.ReadUncommitted) hwConsumer else readConsumer)
+          .asInstanceOf[SkafkaConsumer[IO, K, V]]
+      )
+  }
+
+  // serves `records` one per poll from `position`, advancing it; on an empty poll it sleeps the poll timeout, as a
+  // real blocking poll would - under TestControl each sleep advances virtual time exactly. endOffsets is fixed per
+  // consumer (the isolation-dependent bound) unless an effect is passed (to move it between captures);
+  // `emptyPollsBeforeServe` returns that many empty polls before each record (a slow but progressing read)
+  def consumer(
+    endOffset: Long,
+    positionRef: Ref[IO, Long],
+    records: List[ConsumerRecord[String, ByteVector]],
+  ): SkafkaConsumer[IO, String, ByteVector] =
+    consumer(endOffset.pure[IO], positionRef, records)
+
+  def consumer(
+    endOffset: IO[Long],
+    positionRef: Ref[IO, Long],
+    records: List[ConsumerRecord[String, ByteVector]],
+    emptyPollsBeforeServe: Int = 0,
+  ): SkafkaConsumer[IO, String, ByteVector] =
+    new SkafkaConsumer[IO, String, ByteVector] {
+      private val delegate   = SkafkaConsumer.empty[IO, String, ByteVector]
+      private val emptyPolls = Ref.unsafe[IO, Int](0)
+
+      override def endOffsets(partitions: NonEmptySet[TopicPartition]) =
+        endOffset.map(end => Map(tp -> Offset.unsafe(end)))
+
+      override def position(partition: TopicPartition) = positionRef.get.map(Offset.unsafe(_))
+
+      override def poll(timeout: FiniteDuration) =
+        positionRef.get.flatMap { pos =>
+          records.find(_.offset.value == pos) match {
+            case Some(record) =>
+              emptyPolls.modify { served =>
+                if (served < emptyPollsBeforeServe)
+                  (served + 1, IO.sleep(timeout).as(ConsumerRecords.empty[String, ByteVector]))
+                else
+                  (0, positionRef.set(pos + 1).as(ConsumerRecords(Map(tp -> NonEmptyList.one(record)))))
+              }.flatten
+            case None => IO.sleep(timeout).as(ConsumerRecords.empty[String, ByteVector])
+          }
+        }
+
+      def assign(partitions: NonEmptySet[TopicPartition])                         = delegate.assign(partitions)
+      def assignment                                                              = delegate.assignment
+      def subscribe(topics: NonEmptySet[Topic], listener: RebalanceListener1[IO]) = delegate.subscribe(topics, listener)
+      def subscribe(topics: NonEmptySet[Topic])                                   = delegate.subscribe(topics)
+      def subscribe(pattern: Pattern, listener: RebalanceListener1[IO])   = delegate.subscribe(pattern, listener)
+      def subscribe(pattern: Pattern)                                     = delegate.subscribe(pattern)
+      def subscription                                                    = delegate.subscription
+      def unsubscribe                                                     = delegate.unsubscribe
+      def commit                                                          = delegate.commit
+      def commit(timeout: FiniteDuration)                                 = delegate.commit(timeout)
+      def commit(offsets: NonEmptyMap[TopicPartition, OffsetAndMetadata]) = delegate.commit(offsets)
+      def commit(offsets: NonEmptyMap[TopicPartition, OffsetAndMetadata], timeout: FiniteDuration) =
+        delegate.commit(offsets, timeout)
+      def commitLater                                                          = delegate.commitLater
+      def commitLater(offsets: NonEmptyMap[TopicPartition, OffsetAndMetadata]) = delegate.commitLater(offsets)
+      def seek(partition: TopicPartition, offset: Offset)                      = delegate.seek(partition, offset)
+      def seek(partition: TopicPartition, offsetAndMetadata: OffsetAndMetadata) =
+        delegate.seek(partition, offsetAndMetadata)
+      def seekToBeginning(partitions: NonEmptySet[TopicPartition])     = delegate.seekToBeginning(partitions)
+      def seekToEnd(partitions: NonEmptySet[TopicPartition])           = delegate.seekToEnd(partitions)
+      def position(partition: TopicPartition, timeout: FiniteDuration) = positionRef.get.map(Offset.unsafe(_))
+      def committed(partitions: NonEmptySet[TopicPartition])           = delegate.committed(partitions)
+      def committed(partitions: NonEmptySet[TopicPartition], timeout: FiniteDuration) =
+        delegate.committed(partitions, timeout)
+      def clientInstanceId(timeout: FiniteDuration)         = delegate.clientInstanceId(timeout)
+      def clientMetrics                                     = delegate.clientMetrics
+      def partitions(topic: Topic)                          = delegate.partitions(topic)
+      def partitions(topic: Topic, timeout: FiniteDuration) = delegate.partitions(topic, timeout)
+      def topics                                            = delegate.topics
+      def topics(timeout: FiniteDuration)                   = delegate.topics(timeout)
+      def paused                                            = delegate.paused
+      def pause(partitions: NonEmptySet[TopicPartition])    = delegate.pause(partitions)
+      def resume(partitions: NonEmptySet[TopicPartition])   = delegate.resume(partitions)
+      def offsetsForTimes(timestampsToSearch: Map[TopicPartition, Offset]) =
+        delegate.offsetsForTimes(timestampsToSearch)
+      def offsetsForTimes(timestampsToSearch: Map[TopicPartition, Offset], timeout: FiniteDuration) =
+        delegate.offsetsForTimes(timestampsToSearch, timeout)
+      def beginningOffsets(partitions: NonEmptySet[TopicPartition]) = delegate.beginningOffsets(partitions)
+      def beginningOffsets(partitions: NonEmptySet[TopicPartition], timeout: FiniteDuration) =
+        delegate.beginningOffsets(partitions, timeout)
+      def endOffsets(partitions: NonEmptySet[TopicPartition], timeout: FiniteDuration) = endOffsets(partitions)
+      def currentLag(partition: TopicPartition)                                        = delegate.currentLag(partition)
+      def groupMetadata                                                                = delegate.groupMetadata
+      def enforceRebalance                                                             = delegate.enforceRebalance
+      def wakeup                                                                       = delegate.wakeup
+    }
+}

--- a/persistence-kafka/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/GroupCommitSpec.scala
+++ b/persistence-kafka/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/GroupCommitSpec.scala
@@ -64,7 +64,7 @@ class GroupCommitSpec extends FunSuite {
   private def sentKeys(events: Vector[Event]): List[String] =
     events.collect { case Event.Sent(k) => k }.flatten.toList
 
-  List(1, KafkaSnapshotWriteDatabase.DefaultMaxWritesPerTransaction).foreach { cap =>
+  List(1, KafkaPersistenceModule.TransactionalConfig.DefaultMaxWritesPerTransaction).foreach { cap =>
     test(s"every queued write commits exactly once with its input offset, respecting the cap (cap=$cap)") {
       val keys = (1 to 20).toList.map(i => s"key$i")
       val test = for {

--- a/persistence-kafka/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModuleSpec.scala
+++ b/persistence-kafka/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModuleSpec.scala
@@ -1,0 +1,128 @@
+package com.evolutiongaming.kafka.flow.kafkapersistence
+
+import cats.effect.testkit.TestControl
+import cats.effect.unsafe.implicits.global
+import cats.effect.{IO, Ref, Resource}
+import cats.syntax.all.*
+import com.evolutiongaming.catshelper.LogOf
+import com.evolutiongaming.kafka.flow.PartitionAssignment
+import com.evolutiongaming.skafka.consumer.{
+  AutoOffsetReset,
+  Consumer as SkafkaConsumer,
+  ConsumerConfig,
+  ConsumerGroupMetadata,
+  ConsumerOf,
+  IsolationLevel
+}
+import com.evolutiongaming.skafka.producer.{Producer, ProducerConfig, ProducerOf}
+import com.evolutiongaming.skafka.{CommonConfig, FromBytes, Offset, Partition, TopicPartition}
+import munit.FunSuite
+
+import scala.concurrent.duration.*
+
+/** The transactional module owns the producer settings its design depends on: the stable per-partition
+  * `transactional.id` (a takeover must abort a crashed owner's unfinished transaction) and idempotence - applied over
+  * whatever `producerConfig` carries. Its recovery read is wired `read_committed` from earliest with the configured
+  * deadline enabled.
+  */
+class KafkaPersistenceModuleSpec extends FunSuite {
+
+  implicit val logOf: LogOf[IO] = LogOf.empty[IO]
+
+  // recovery reads lazily (keysOf.all); module acquisition itself must not open a consumer
+  private def unusedConsumerOf: ConsumerOf[IO] = new ConsumerOf[IO] {
+    def apply[K, V](
+      config: ConsumerConfig
+    )(implicit fromBytesK: FromBytes[IO, K], fromBytesV: FromBytes[IO, V]) =
+      Resource.eval(
+        IO.raiseError[SkafkaConsumer[IO, K, V]](new IllegalStateException("consumer opened at acquisition"))
+      )
+  }
+
+  test("the module applies the stable per-partition id, idempotence and the suffixed client id") {
+    val test = for {
+      captured <- Ref.of[IO, Option[ProducerConfig]](none)
+      producerOf = new ProducerOf[IO] {
+        def apply(config: ProducerConfig): Resource[IO, Producer[IO]] =
+          Resource.eval(captured.set(config.some)).as(Producer.empty[IO])
+      }
+      config = KafkaPersistenceModule.TransactionalConfig(
+        consumerConfig        = ConsumerConfig(),
+        producerConfig        = ProducerConfig(common = CommonConfig(clientId = "client".some)),
+        transactionalIdPrefix = "app",
+        snapshotTopic         = "state-topic",
+      )
+      assignment = PartitionAssignment[IO](
+        topicPartition = TopicPartition("input-topic", Partition.min),
+        assignedAt     = Offset.min,
+        groupMetadata  = IO.pure(none[ConsumerGroupMetadata]),
+      )
+      _ <- KafkaPersistenceModule
+        .cachingTransactional[IO, String](unusedConsumerOf, producerOf, config, assignment)
+        .use_
+      config <- captured.get
+    } yield {
+      val produced = config.getOrElse(fail("no producer was created at module acquisition"))
+      assertEquals(produced.transactionalId, "app-0".some)
+      assertEquals(produced.idempotence, true)
+      assertEquals(produced.common.clientId, "client-snapshot-0".some)
+    }
+    test.unsafeRunSync()
+  }
+
+  test("the module's recovery read is read_committed from earliest, suffixed, and deadline-enabled") {
+    // a parked recovery driven through keysOf.all: the captured configs and the stall error pin the wiring
+    val tp    = TopicPartition("state-topic", Partition.min)
+    val fakes = new FakeConsumers(tp)
+    val test = for {
+      captured    <- Ref.of[IO, List[ConsumerConfig]](Nil)
+      positionRef <- Ref.of[IO, Long](0L)
+      readConsumer = fakes.consumer(endOffset = 1L, positionRef = positionRef, records = Nil)
+      hwConsumer   = fakes.consumer(endOffset = 3L, positionRef = positionRef, records = Nil)
+      inner        = fakes.consumerOf(readConsumer = readConsumer, hwConsumer = hwConsumer)
+      capturingOf = new ConsumerOf[IO] {
+        def apply[K, V](
+          config: ConsumerConfig
+        )(implicit fromBytesK: FromBytes[IO, K], fromBytesV: FromBytes[IO, V]) =
+          Resource.eval(captured.update(_ :+ config)) *> inner(config)
+      }
+      producerOf = new ProducerOf[IO] {
+        def apply(config: ProducerConfig): Resource[IO, Producer[IO]] = Resource.pure(Producer.empty[IO])
+      }
+      result <- KafkaPersistenceModule
+        .cachingTransactional[IO, String](
+          consumerOf = capturingOf,
+          producerOf = producerOf,
+          config = KafkaPersistenceModule.TransactionalConfig(
+            consumerConfig        = ConsumerConfig(common = CommonConfig(clientId = "client".some)),
+            producerConfig        = ProducerConfig(),
+            transactionalIdPrefix = "app",
+            snapshotTopic         = "state-topic",
+            recoveryStallTimeout  = 200.millis,
+          ),
+          assignment = PartitionAssignment[IO](
+            topicPartition = TopicPartition("input-topic", Partition.min),
+            assignedAt     = Offset.min,
+            groupMetadata  = IO.pure(none[ConsumerGroupMetadata]),
+          ),
+        )
+        .use(_.keysOf.all("app", "group", tp).toList.timeout(1.minute))
+        .attempt
+      configs <- captured.get
+    } yield {
+      result match {
+        case Left(_: KafkaPartitionPersistence.RecoveryReadStalledError) => ()
+        case other => fail(s"expected the enabled deadline to fail the parked recovery, got $other")
+      }
+      val read =
+        configs.find(_.common.clientId.contains("client-snapshot-0")).getOrElse(fail(s"no read consumer: $configs"))
+      val hw =
+        configs.find(_.common.clientId.contains("client-snapshot-0-hw")).getOrElse(fail(s"no hw consumer: $configs"))
+      assertEquals(read.isolationLevel, IsolationLevel.ReadCommitted)
+      assertEquals(read.autoOffsetReset, AutoOffsetReset.Earliest)
+      assertEquals(hw.isolationLevel, IsolationLevel.ReadUncommitted)
+    }
+    TestControl.executeEmbed(test).unsafeRunSync()
+  }
+
+}

--- a/persistence-kafka/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModuleSpec.scala
+++ b/persistence-kafka/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModuleSpec.scala
@@ -23,7 +23,8 @@ import scala.concurrent.duration.*
 /** The transactional module owns the producer settings its design depends on: the stable per-partition
   * `transactional.id` (a takeover must abort a crashed owner's unfinished transaction) and idempotence - applied over
   * whatever `producerConfig` carries. Its recovery read is wired `read_committed` from earliest with the configured
-  * deadline enabled.
+  * deadline enabled, and its ephemeral consumers are group-less and never commit offsets - a committed offset would
+  * override the earliest reset on the next recovery.
   */
 class KafkaPersistenceModuleSpec extends FunSuite {
 
@@ -70,7 +71,7 @@ class KafkaPersistenceModuleSpec extends FunSuite {
     test.unsafeRunSync()
   }
 
-  test("the module's recovery read is read_committed from earliest, suffixed, and deadline-enabled") {
+  test("the module's recovery read is read_committed from earliest, suffixed, offsets-neutral, and deadline-enabled") {
     // a parked recovery driven through keysOf.all: the captured configs and the stall error pin the wiring
     val tp    = TopicPartition("state-topic", Partition.min)
     val fakes = new FakeConsumers(tp)
@@ -94,7 +95,13 @@ class KafkaPersistenceModuleSpec extends FunSuite {
           consumerOf = capturingOf,
           producerOf = producerOf,
           config = KafkaPersistenceModule.TransactionalConfig(
-            consumerConfig        = ConsumerConfig(common = CommonConfig(clientId = "client".some)),
+            // the hazardous shape: a group plus auto-commit, which the module must clear on its ephemeral
+            // readers - a committed offset would override the earliest reset on the next recovery
+            consumerConfig = ConsumerConfig(
+              common     = CommonConfig(clientId = "client".some),
+              groupId    = "app-group".some,
+              autoCommit = true,
+            ),
             producerConfig        = ProducerConfig(),
             transactionalIdPrefix = "app",
             snapshotTopic         = "state-topic",
@@ -121,6 +128,10 @@ class KafkaPersistenceModuleSpec extends FunSuite {
       assertEquals(read.isolationLevel, IsolationLevel.ReadCommitted)
       assertEquals(read.autoOffsetReset, AutoOffsetReset.Earliest)
       assertEquals(hw.isolationLevel, IsolationLevel.ReadUncommitted)
+      List(read, hw).foreach { config =>
+        assertEquals(config.groupId, none[String])
+        assertEquals(config.autoCommit, false)
+      }
     }
     TestControl.executeEmbed(test).unsafeRunSync()
   }

--- a/persistence-kafka/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/ReadSnapshotsSpec.scala
+++ b/persistence-kafka/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/ReadSnapshotsSpec.scala
@@ -1,0 +1,313 @@
+package com.evolutiongaming.kafka.flow.kafkapersistence
+
+import cats.effect.testkit.TestControl
+import cats.effect.unsafe.implicits.global
+import cats.effect.{IO, Ref, Resource}
+import cats.syntax.all.*
+import com.evolutiongaming.catshelper.{FromTry, Log}
+import com.evolutiongaming.skafka.*
+import com.evolutiongaming.skafka.consumer.{ConsumerConfig, ConsumerOf, ConsumerRecord, IsolationLevel, WithSize}
+import munit.FunSuite
+import scodec.bits.ByteVector
+
+import java.util.concurrent.TimeoutException
+import scala.concurrent.duration.*
+
+/** Pins the recovery-read behaviour: the target is the high watermark, not the read consumer's own end offset; a read
+  * making no progress for the whole stall deadline (progress resets the clock) fails loudly with a diagnosis, while
+  * without a deadline (the non-transactional read) it keeps waiting.
+  */
+class ReadSnapshotsSpec extends FunSuite {
+
+  implicit val log: Log[IO]         = Log.empty[IO]
+  implicit val fromTry: FromTry[IO] = FromTry.lift
+
+  private val topic     = "state-topic"
+  private val partition = Partition.min
+  private val tp        = TopicPartition(topic, partition)
+
+  private val fakes = new FakeConsumers(tp)
+  import fakes.{consumer, consumerOf}
+
+  private def bytes(value: String): ByteVector = ByteVector.encodeUtf8(value).toOption.get
+
+  private def record(offset: Long, key: String): ConsumerRecord[String, ByteVector] =
+    record(offset, key, s"$key-value".some)
+
+  private def record(offset: Long, key: String, value: Option[String]): ConsumerRecord[String, ByteVector] =
+    ConsumerRecord(
+      topicPartition   = tp,
+      offset           = Offset.unsafe(offset),
+      timestampAndType = none,
+      key              = WithSize(key).some,
+      value            = value.map(v => WithSize(bytes(v))),
+    )
+
+  private def keyless(offset: Long): ConsumerRecord[String, ByteVector] =
+    ConsumerRecord(
+      topicPartition   = tp,
+      offset           = Offset.unsafe(offset),
+      timestampAndType = none,
+      key              = none,
+      value            = WithSize(bytes("ignored")).some,
+    )
+
+  test("a read_committed read drains to the read_uncommitted end offset, not its own") {
+    // The read consumer's own endOffsets is the last-stable-offset, which an open transaction pins below
+    // committed records (here: LSO = 1, records up to the high watermark 5) - a target taken from it
+    // would stop after one record, silently missing the rest. The records past the LSO include a
+    // tombstone for k0 and a keyless record: applied and ignored respectively.
+    val lso           = 1L
+    val highWatermark = 5L
+    val records =
+      List(record(0, "k0"), record(1, "k1"), record(2, "k2"), record(3, "k0", value = none), keyless(4))
+
+    val test = for {
+      positionRef <- Ref.of[IO, Long](0L)
+      readConsumer = consumer(endOffset = lso, positionRef = positionRef, records = records)
+      hwConsumer   = consumer(endOffset = highWatermark, positionRef = positionRef, records = Nil)
+      stored <- KafkaPartitionPersistence.readSnapshots[IO](
+        consumerOf     = consumerOf(readConsumer = readConsumer, hwConsumer = hwConsumer),
+        consumerConfig = ConsumerConfig(isolationLevel = IsolationLevel.ReadCommitted),
+        snapshotTopic  = topic,
+        partition      = partition,
+        stall = KafkaPartitionPersistence
+          .Stall(KafkaPersistenceModule.TransactionalConfig.DefaultRecoveryStallTimeout, IO.monotonic)
+          .some,
+      )
+    } yield assertEquals(
+      stored,
+      Map("k1" -> bytes("k1-value"), "k2" -> bytes("k2-value")),
+      "the read must drain past its own LSO, apply the tombstone and ignore the keyless record",
+    )
+
+    TestControl.executeEmbed(test.timeout(1.minute)).unsafeRunSync()
+  }
+
+  test("a read stalled past the deadline fails loudly instead of hanging") {
+    // The last-stable-offset pins the position at 1 while the high watermark stays 3: an open transaction
+    // outlived the deadline, which the diagnosis must name - the log end still covers the target, so this
+    // is not truncation.
+    val test = for {
+      positionRef <- Ref.of[IO, Long](0L)
+      readConsumer = consumer(endOffset = 1L, positionRef = positionRef, records = List(record(0, "k0")))
+      hwConsumer   = consumer(endOffset = 3L, positionRef = positionRef, records = Nil)
+      result <- KafkaPartitionPersistence
+        .readSnapshots[IO](
+          consumerOf     = consumerOf(readConsumer = readConsumer, hwConsumer = hwConsumer),
+          consumerConfig = ConsumerConfig(isolationLevel = IsolationLevel.ReadCommitted),
+          snapshotTopic  = topic,
+          partition      = partition,
+          stall          = KafkaPartitionPersistence.Stall(200.millis, IO.monotonic).some,
+        )
+        .attempt
+    } yield result match {
+      case Left(e: KafkaPartitionPersistence.RecoveryReadStalledError) =>
+        assertEquals(e.position, Offset.unsafe(1))
+        assertEquals(e.targetOffset, Offset.unsafe(3))
+        assert(e.diagnosis.contains("open transaction"), s"unexpected diagnosis: ${e.diagnosis}")
+      case other => fail(s"expected RecoveryReadStalledError, got $other")
+    }
+
+    TestControl.executeEmbed(test.timeout(1.minute)).unsafeRunSync()
+  }
+
+  test("a read stalled past the deadline with a regressed log end is diagnosed as truncation") {
+    // The high watermark is 3 at capture but 1 when the deadline fires (the log was truncated in
+    // between): the diagnosis must name truncation.
+    val test = for {
+      positionRef <- Ref.of[IO, Long](0L)
+      hwRef       <- Ref.of[IO, Long](3L)
+      readConsumer = consumer(endOffset = 1L, positionRef = positionRef, records = List(record(0, "k0")))
+      hwConsumer   = consumer(endOffset = hwRef.getAndSet(1L), positionRef = positionRef, records = Nil)
+      result <- KafkaPartitionPersistence
+        .readSnapshots[IO](
+          consumerOf     = consumerOf(readConsumer = readConsumer, hwConsumer = hwConsumer),
+          consumerConfig = ConsumerConfig(isolationLevel = IsolationLevel.ReadCommitted),
+          snapshotTopic  = topic,
+          partition      = partition,
+          stall          = KafkaPartitionPersistence.Stall(200.millis, IO.monotonic).some,
+        )
+        .attempt
+    } yield result match {
+      case Left(e: KafkaPartitionPersistence.RecoveryReadStalledError) =>
+        assert(e.diagnosis.contains("log truncation"), s"unexpected diagnosis: ${e.diagnosis}")
+      case other => fail(s"expected RecoveryReadStalledError, got $other")
+    }
+
+    TestControl.executeEmbed(test.timeout(1.minute)).unsafeRunSync()
+  }
+
+  test("a slow but progressing read outlives the deadline without failing") {
+    // progress resets the stall clock, so the deadline caps the longest stall, not the whole read: every stall
+    // is exactly 90ms (nine 10ms empty polls per record), under the 300ms deadline, while the whole read takes
+    // 720ms - over it
+    val records = (0L until 8L).toList.map(i => record(i, s"k$i"))
+    val test = for {
+      positionRef <- Ref.of[IO, Long](0L)
+      readConsumer =
+        consumer(endOffset = 8L.pure[IO], positionRef = positionRef, records = records, emptyPollsBeforeServe = 9)
+      stored <- KafkaPartitionPersistence.readSnapshots[IO](
+        // the same fake serves both views: equal bounds, no pin
+        consumerOf     = consumerOf(readConsumer = readConsumer, hwConsumer = readConsumer),
+        consumerConfig = ConsumerConfig(isolationLevel = IsolationLevel.ReadCommitted),
+        snapshotTopic  = topic,
+        partition      = partition,
+        stall          = KafkaPartitionPersistence.Stall(300.millis, IO.monotonic).some,
+      )
+    } yield assertEquals(stored.keys.toList.sorted, (0 until 8).map(i => s"k$i").toList)
+
+    TestControl.executeEmbed(test.timeout(1.minute)).unsafeRunSync()
+  }
+
+  test("a stalled read whose diagnosis re-read fails still fails as a stall, cause undetermined") {
+    // the diagnosis is best-effort: a failing high-watermark re-read must not mask the stall error
+    val test = for {
+      positionRef <- Ref.of[IO, Long](0L)
+      hwCalls     <- Ref.of[IO, Int](0)
+      readConsumer = consumer(endOffset = 1L, positionRef = positionRef, records = List(record(0, "k0")))
+      hwEndOffset = hwCalls.getAndUpdate(_ + 1).flatMap {
+        case 0 => 3L.pure[IO]
+        case _ => IO.raiseError[Long](new RuntimeException("hw re-read failed"))
+      }
+      hwConsumer = consumer(hwEndOffset, positionRef, Nil)
+      result <- KafkaPartitionPersistence
+        .readSnapshots[IO](
+          consumerOf     = consumerOf(readConsumer = readConsumer, hwConsumer = hwConsumer),
+          consumerConfig = ConsumerConfig(isolationLevel = IsolationLevel.ReadCommitted),
+          snapshotTopic  = topic,
+          partition      = partition,
+          stall          = KafkaPartitionPersistence.Stall(200.millis, IO.monotonic).some,
+        )
+        .attempt
+    } yield result match {
+      case Left(e: KafkaPartitionPersistence.RecoveryReadStalledError) =>
+        assert(e.diagnosis.contains("could not be determined"), s"unexpected diagnosis: ${e.diagnosis}")
+      case other => fail(s"expected RecoveryReadStalledError, got $other")
+    }
+
+    TestControl.executeEmbed(test.timeout(1.minute)).unsafeRunSync()
+  }
+
+  test("a stalled read logs its lack of progress every 5s until the deadline") {
+    // the throttled "no progress" lines make a stuck recovery visible long before the deadline: with a 12s
+    // deadline they land at exactly 5s and 10s of stall, then the read fails
+    val test = for {
+      logged      <- Ref.of[IO, List[String]](Nil)
+      positionRef <- Ref.of[IO, Long](0L)
+      readConsumer = consumer(endOffset = 1L, positionRef = positionRef, records = List(record(0, "k0")))
+      hwConsumer   = consumer(endOffset = 3L, positionRef = positionRef, records = Nil)
+      result <- {
+        implicit val log: Log[IO] = recordingLog(logged)
+        KafkaPartitionPersistence
+          .readSnapshots[IO](
+            consumerOf     = consumerOf(readConsumer = readConsumer, hwConsumer = hwConsumer),
+            consumerConfig = ConsumerConfig(isolationLevel = IsolationLevel.ReadCommitted),
+            snapshotTopic  = topic,
+            partition      = partition,
+            stall          = KafkaPartitionPersistence.Stall(12.seconds, IO.monotonic).some,
+          )
+          .attempt
+      }
+      lines <- logged.get
+    } yield {
+      assert(result.isLeft, s"expected the stalled read to fail, got $result")
+      val stallLines = lines.filter(_.contains("making no progress"))
+      assertEquals(stallLines.size, 2, s"expected two throttled stall lines, got: $stallLines")
+      assert(stallLines.exists(_.contains("stalled for 5s")), s"missing the 5s line: $stallLines")
+      assert(stallLines.exists(_.contains("stalled for 10s")), s"missing the 10s line: $stallLines")
+    }
+
+    TestControl.executeEmbed(test.timeout(1.minute)).unsafeRunSync()
+  }
+
+  test("recovery warns about the wait when the target sits above the last-stable-offset") {
+    // the wait names its cause up front: one warn at read start when an open transaction pins the LSO below
+    // the captured target, none when the two bounds agree
+    def read(lso: Long, logged: Ref[IO, List[String]]): IO[Unit] = for {
+      positionRef <- Ref.of[IO, Long](0L)
+      records      = List(record(0, "k0"), record(1, "k1"), record(2, "k2"))
+      readConsumer = consumer(endOffset = lso, positionRef = positionRef, records = records)
+      hwConsumer   = consumer(endOffset = 3L, positionRef = positionRef, records = Nil)
+      _ <- {
+        implicit val log: Log[IO] = recordingLog(logged)
+        KafkaPartitionPersistence.readSnapshots[IO](
+          consumerOf     = consumerOf(readConsumer = readConsumer, hwConsumer = hwConsumer),
+          consumerConfig = ConsumerConfig(isolationLevel = IsolationLevel.ReadCommitted),
+          snapshotTopic  = topic,
+          partition      = partition,
+          stall = KafkaPartitionPersistence
+            .Stall(KafkaPersistenceModule.TransactionalConfig.DefaultRecoveryStallTimeout, IO.monotonic)
+            .some,
+        )
+      }
+    } yield ()
+
+    val test = for {
+      logged   <- Ref.of[IO, List[String]](Nil)
+      _        <- read(lso = 1L, logged = logged)
+      pinned   <- logged.getAndSet(Nil)
+      _        <- read(lso = 3L, logged = logged)
+      unpinned <- logged.get
+    } yield {
+      val warns = pinned.filter(_.contains("recovery waits for open transaction(s)"))
+      assertEquals(warns.size, 1, s"expected one wait warn, got: $pinned")
+      assert(
+        warns.head.contains(s"last-stable-offset ${Offset.unsafe(1)} below captured target ${Offset.unsafe(3)}"),
+        s"unexpected wait warn: $warns",
+      )
+      assert(!unpinned.exists(_.contains("recovery waits")), s"unexpected wait warn without a pin: $unpinned")
+    }
+
+    TestControl.executeEmbed(test.timeout(1.minute)).unsafeRunSync()
+  }
+
+  test("with no deadline a stalled read keeps waiting, and read_uncommitted opens no capture consumer") {
+    // the plain caching shape through readSnapshots: the None dispatch takes the unbounded drain - still
+    // polling a virtual minute in - and under read_uncommitted the consumer's own end offset already is the
+    // target, so exactly one consumer is opened
+    val test = for {
+      created     <- Ref.of[IO, Int](0)
+      positionRef <- Ref.of[IO, Long](0L)
+      readConsumer = consumer(endOffset = 3L, positionRef = positionRef, records = List(record(0, "k0")))
+      inner        = consumerOf(readConsumer = readConsumer, hwConsumer = readConsumer)
+      countingOf = new ConsumerOf[IO] {
+        def apply[K, V](
+          config: ConsumerConfig
+        )(implicit fromBytesK: FromBytes[IO, K], fromBytesV: FromBytes[IO, V]) =
+          Resource.eval(created.update(_ + 1)) *> inner(config)
+      }
+      result <- KafkaPartitionPersistence
+        .readSnapshots[IO](
+          consumerOf     = countingOf,
+          consumerConfig = ConsumerConfig(),
+          snapshotTopic  = topic,
+          partition      = partition,
+          stall          = none,
+        )
+        .timeout(1.minute)
+        .attempt
+      n <- created.get
+    } yield {
+      result match {
+        case Left(_: TimeoutException) => () // timed out by the outer hour while still polling - it kept waiting
+        case other                     => fail(s"expected the read to keep waiting, got $other")
+      }
+      assertEquals(n, 1, "read_uncommitted must not open a capture consumer")
+    }
+
+    TestControl.executeEmbed(test).unsafeRunSync()
+  }
+
+  // captures info and warn lines - the levels the read logs at
+  private def recordingLog(lines: Ref[IO, List[String]]): Log[IO] = new Log[IO] {
+    def trace(msg: => String, mdc: Log.Mdc)                   = IO.unit
+    def debug(msg: => String, mdc: Log.Mdc)                   = IO.unit
+    def info(msg: => String, mdc: Log.Mdc)                    = lines.update(_ :+ msg)
+    def warn(msg: => String, mdc: Log.Mdc)                    = lines.update(_ :+ msg)
+    def warn(msg: => String, cause: Throwable, mdc: Log.Mdc)  = lines.update(_ :+ msg)
+    def error(msg: => String, mdc: Log.Mdc)                   = IO.unit
+    def error(msg: => String, cause: Throwable, mdc: Log.Mdc) = IO.unit
+  }
+
+}


### PR DESCRIPTION
Transactional snapshot recovery had two gaps, surfaced by the research linked below; both are closed here, with the mechanism documented in the included design doc.

**The silent miss ([#850](https://github.com/evolution-gaming/kafka-flow/issues/850)).** Under `read_committed` the read stopped at the last-stable-offset, so an open transaction pinned it below newer committed snapshots: recovery returned incomplete state, and a second handover resumed from the newer committed offset over the stale state — the corruption shape of [#732](https://github.com/evolution-gaming/kafka-flow/issues/732), with no fence violated. The read now targets the high watermark (captured up front through a short-lived `read_uncommitted` consumer) and waits out open transactions below it — the shape Kafka Streams' exactly-once restore settled on ([KAFKA-10167](https://issues.apache.org/jira/browse/KAFKA-10167)). A stable per-partition `transactional.id` keeps the wait sub-second (a takeover's `initTransactions` aborts a crashed predecessor's transaction); fencing deliberately stays with the consumer generation, so completeness rests on the read bound, never on naming.

**The silent hang ([#849](https://github.com/evolution-gaming/kafka-flow/issues/849)).** Truncation (the log end regressing below the captured target) or a hanging transaction ([KIP-664](https://cwiki.apache.org/confluence/display/KAFKA/KIP-664%3A+Provide+tooling+to+detect+and+abort+hanging+transactions) detects and aborts these; [KIP-890](https://cwiki.apache.org/confluence/display/KAFKA/KIP-890%3A+Transactions+Server-Side+Defense) brokers prevent them) could keep the read from its target forever — on the poll thread, so `max.poll.interval.ms` evicted the member silently. A no-progress deadline (default 3 minutes, reset by every position advance) fails the read with `RecoveryReadStalledError` instead, diagnosed against a re-read log end (truncation versus a transaction that outlived the deadline — opposite operator responses), and the restarted recovery captures a fresh target.

**Follow-up commit.** A post-merge adversarial review found the ephemeral recovery consumers inheriting the caller's `groupId` and `autoCommit` (on by default in skafka): a committed offset from a prior read pre-empts the `earliest` reset and silently truncates the next recovery. Pre-existing since the first snapshot-recovery read; both fields are now forced off at the shared chokepoint, and the module spec seeds the hazardous shape and asserts both consumers come out cleared.

**Review aid.** The recovery read under stall on one page — the poll loop's advancing/waiting turns, the four scenarios, the verbatim log lines; kept outside the PR:

![Recovery-read stall cheat sheet](https://raw.githubusercontent.com/tobiajo/kafka-flow/tj/recovery-stall-cheatsheet/recovery-stall-cheatsheet/recovery-stall-cheatsheet.png)

**Backing research.** Worked out in the [research corpus](https://github.com/tobiajo/kafka-flow/tree/tj/address-partition-ownership-overlap-possiblity-models/research) ([#835](https://github.com/evolution-gaming/kafka-flow/pull/835)) — requirements register, TLA+ models of the read bound and the stall deadline, the remedy decision, the follow-up as finding F-12. The checked-in material stands alone and does not reference it.