### PR TITLE
Fix gh-pages deploy: grant `contents: write` to the `docs` job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
 
   docs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # required by `peaceiris/actions-gh-pages` to push to `gh-pages`
     steps:
       - uses: actions/checkout@v5
 


### PR DESCRIPTION
## Problem

Every push to `master` since #908 fails CI in the `docs` job, at its final `deploy` step:

```
remote: Permission to evolution-gaming/kafka-flow.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/evolution-gaming/kafka-flow.git/': The requested URL returned error: 403
##[error]Action failed with "The process '/usr/bin/git' failed with exit code 128"
```

Affected runs: [#908](https://github.com/evolution-gaming/kafka-flow/actions/runs/32729216227), [#895](https://github.com/evolution-gaming/kafka-flow/actions/runs/32747782209), [#910](https://github.com/evolution-gaming/kafka-flow/actions/runs/32753236399), [#909](https://github.com/evolution-gaming/kafka-flow/actions/runs/32842582282). Tests pass in all of them — only the docs deploy is broken.

## Cause

`7d6c172d7` (#908) added a workflow-level

```yaml
permissions:
  contents: read
```

to `.github/workflows/ci.yml`. The `docs` job doesn't override it, so `peaceiris/actions-gh-pages@v3` receives a read-only `GITHUB_TOKEN` and cannot push to `gh-pages`.

## Fix

Grant `contents: write` on the `docs` job only, leaving the restrictive workflow-level default in place for everything else.

## Note on verification

The `deploy` step is gated on `github.ref == 'refs/heads/master'`, so this PR's own CI will not exercise it — the docs job here builds the site but skips the push. The fix is confirmed by the first master push after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation publishing automation to ensure generated documentation can be deployed successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->