### PR TITLE
Update scassandra to 5.6.0

### DIFF
--- a/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/CassandraSessionStub.scala
+++ b/persistence-cassandra-it-tests/src/test/scala/com/evolutiongaming/kafka/flow/CassandraSessionStub.scala
@@ -6,6 +6,8 @@ import cats.syntax.all.*
 import com.datastax.driver.core.{Host, PreparedStatement, RegularStatement, ResultSet, Statement}
 import com.evolutiongaming.scassandra.CassandraSession
 
+import scala.annotation.nowarn
+
 object CassandraSessionStub {
   // Doesn't inject failures on statements preparation since we don't prepare them on each call.
   def injectFailures[F[_]](
@@ -39,11 +41,21 @@ object CassandraSessionStub {
     override def prepare(statement: RegularStatement): F[PreparedStatement] =
       session.prepare(statement)
 
+    override def stateSnapshot: F[CassandraSession.StateSnapshot] = F.pure {
+      new CassandraSession.StateSnapshot {
+        override def connectedHosts: Iterable[Host]      = Iterable.empty
+        override def openConnections(host: Host): Int    = 0
+        override def trashedConnections(host: Host): Int = 0
+        override def inFlightQueries(host: Host): Int    = 0
+      }
+    }
+
+    @nowarn("cat=deprecation")
     override def state: CassandraSession.State[F] = new CassandraSession.State[F] {
-      override def connectedHosts: F[Iterable[Host]]      = F.pure(Iterable.empty)
-      override def openConnections(host: Host): F[Int]    = F.pure(0)
-      override def trashedConnections(host: Host): F[Int] = F.pure(0)
-      override def inFlightQueries(host: Host): F[Int]    = F.pure(0)
+      override def connectedHosts: F[Iterable[Host]]      = stateSnapshot.map(_.connectedHosts)
+      override def openConnections(host: Host): F[Int]    = stateSnapshot.map(_.openConnections(host))
+      override def trashedConnections(host: Host): F[Int] = stateSnapshot.map(_.trashedConnections(host))
+      override def inFlightQueries(host: Host): F[Int]    = stateSnapshot.map(_.inFlightQueries(host))
     }
 
   }

--- a/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/SessionHelper.scala
+++ b/persistence-cassandra/src/main/scala/com/evolutiongaming/kafka/flow/cassandra/SessionHelper.scala
@@ -9,6 +9,8 @@ import com.evolution.scache.Cache
 import com.evolutiongaming.catshelper.Runtime
 import com.evolutiongaming.scassandra.{CassandraSession, NextHostRetryPolicy}
 
+import scala.annotation.nowarn
+
 object SessionHelper {
   implicit final class SessionOps[F[_]](val self: CassandraSession[F]) extends AnyVal {
     def enhanceError(implicit F: MonadThrow[F]): CassandraSession[F] = {
@@ -73,6 +75,9 @@ object SessionHelper {
     def execute(statement: Statement): F[ResultSet]                       = self.execute(statement)
     def prepare(query: String): F[PreparedStatement]                      = self.prepare(query)
     def prepare(statement: RegularStatement): F[PreparedStatement]        = self.prepare(statement)
-    def state: CassandraSession.State[F]                                  = self.state
+    override def stateSnapshot: F[CassandraSession.StateSnapshot]         = self.stateSnapshot
+
+    @nowarn("cat=deprecation")
+    def state: CassandraSession.State[F] = self.state
   }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   val scache            = "com.evolution"       %% "scache"              % "6.0.1"
   val skafka            = "com.evolutiongaming" %% "skafka"              % "21.0.0"
   val sstream           = "com.evolutiongaming" %% "sstream"             % "1.3.0"
-  val scassandra        = "com.evolutiongaming" %% "scassandra"          % "5.5.0"
+  val scassandra        = "com.evolutiongaming" %% "scassandra"          % "5.6.0"
   val cassandraSync     = "com.evolutiongaming" %% "cassandra-sync"      % "4.0.0"
   val random            = "com.evolution"       %% "random"              % "1.0.5"
   val retry             = "com.evolutiongaming" %% "retry"               % "3.1.0"


### PR DESCRIPTION
5.6.0 deprecates `CassandraSession.state`/`State` in favour of `stateSnapshot`/`StateSnapshot`, so migrate both implementors of `CassandraSession`:

- `SessionHelper.Delegate` forwards `stateSnapshot`. It still has to implement the deprecated `state`, which remains abstract upstream, so that member is annotated with `@nowarn`.
- `CassandraSessionStub` implements `stateSnapshot` and derives `state` from it.

`stateSnapshot` only has a `???` default in 5.6.0 (kept for binary compatibility), so every implementor must override it.