### PR TITLE
Mark the snapshot writer's transactional.id as such

### DIFF
--- a/docs/kafka-single-writer-design.md
+++ b/docs/kafka-single-writer-design.md
@@ -157,10 +157,11 @@ default timeout.
 
 ### Stable transactional.id: the takeover aborts unfinished transactions
 
-Each partition's producer uses a **stable** `transactional.id`, `"<prefix>-snapshot-<partition>"` — a scheme
-whose cost, a producer per partition, this mode pays anyway. Every owner of a partition shares its
-id, so a new owner's mandatory `initTransactions` fences the previous owner's producer and aborts
-any transaction it left open, before the new owner may write.
+Each partition's producer uses a **stable** `transactional.id`, derived from the configured prefix
+and the partition, with nothing per-assignment in it — a scheme whose cost, a producer per
+partition, this mode pays anyway. Every owner of a partition shares its id, so a new owner's
+mandatory `initTransactions` fences the previous owner's producer and aborts any transaction it
+left open, before the new owner may write.
 
 Sharing the id serializes the partition's own writes: a committed snapshot never sits above an open
 transaction of the same id, so the recovery read's wait (previous section) never engages for the
@@ -372,10 +373,10 @@ real broker:
   (Write path, above); asserted safe for distinct keys.
 - **Unfinished transactions, both resolutions** — the takeover-abort at the handover: the
   last-stable-offset is back at the high watermark immediately after module acquisition, a state
-  only the abort produces, never the broker's timeout; the same test pins the
-  `"<prefix>-snapshot-<partition>"` id shape. And the wait for a transaction no takeover aborts (Recovery
-  read, above): a foreign transaction held open through the read, its LSO pin asserted active, then
-  waited out under a deadline set above the wait — the read completes, the deadline never fires.
+  only the abort produces, never the broker's timeout; the same test pins the id shape. And the
+  wait for a transaction no takeover aborts (Recovery read, above): a foreign transaction held
+  open through the read, its LSO pin asserted active, then waited out under a deadline set above
+  the wait — the read completes, the deadline never fires.
 
 The suites drive flows with explicit consumer generations rather than live rebalances; the
 protocol/assignor matrix (Consumer rebalance protocols, above) rests on broker semantics, not on
@@ -413,13 +414,13 @@ Unit suites pin the client-side pieces the mechanism depends on:
 - **Producer-epoch order as the fence**: epoch order can diverge from ownership order, spuriously
   fencing the true owner — the stable id is kept for the takeover-abort, never as the fence (see
   Stable transactional.id).
