### PR TITLE
Make PartitionFlowSpec deterministic under the poll gates

### DIFF
--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/PartitionFlowSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/PartitionFlowSpec.scala
@@ -1,5 +1,6 @@
 package com.evolutiongaming.kafka.flow
 
+import cats.effect.testkit.TestControl
 import cats.effect.unsafe.IORuntime
 import cats.effect.{IO, Ref, Resource}
 import cats.syntax.all.*
@@ -67,6 +68,8 @@ class PartitionFlowSpec extends FunSuite {
 
     val flow = f.flow use { flow =>
       for {
+        // step past the acquisition ms: poll gates are strict `isAfter`
+        _ <- IO.sleep(1.milli)
         // When("exactly 3 messages come")
         _      <- flow(f.records("key1", 100, List("event1", "event2", "event3")))
         offset <- f.pendingOffset.get
@@ -74,7 +77,7 @@ class PartitionFlowSpec extends FunSuite {
         _ <- IO { assertEquals(offset, Some(Offset.unsafe(103))) }
       } yield ()
     }
-    flow.unsafeRunSync()
+    TestControl.executeEmbed(flow).unsafeRunSync()
   }
 
   test("PartitionFlow does not allow commit until working with key is finished") {
@@ -84,6 +87,8 @@ class PartitionFlowSpec extends FunSuite {
 
     val flow = f.flow use { flow =>
       for {
+        // step past the acquisition ms: poll gates are strict `isAfter`
+        _ <- IO.sleep(1.milli)
         // When("2 messages come for the key1")
         _ <- flow(f.records("key1", 100, List("event1", "event2")))
         // And("2 messages come for the key2")
@@ -102,7 +107,7 @@ class PartitionFlowSpec extends FunSuite {
 
       } yield ()
     }
-    flow.unsafeRunSync()
+    TestControl.executeEmbed(flow).unsafeRunSync()
 
   }
 
@@ -192,6 +197,8 @@ class PartitionFlowSpec extends FunSuite {
 
     val flow = f.flow.use { flow =>
       for {
+        // step past the acquisition ms: poll gates are strict `isAfter`
+        _ <- IO.sleep(1.milli)
         // The first two events for each state are handled without errors, offset is committed
         _ <- flow(f.records("key1", 100, List("event1", "event2")) ++ f.records("key2", 102, List("event3", "event4")))
         _ <- f.pendingOffset.get.map(offset => assertEquals(offset, Some(Offset.unsafe(104))))
@@ -204,7 +211,7 @@ class PartitionFlowSpec extends FunSuite {
       } yield ()
     }
 
-    flow.unsafeRunSync()
+    TestControl.executeEmbed(flow).unsafeRunSync()
   }
 
   test("PartitionFlow filters out events but commits offsets") {
@@ -247,6 +254,8 @@ class PartitionFlowSpec extends FunSuite {
 
     val flow = f.flow.use { flow =>
       for {
+        // step past the acquisition ms: poll gates are strict `isAfter`
+        _ <- IO.sleep(1.milli)
         // Only one key is processed and persisted, the second one is not, but the latest offset is committed nonetheless
         _ <- flow(f.records(processedKey, 100, List("event1")) ++ f.records(skippedKey, 101, List("event2")))
         _ <- f.pendingOffset.get.map(offset => assertEquals(offset, Some(Offset.unsafe(102))))
@@ -265,7 +274,7 @@ class PartitionFlowSpec extends FunSuite {
       } yield ()
     }
 
-    flow.unsafeRunSync()
+    TestControl.executeEmbed(flow).unsafeRunSync()
   }
 
   test("RemapKeys derives keys correctly and updates them before applying filters and folds") {
@@ -294,6 +303,8 @@ class PartitionFlowSpec extends FunSuite {
         )
 
         for {
+          // step past the acquisition ms: poll gates are strict `isAfter`
+          _ <- IO.sleep(1.milli)
           // Ensure pre-existing data is loaded correctly from the storage
           _ <- cache.keys.map(keys => assertEquals(keys.size, 1))
           _ <- keys.get.map(keys => assertEquals(keys, Set(initialKey)))
@@ -319,7 +330,7 @@ class PartitionFlowSpec extends FunSuite {
 
     }
 
-    test.unsafeRunSync()
+    TestControl.executeEmbed(test).unsafeRunSync()
   }
 
   test(


### PR DESCRIPTION
Five `PartitionFlowSpec` tests failed intermittently — 113–168 times per 200 iterations — while passing when run in isolation.

**Why.** Both poll gates compare strictly (`clock isAfter <at>`, `PartitionFlow.scala:275` and `:279`) against refs seeded with the flow's acquisition instant, read from a millisecond-truncated clock. A poll takes a few hundred microseconds, so the opening polls finish inside that same millisecond and skip the gated work: no timers triggered, no commit offset computed. The assertions that follow then see stale state — no scheduled commit, or a committed offset that never advanced. Records still fold and later polls evaluate normally, so the fault is in the tests, not in production behaviour.

**Fix.** Run those bodies under `TestControl` and step virtual time by 1 ms before the first poll, which opens the gates deterministically at no wall-clock cost.

| `PartitionFlowSpec` test | Before | After |
|---|---|---|
| allows commit when working with key is finished | 125/200 | **0/200** |
| does not allow commit until working with key is finished | 113/200 | **0/200** |
| doesn't commit new offset if periodic persisting fails (`ignorePersistErrors=true`) | 157/200 | **0/200** |
| filters out events but commits offsets | 168/200 | **0/200** |
| RemapKeys derives keys correctly and updates them before applying filters and folds | 157/200 | **0/200** |

N = 200 looped iterations per test on a warm JVM. Also 10/10 consecutive clean suite runs, and `core` 89/89 on 2.13.18 and 3.3.7.

No assertion changed: every `assertEquals` is byte-for-byte the same — no retry wrapper, no real-clock sleep, no widened tolerance.

Nothing else changed: selected tests in `GroupCommitSpec`, `ReadSnapshotsSpec` and `KafkaPersistenceModuleSpec` measured 0/1000, and in `EntityRegistryTest`, `TopicFlowSpec` and `TimerFlowOfSpec` 0/300. No other flakiness could be proven.
