### PR TITLE
Publish the pinned dependency versions to consumers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,6 +21,20 @@ ThisBuild / dependencyOverrides ++= Seq(
   "io.netty"                   % "netty-transport-native-unix-common" % NettyVersion,
 )
 
+// `dependencyOverrides` above are not published to the POM, so from a consumer's point of view
+// the previous release still brings the versions pulled in by the Cassandra driver. Ignore these
+// libraries in the version policy check for as long as they are bumped via overrides.
+ThisBuild / versionPolicyIgnored ++= Seq(
+  "com.google.guava" % "guava",
+  "io.netty"         % "netty-buffer",
+  "io.netty"         % "netty-codec",
+  "io.netty"         % "netty-common",
+  "io.netty"         % "netty-handler",
+  "io.netty"         % "netty-resolver",
+  "io.netty"         % "netty-transport",
+  "io.netty"         % "netty-transport-native-unix-common",
+)
+
 lazy val Scala3Version = "3.3.8"
 lazy val Scala2Version = "2.13.18"
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,26 +4,12 @@ ThisBuild / versionScheme := Some("early-semver")
 ThisBuild / evictionErrorLevel := Level.Warn
 ThisBuild / versionPolicyIntention := Compatibility.BinaryCompatible
 
-lazy val JacksonVersion = "2.18.9"
-lazy val NettyVersion   = "4.1.136.Final"
+// covers the test-only dependency paths, the published modules declare `Pinned` explicitly
+ThisBuild / dependencyOverrides ++= Pinned.all
 
-ThisBuild / dependencyOverrides ++= Seq(
-  "at.yawk.lz4"                % "lz4-java"                           % "1.11.1",
-  "com.fasterxml.jackson.core" % "jackson-core"                       % JacksonVersion,
-  "com.fasterxml.jackson.core" % "jackson-databind"                   % JacksonVersion,
-  "com.google.guava"           % "guava"                              % "32.1.3-jre",
-  "io.netty"                   % "netty-buffer"                       % NettyVersion,
-  "io.netty"                   % "netty-codec"                        % NettyVersion,
-  "io.netty"                   % "netty-common"                       % NettyVersion,
-  "io.netty"                   % "netty-handler"                      % NettyVersion,
-  "io.netty"                   % "netty-resolver"                     % NettyVersion,
-  "io.netty"                   % "netty-transport"                    % NettyVersion,
-  "io.netty"                   % "netty-transport-native-unix-common" % NettyVersion,
-)
-
-// `dependencyOverrides` above are not published to the POM, so from a consumer's point of view
-// the previous release still brings the versions pulled in by the Cassandra driver. Ignore these
-// libraries in the version policy check for as long as they are bumped via overrides.
+// The previous release resolves guava and netty to the versions brought in by the Cassandra
+// driver, because back then they were pinned via `dependencyOverrides` only, which sbt does not
+// publish to the POM. TODO remove after the next release, which declares them properly.
 ThisBuild / versionPolicyIgnored ++= Seq(
   "com.google.guava" % "guava",
   "io.netty"         % "netty-buffer",
@@ -109,6 +95,7 @@ lazy val core = (project in file("core"))
       random,
       retry,
       Scodec.bits,
+      Pinned.lz4,
       Testing.munit % Test,
     ),
     libraryDependencies ++= crossSettings(
@@ -151,7 +138,9 @@ lazy val `persistence-cassandra` = (project in file("persistence-cassandra"))
     libraryDependencies ++= Seq(
       scassandra,
       cassandraSync,
+      Pinned.guava,
     ),
+    libraryDependencies ++= Pinned.netty,
     libraryDependencies ++= crossSettings(
       scalaVersion.value,
       if3 = List(PureConfig.GenericScala3),
@@ -209,6 +198,7 @@ lazy val journal = (project in file("kafka-journal"))
       KafkaJournal.journal,
       Testing.munit % Test,
     ),
+    libraryDependencies ++= Pinned.jackson,
   )
 
 lazy val docs = (project in file("kafka-flow-docs"))

--- a/build.sbt
+++ b/build.sbt
@@ -3,22 +3,6 @@ import Dependencies.*
 ThisBuild / versionScheme := Some("early-semver")
 ThisBuild / evictionErrorLevel := Level.Warn
 ThisBuild / versionPolicyIntention := Compatibility.BinaryCompatible
