### PR TITLE
[Security] Use shared dependency-graph workflow

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [ master ]
 
+permissions:
+  contents: write
+
 jobs:
   submit:
     uses: evolution-gaming/scala-github-actions/.github/workflows/dependency-graph.yml@2a50f1819b6fef2657ba802fd62612b7fc8450f0 # v6.4.0

--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -1,32 +1,15 @@
-name: Update Dependency Graph
+name: Dependency graph
+
 on:
   push:
-    branches:
-      - master
+    branches: [ master ]
+
 jobs:
-  dependency-graph:
-    name: Update Dependency Graph
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: setup Java 17
-        uses: actions/setup-java@v4
-        with:
-          java-version: '17'
-          distribution: 'oracle'
-          cache: 'sbt'
-
-      - name: setup SBT
-        uses: sbt/setup-sbt@v1
-
-      - uses: scalacenter/sbt-dependency-submission@v2
-        with:
-          modules-ignore: >
-            docs_2.13
-            kafka-flow-core-it-tests_2.13
-            kafka-flow-persistence-kafka-it-tests_2.13
-            kafka-flow-persistence-cassandra-it-tests_2.13
-          configs-ignore: test integration-test scala-tool scala-doc-tool
-permissions:
-  contents: write
+  submit:
+    uses: evolution-gaming/scala-github-actions/.github/workflows/dependency-graph.yml@2a50f1819b6fef2657ba802fd62612b7fc8450f0 # v6.4.0
+    with:
+      modules_ignore: >-
+        docs_2.13
+        kafka-flow-core-it-tests_2.13
+        kafka-flow-persistence-kafka-it-tests_2.13
+        kafka-flow-persistence-cassandra-it-tests_2.13


### PR DESCRIPTION
Replaces the local dependency submission job with the reusable workflow from scala-github-actions (v6.4.0). Same modules-ignore and configs-ignore, but action versions (checkout v7, setup-java v5, sbt-dependency-submission v3) are now maintained in one place.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency graph automation to use a standardized workflow.
  * Preserved dependency graph updates for changes pushed to the master branch.
  * Maintained write permissions and exclusions for designated modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->