### PR TITLE
Honour persistEvery in TimerFlowOf#persistPeriodicallyAndUnloadOrphaned

### DIFF
--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/timer/TimerFlowOf.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/timer/TimerFlowOf.scala
@@ -177,6 +177,7 @@ object TimerFlowOf {
         def onTimer: F[Unit] = for {
           current         <- timers.current
           processedAt     <- timers.processedAt
+          persistedAt     <- timers.persistedAt
           touchedAt        = processedAt getOrElse committedAt
           expiredAt        = touchedAt.clock plusMillis maxIdle.toMillis
           offsetDifference = current.offset.value - touchedAt.offset.value

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/timer/TimerFlowOfSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/timer/TimerFlowOfSpec.scala
@@ -380,6 +380,64 @@ class TimerFlowOfSpec extends FunSuite {
 
   }
 
+  /** Ticks the clock forward one minute at a time, triggering the timers on every tick and never processing a record,
+    * and returns how many times the state was flushed.
+    *
+    * A key that is never touched keeps its offset, so `maxOffsetDifference` cannot cause a flush here: whatever flushes
+    * happen are driven by `persistEvery` alone.
+    */
+  private def flushesOverMinutes(flowOf: TimerFlowOf[IO], minutes: Int): IO[Int] = {
+    val f       = new ConstFixture
+    val startAt = f.timestamp.clock
+
+    def tick(flow: TimerFlow[IO], minute: Int) =
+      f.timerContext.set(f.timestamp.copy(clock = startAt.plusSeconds(minute * 60L))) *>
+        f.timerContext.trigger(flow)
+
+    flowOf(f.keyContext, f.flushBuffers, f.timerContext)
+      .use(flow => (1 to minutes).toList.traverse_(minute => tick(flow, minute)))
+      .flatMap(_ => f.contextRef.get.map(_.flushed))
+  }
+
+  /** Both flows that honour `persistEvery`, fired every minute, with unloading kept out of the way */
+  private def flowsFiringEveryMinute(persistEvery: FiniteDuration): List[(String, TimerFlowOf[IO])] = List(
+    "persistPeriodically" -> TimerFlowOf.persistPeriodically[IO](
+      fireEvery    = 1.minute,
+      persistEvery = persistEvery
+    ),
+    "persistPeriodicallyAndUnloadOrphaned" -> TimerFlowOf.persistPeriodicallyAndUnloadOrphaned[IO](
+      fireEvery    = 1.minute,
+      persistEvery = persistEvery,
+      maxIdle      = 1.hour
+    )
+  )
+
+  test(
+    "persistPeriodically and persistPeriodicallyAndUnloadOrphaned flush every minute when persistEvery = fireEvery"
+  ) {
+
+    // Given("flows that fire every minute and persist every minute")
+    // When("timers are triggered once a minute for six minutes")
+    flowsFiringEveryMinute(persistEvery = 1.minute) foreach {
+      case (name, flowOf) =>
+        // Then("the state is flushed on every trigger")
+        assertEquals(flushesOverMinutes(flowOf, minutes = 6).unsafeRunSync(), 6, name)
+    }
+
+  }
+
+  test("persistPeriodically and persistPeriodicallyAndUnloadOrphaned flush every persistEvery, not every fireEvery") {
+
+    // Given("flows that fire every minute but are only supposed to persist every three minutes")
+    // When("timers are triggered once a minute for six minutes")
+    flowsFiringEveryMinute(persistEvery = 3.minutes) foreach {
+      case (name, flowOf) =>
+        // Then("the state is flushed twice: at the third and at the sixth minute")
+        assertEquals(flushesOverMinutes(flowOf, minutes = 6).unsafeRunSync(), 2, name)
+    }
+
+  }
+
   test("persistPeriodically flushes when resource is cancelled if configured to do so") {
 
     val f = new ConstFixture


### PR DESCRIPTION
## Disclaimer
This was made with AI but manually verified by me

## Problem

`TimerFlowOf.persistPeriodicallyAndUnloadOrphaned` ignores `persistEvery` after the first flush: from then on it flushes on *every* timer fire, i.e. at the `fireEvery` rate. With `fireEvery = 1.minute, persistEvery = 15.minutes` that's 15x the intended writes per key, indefinitely. `persistPeriodically` is not affected.

## Root cause

`onTimer` read `persistedAt` from the enclosing `acquire` binding instead of re-reading it:

```scala
persistedAt <- timers.persistedAt              // L172: evaluated once, at key creation
committedAt  = persistedAt getOrElse current
...
  def onTimer: F[Unit] = for {
    current         <- timers.current          // re-read
    processedAt     <- timers.processedAt      // re-read
    flushedAt        = persistedAt getOrElse committedAt   // stale capture
    triggerFlushAt   = flushedAt.clock plusMillis persistEvery.toMillis
```

`persistedAt` is `None` at `acquire` time in every built-in wiring (`Persistence.read` runs later, inside `KeyFlow.of`), so `flushedAt` was pinned to the key's creation time, `triggerFlushAt` never moved, and `canPersist` stayed `true` after the first flush.

## Fix

One line — re-read `persistedAt` inside `onTimer`, exactly as `persistPeriodically` already does (`TimerFlowOf.scala:119`):

```diff
       def onTimer: F[Unit] = for {
         current         <- timers.current
         processedAt     <- timers.processedAt
+        persistedAt     <- timers.persistedAt
         touchedAt        = processedAt getOrElse committedAt
```

## Tests

Existing coverage missed this because `"persistPeriodically flushes correct number of times"` only exercises `persistEvery == fireEvery`, where the correct and the buggy behaviour give the same flush count.

Added two tests running both flows through the same program — six one-minute ticks, no records processed, so `persistEvery` is the only thing that can drive a flush:

| case | before | after |
|---|---|---|
| `persistEvery = fireEvery = 1.minute` | 6 flushes | 6 flushes |
| `fireEvery = 1.minute, persistEvery = 3.minutes` | **4 flushes** (minutes 3, 4, 5, 6) | 2 flushes (minutes 3 and 6) |

`persistPeriodically` returns 6 and 2 in both columns. The equal-intervals case is included to pin the behaviour that already worked and to document the coverage gap.

`core` 89/89, `journal` 6/6, `metrics` 5/5, `persistence-cassandra` 19/19, `persistence-kafka` 19/19.