-ThisBuild / versionPolicyIgnored ++= Seq(
-  // add libraries here that are known to be binary compatible, like:
-  // TODO remove after next release, this project doesn't use doobie module from `smetrics`
-  //  and all other libraries do not affect public API
-  "com.evolutiongaming" %% "smetrics",
-  "com.evolution"       %% "kafka-journal-core",
-  "com.evolution"       %% "kafka-journal",
-  "com.google.guava"     % "guava",
-  "io.netty"             % "netty-buffer",
-  "io.netty"             % "netty-codec",
-  "io.netty"             % "netty-common",
-  "io.netty"             % "netty-handler",
-  "io.netty"             % "netty-resolver",
-  "io.netty"             % "netty-transport",
-  "io.netty"             % "netty-transport-native-unix-common",
-)
 
 lazy val JacksonVersion = "2.18.9"
 lazy val NettyVersion   = "4.1.136.Final"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,6 +14,40 @@ object Dependencies {
   val retry             = "com.evolutiongaming" %% "retry"               % "3.1.0"
   val playJsonJsoniter  = "com.evolution"       %% "play-json-jsoniter"  % "1.4.0"
 
+  /** Transitive dependencies pinned to versions without known vulnerabilities.
+    *
+    * These are declared as direct dependencies of the modules that pull them in, on top of being listed in
+    * `dependencyOverrides`: overrides only affect the resolution of this build and are not published to the POM, so on
+    * their own they leave the consumers of the library with the original, vulnerable versions.
+    */
+  object Pinned {
+    private val jacksonVersion = "2.18.9"
+    private val nettyVersion   = "4.1.136.Final"
+
+    // comes from `skafka` via `kafka-clients`
+    val lz4 = "at.yawk.lz4" % "lz4-java" % "1.11.1"
+
+    // comes from `kafka-journal`
+    val jackson = Seq(
+      "com.fasterxml.jackson.core" % "jackson-core"     % jacksonVersion,
+      "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
+    )
+
+    // come from `scassandra` and `cassandra-sync` via `cassandra-driver-core`
+    val guava = "com.google.guava" % "guava" % "32.1.3-jre"
+    val netty = Seq(
+      "io.netty" % "netty-buffer"                       % nettyVersion,
+      "io.netty" % "netty-codec"                        % nettyVersion,
+      "io.netty" % "netty-common"                       % nettyVersion,
+      "io.netty" % "netty-handler"                      % nettyVersion,
+      "io.netty" % "netty-resolver"                     % nettyVersion,
+      "io.netty" % "netty-transport"                    % nettyVersion,
+      "io.netty" % "netty-transport-native-unix-common" % nettyVersion,
+    )
+
+    val all = lz4 +: guava +: (jackson ++ netty)
+  }
+
   object Cats {
     private val version       = "2.13.0"
     private val effectVersion = "3.7.1"


### PR DESCRIPTION
#910 pinned lz4, jackson, guava and netty via `dependencyOverrides`, which sbt does not publish to
the POM — so only this build got the fixed versions, while consumers kept resolving the vulnerable
ones from the parents (guava `19.0`, netty `4.1.94.Final`, ...).

This PR declares them as direct dependencies of the modules that pull them in (`core` → lz4,
`kafka-journal` → jackson, `persistence-cassandra` → guava + netty), so the versions land in the
published POMs. Coordinates moved to `Dependencies.Pinned` and are reused by `dependencyOverrides`,
which stays for the test-only paths.

`versionPolicyIgnored`, which this branch originally dropped: only the `smetrics` and
`kafka-journal` entries were redundant. The guava/netty ones stay until a release ships with the
dependencies declared, since the check still compares against `10.1.0` — marked with a TODO.

Verified: POMs list every pin, a consumer resolving the locally published artifacts gets
32.1.3-jre / 4.1.136.Final / 1.11.1, the Cassandra IT tests pass against a real container, and
`versionPolicyCheck` is green on 2.13.18 and 3.3.8.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency publication settings.
  * Refined which dependencies are excluded from generated metadata.
  * Added clarification about dependency overrides not being published.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
