### PR TITLE
Fix dependabot alerts

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -13,6 +13,10 @@ jobs:
     with:
       modules_ignore: >-
         docs_2.13
+        docs_3
         kafka-flow-core-it-tests_2.13
+        kafka-flow-core-it-tests_3
         kafka-flow-persistence-kafka-it-tests_2.13
+        kafka-flow-persistence-kafka-it-tests_3
         kafka-flow-persistence-cassandra-it-tests_2.13
+        kafka-flow-persistence-cassandra-it-tests_3

--- a/build.sbt
+++ b/build.sbt
@@ -5,19 +5,20 @@ ThisBuild / evictionErrorLevel := Level.Warn
 ThisBuild / versionPolicyIntention := Compatibility.None
 
 lazy val JacksonVersion = "2.18.9"
+lazy val NettyVersion   = "4.1.136.Final"
 
 ThisBuild / dependencyOverrides ++= Seq(
   "at.yawk.lz4"                % "lz4-java"                           % "1.11.1",
   "com.fasterxml.jackson.core" % "jackson-core"                       % JacksonVersion,
   "com.fasterxml.jackson.core" % "jackson-databind"                   % JacksonVersion,
   "com.google.guava"           % "guava"                              % "32.1.3-jre",
-  "io.netty"                   % "netty-buffer"                       % "4.1.136.Final",
-  "io.netty"                   % "netty-codec"                        % "4.1.136.Final",
-  "io.netty"                   % "netty-common"                       % "4.1.136.Final",
-  "io.netty"                   % "netty-handler"                      % "4.1.136.Final",
-  "io.netty"                   % "netty-resolver"                     % "4.1.136.Final",
-  "io.netty"                   % "netty-transport"                    % "4.1.136.Final",
-  "io.netty"                   % "netty-transport-native-unix-common" % "4.1.136.Final",
+  "io.netty"                   % "netty-buffer"                       % NettyVersion,
+  "io.netty"                   % "netty-codec"                        % NettyVersion,
+  "io.netty"                   % "netty-common"                       % NettyVersion,
+  "io.netty"                   % "netty-handler"                      % NettyVersion,
+  "io.netty"                   % "netty-resolver"                     % NettyVersion,
+  "io.netty"                   % "netty-transport"                    % NettyVersion,
+  "io.netty"                   % "netty-transport-native-unix-common" % NettyVersion,
 )
 
 lazy val Scala3Version = "3.3.8"

--- a/build.sbt
+++ b/build.sbt
@@ -4,10 +4,12 @@ ThisBuild / versionScheme := Some("early-semver")
 ThisBuild / evictionErrorLevel := Level.Warn
 ThisBuild / versionPolicyIntention := Compatibility.None
 
