### PR TITLE
Drop the duplicate GitHub "Star" footer link

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -113,10 +113,6 @@ const config = {
                 label: "GitHub",
                 href: "https://github.com/evolution-gaming/kafka-flow",
               },
-              {
-                label: "Star",
-                href: "https://github.com/evolution-gaming/kafka-flow/stargazers",
-              },
             ],
           },
         ],


### PR DESCRIPTION
Fixes mistake from the D1 to D3 migration.