-- **Unique per-assignment `transactional.id`s** (`"<prefix>-snapshot-<partition>-<uuid>"`): with no shared
-  id a late-initing stale owner cannot win the epoch and spuriously fence the valid owner (see
-  Stable transactional.id) — but nothing ever aborts a crashed owner's unfinished transaction, so
-  every post-crash recovery waits out the full transaction timeout the stable id resolves at init,
-  and coordinator state accumulates per assignment until `transactional.id.expiration.ms`. Either
-  choice is sound (the read bound holds under both); the sub-second takeover was judged worth the
-  spurious-fence cost.
+- **Unique per-assignment `transactional.id`s** (the per-partition id plus a unique suffix): with
+  no shared id a late-initing stale owner cannot win the epoch and spuriously fence the valid
+  owner (see Stable transactional.id) — but nothing ever aborts a crashed owner's unfinished
+  transaction, so every post-crash recovery waits out the full transaction timeout the stable id
+  resolves at init, and coordinator state accumulates per assignment until
+  `transactional.id.expiration.ms`. Either choice is sound (the read bound holds under both); the
+  sub-second takeover was judged worth the spurious-fence cost.
 - **Static partition assignment** (`assign()` instead of `subscribe()`): no consumer group, so no
   rebalance, no overlap window, no fence needed — but it gives up automatic failover and elastic
   reassignment, and safe *dynamic* assignment is the point of this design. (Static *membership*

--- a/docs/kafka-single-writer-design.md
+++ b/docs/kafka-single-writer-design.md
@@ -413,7 +413,7 @@ Unit suites pin the client-side pieces the mechanism depends on:
 - **Producer-epoch order as the fence**: epoch order can diverge from ownership order, spuriously
   fencing the true owner — the stable id is kept for the takeover-abort, never as the fence (see
   Stable transactional.id).
-- **Unique per-assignment `transactional.id`s** (`"<prefix>-snapshot-<partition>-<uuid8>"`): with no shared
+- **Unique per-assignment `transactional.id`s** (`"<prefix>-snapshot-<partition>-<uuid>"`): with no shared
   id a late-initing stale owner cannot win the epoch and spuriously fence the valid owner (see
   Stable transactional.id) — but nothing ever aborts a crashed owner's unfinished transaction, so
   every post-crash recovery waits out the full transaction timeout the stable id resolves at init,

--- a/docs/kafka-single-writer-design.md
+++ b/docs/kafka-single-writer-design.md
@@ -157,7 +157,7 @@ default timeout.
 
 ### Stable transactional.id: the takeover aborts unfinished transactions
 
-Each partition's producer uses a **stable** `transactional.id`, `"<prefix>-<partition>"` — a scheme
+Each partition's producer uses a **stable** `transactional.id`, `"<prefix>-snapshot-<partition>"` — a scheme
 whose cost, a producer per partition, this mode pays anyway. Every owner of a partition shares its
 id, so a new owner's mandatory `initTransactions` fences the previous owner's producer and aborts
 any transaction it left open, before the new owner may write.
@@ -373,7 +373,7 @@ real broker:
 - **Unfinished transactions, both resolutions** — the takeover-abort at the handover: the
   last-stable-offset is back at the high watermark immediately after module acquisition, a state
   only the abort produces, never the broker's timeout; the same test pins the
-  `"<prefix>-<partition>"` id shape. And the wait for a transaction no takeover aborts (Recovery
+  `"<prefix>-snapshot-<partition>"` id shape. And the wait for a transaction no takeover aborts (Recovery
   read, above): a foreign transaction held open through the read, its LSO pin asserted active, then
   waited out under a deadline set above the wait — the read completes, the deadline never fires.
 
@@ -413,7 +413,7 @@ Unit suites pin the client-side pieces the mechanism depends on:
 - **Producer-epoch order as the fence**: epoch order can diverge from ownership order, spuriously
   fencing the true owner — the stable id is kept for the takeover-abort, never as the fence (see
   Stable transactional.id).
-- **Unique per-assignment `transactional.id`s** (`"<prefix>-<partition>-<uuid8>"`): with no shared
+- **Unique per-assignment `transactional.id`s** (`"<prefix>-snapshot-<partition>-<uuid8>"`): with no shared
   id a late-initing stale owner cannot win the epoch and spuriously fence the valid owner (see
   Stable transactional.id) — but nothing ever aborts a crashed owner's unfinished transaction, so
   every post-crash recovery waits out the full transaction timeout the stable id resolves at init,

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -92,7 +92,7 @@ val moduleOf = KafkaPersistenceModuleOf.cachingTransactional[F, State](
 `idempotence` and the per-partition `transactional.id` are set for you — don't configure them in
 `producerConfig` — and the snapshot `consumerConfig` is forced to `read_committed`, with `groupId`
 cleared and `autoCommit` off: the recovery readers never join a group or commit offsets.
-The id is stable per partition (`"<prefix>-<partition>"`): every owner of a partition shares it, so a
+The id is stable per partition (`"<prefix>-snapshot-<partition>"`): every owner of a partition shares it, so a
 takeover's `initTransactions` fences the previous owner's producer and aborts any transaction it left
 open. The input topic whose offsets are committed transactionally, and the consumer generation used
 to fence stale writers, are both supplied

--- a/persistence-kafka-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/TransactionalKafkaPersistenceSpec.scala
+++ b/persistence-kafka-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/TransactionalKafkaPersistenceSpec.scala
@@ -487,7 +487,7 @@ class TransactionalKafkaPersistenceSpec extends ForAllKafkaSuite {
   test("a takeover aborts the crashed owner's unfinished transaction (stable transactional.id)") {
     // The crashed producer's transaction.timeout.ms is deliberately long (10 minutes): the
     // last-stable-offset can be back at the high watermark right after module acquisition only through
-    // the takeover-abort of the stable "<prefix>-<partition>" id, never the broker's timeout - a
+    // the takeover-abort of the stable "<prefix>-snapshot-<partition>" id, never the broker's timeout - a
     // unique-suffix id would leave the transaction open and fail the assertion.
     val stateTopic = "tx-takeover-abort-state-topic"
     val inputTopic = s"input-$stateTopic"
@@ -503,7 +503,7 @@ class TransactionalKafkaPersistenceSpec extends ForAllKafkaSuite {
     val crashedProducer =
       producerOf(
         producerConfig.copy(
-          transactionalId    = s"$appId-${Partition.min.value}".some,
+          transactionalId    = s"$appId-snapshot-${Partition.min.value}".some,
           idempotence        = true,
           transactionTimeout = 10.minutes,
         )

--- a/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModule.scala
+++ b/persistence-kafka/src/main/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModule.scala
@@ -44,7 +44,7 @@ object KafkaPersistenceModule {
     *   base config for the snapshot producer; `transactionalId` and `idempotence` are overridden per producer and
     *   `clientId` is suffixed with `-snapshot-<partition>`
     * @param transactionalIdPrefix
-    *   prefix for `transactional.id` (the partition number is appended; stable per partition). It does not affect
+    *   prefix for `transactional.id` (suffixed `-snapshot-<partition>`; stable per partition). It does not affect
     *   fencing of stale writers (that is by consumer generation) - it is a readable label and, on an ACL-secured
     *   cluster, the `transactional.id` prefix the producer principal must be authorized for. Because the id is stable
     *   per partition, the prefix must be unique per flow: use your `applicationId`, and an application running several
@@ -228,7 +228,7 @@ object KafkaPersistenceModule {
     import assignment.{assignedAt, groupMetadata, topicPartition as inputTopicPartition}
 
     val partition       = inputTopicPartition.partition
-    val transactionalId = s"$transactionalIdPrefix-${partition.value}"
+    val transactionalId = s"$transactionalIdPrefix-snapshot-${partition.value}"
     val transactionalProducerConfig = producerConfig.copy(
       transactionalId = transactionalId.some,
       idempotence     = true,

--- a/persistence-kafka/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModuleSpec.scala
+++ b/persistence-kafka/src/test/scala/com/evolutiongaming/kafka/flow/kafkapersistence/KafkaPersistenceModuleSpec.scala
@@ -64,7 +64,7 @@ class KafkaPersistenceModuleSpec extends FunSuite {
       config <- captured.get
     } yield {
       val produced = config.getOrElse(fail("no producer was created at module acquisition"))
-      assertEquals(produced.transactionalId, "app-0".some)
+      assertEquals(produced.transactionalId, "app-snapshot-0".some)
       assertEquals(produced.idempotence, true)
       assertEquals(produced.common.clientId, "client-snapshot-0".some)
     }


### PR DESCRIPTION
Makes the snapshot writer's `transactional.id` self-describing: `<prefix>-snapshot-<partition>`.

- With no `clientId` configured (the default) the `transactional.id` is the producer's only operator-visible label.
- When recovery is blocked on an open transaction, the id tells you whose it is: `myapp-snapshot-3` is the snapshot writer's own, a bare `myapp-3` could be any producer.
- The recommended prefix is the application id, so a bare `myapp-3` is exactly what an application's own transactional producer would pick — and producers sharing an id fence each other.
- Matches the `client.id` and recovery-consumer suffixes.

`cachingTransactional` is still marked EXPERIMENTAL, hence the id change without a migration path.