+lazy val JacksonVersion = "2.18.9"
+
 ThisBuild / dependencyOverrides ++= Seq(
   "at.yawk.lz4"                % "lz4-java"                           % "1.11.1",
-  "com.fasterxml.jackson.core" % "jackson-core"                       % "2.18.9",
-  "com.fasterxml.jackson.core" % "jackson-databind"                   % "2.18.9",
+  "com.fasterxml.jackson.core" % "jackson-core"                       % JacksonVersion,
+  "com.fasterxml.jackson.core" % "jackson-databind"                   % JacksonVersion,
   "com.google.guava"           % "guava"                              % "32.1.3-jre",
   "io.netty"                   % "netty-buffer"                       % "4.1.136.Final",
   "io.netty"                   % "netty-codec"                        % "4.1.136.Final",

--- a/build.sbt
+++ b/build.sbt
@@ -5,17 +5,17 @@ ThisBuild / evictionErrorLevel := Level.Warn
 ThisBuild / versionPolicyIntention := Compatibility.None
 
 ThisBuild / dependencyOverrides ++= Seq(
-  "at.yawk.lz4" % "lz4-java" % "1.11.1",
-  "com.fasterxml.jackson.core" % "jackson-core" % "2.18.8",
-  "com.fasterxml.jackson.core" % "jackson-databind" % "2.18.9",
-  "com.google.guava" % "guava" % "32.1.3-jre",
-  "io.netty" % "netty-buffer" % "4.1.136.Final",
-  "io.netty" % "netty-codec" % "4.1.136.Final",
-  "io.netty" % "netty-common" % "4.1.136.Final",
-  "io.netty" % "netty-handler" % "4.1.136.Final",
-  "io.netty" % "netty-resolver" % "4.1.136.Final",
-  "io.netty" % "netty-transport" % "4.1.136.Final",
-  "io.netty" % "netty-transport-native-unix-common" % "4.1.136.Final",
+  "at.yawk.lz4"                % "lz4-java"                           % "1.11.1",
+  "com.fasterxml.jackson.core" % "jackson-core"                       % "2.18.8",
+  "com.fasterxml.jackson.core" % "jackson-databind"                   % "2.18.9",
+  "com.google.guava"           % "guava"                              % "32.1.3-jre",
+  "io.netty"                   % "netty-buffer"                       % "4.1.136.Final",
+  "io.netty"                   % "netty-codec"                        % "4.1.136.Final",
+  "io.netty"                   % "netty-common"                       % "4.1.136.Final",
+  "io.netty"                   % "netty-handler"                      % "4.1.136.Final",
+  "io.netty"                   % "netty-resolver"                     % "4.1.136.Final",
+  "io.netty"                   % "netty-transport"                    % "4.1.136.Final",
+  "io.netty"                   % "netty-transport-native-unix-common" % "4.1.136.Final",
 )
 
 lazy val Scala3Version = "3.3.8"

--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,20 @@ ThisBuild / versionScheme := Some("early-semver")
 ThisBuild / evictionErrorLevel := Level.Warn
 ThisBuild / versionPolicyIntention := Compatibility.None
 
+ThisBuild / dependencyOverrides ++= Seq(
+  "at.yawk.lz4" % "lz4-java" % "1.11.1",
+  "com.fasterxml.jackson.core" % "jackson-core" % "2.18.8",
+  "com.fasterxml.jackson.core" % "jackson-databind" % "2.18.9",
+  "com.google.guava" % "guava" % "32.1.3-jre",
+  "io.netty" % "netty-buffer" % "4.1.136.Final",
+  "io.netty" % "netty-codec" % "4.1.136.Final",
+  "io.netty" % "netty-common" % "4.1.136.Final",
+  "io.netty" % "netty-handler" % "4.1.136.Final",
+  "io.netty" % "netty-resolver" % "4.1.136.Final",
+  "io.netty" % "netty-transport" % "4.1.136.Final",
+  "io.netty" % "netty-transport-native-unix-common" % "4.1.136.Final",
+)
+
 lazy val Scala3Version = "3.3.8"
 lazy val Scala2Version = "2.13.18"
 

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ ThisBuild / versionPolicyIntention := Compatibility.None
 
 ThisBuild / dependencyOverrides ++= Seq(
   "at.yawk.lz4"                % "lz4-java"                           % "1.11.1",
-  "com.fasterxml.jackson.core" % "jackson-core"                       % "2.18.8",
+  "com.fasterxml.jackson.core" % "jackson-core"                       % "2.18.9",
   "com.fasterxml.jackson.core" % "jackson-databind"                   % "2.18.9",
   "com.google.guava"           % "guava"                              % "32.1.3-jre",
   "io.netty"                   % "netty-buffer"                       % "4.1.136.Final",

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -6183,17 +6183,17 @@ joi@^17.9.2:
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
 js-yaml@^3.13.1:
-  version "3.15.0"
-  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz"
-  integrity sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==
+  version "3.15.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.15.1.tgz#24bc95028f361cdaaa84745b06a109c4486773c0"
+  integrity sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
 js-yaml@^4.1.0:
-  version "4.3.0"
-  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz"
-  integrity sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.1.tgz#01216c001d67f48e2cd560d708c7af21090a3848"
+  integrity sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==
   dependencies:
     argparse "^2.0.1"
 


### PR DESCRIPTION
Pins vulnerable transitive deps (netty, jackson-core/databind, guava, lz4-java) to patched versions via dependencyOverrides. Adds the Scala 3 module names to dependency graph ignores, the _3 variants of docs/it-tests were still submitted and kept undertow/jsoup alerts open. Also bumps js-yaml in the website lockfile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management to use consistent versions for core networking, serialization, compression, and utility components.
  * Expanded automated dependency tracking coverage to include additional Scala 3 integration-test variants.
  * These updates improve build consistency and verification without changing the product’s end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->