### PR TITLE
Align pinned dependency versions with scassandra

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,18 +7,19 @@ ThisBuild / versionPolicyIntention := Compatibility.BinaryCompatible
 // covers the test-only dependency paths, the published modules declare `Pinned` explicitly
 ThisBuild / dependencyOverrides ++= Pinned.all
 
-// The previous release resolves guava and netty to the versions brought in by the Cassandra
-// driver, because back then they were pinned via `dependencyOverrides` only, which sbt does not
-// publish to the POM. TODO remove after the next release, which declares them properly.
+// Guava major bumps are security fixes. The only Guava type reaching the public API is
+// `ListenableFuture`, coming from `scassandra`, which is unchanged since 19.0. The rest are the
+// annotation-only artifacts that Guava adds, drops and bumps between its major versions.
+//
+// TODO remove the annotation-only entries after the next release: they only cover the 32 -> 33
+//  transition, and once a release ships with Guava 33 both sides of the check resolve the same
+//  graph. The `guava` entry itself is needed for as long as the version is pinned here, as every
+//  security bump of it is a major one.
 ThisBuild / versionPolicyIgnored ++= Seq(
-  "com.google.guava" % "guava",
-  "io.netty"         % "netty-buffer",
-  "io.netty"         % "netty-codec",
-  "io.netty"         % "netty-common",
-  "io.netty"         % "netty-handler",
-  "io.netty"         % "netty-resolver",
-  "io.netty"         % "netty-transport",
-  "io.netty"         % "netty-transport-native-unix-common",
+  "com.google.guava"         % "guava",
+  "com.google.code.findbugs" % "jsr305",
+  "com.google.j2objc"        % "j2objc-annotations",
+  "org.checkerframework"     % "checker-qual",
 )
 
 lazy val Scala3Version = "3.3.8"
@@ -140,7 +141,7 @@ lazy val `persistence-cassandra` = (project in file("persistence-cassandra"))
       cassandraSync,
       Pinned.guava,
     ),
-    libraryDependencies ++= Pinned.netty,
+    libraryDependencies ++= Pinned.netty ++ Pinned.jackson,
     libraryDependencies ++= crossSettings(
       scalaVersion.value,
       if3 = List(PureConfig.GenericScala3),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,20 +21,20 @@ object Dependencies {
     * their own they leave the consumers of the library with the original, vulnerable versions.
     */
   object Pinned {
-    private val jacksonVersion = "2.18.9"
+    private val jacksonVersion = "2.18.10"
     private val nettyVersion   = "4.1.136.Final"
 
     // comes from `skafka` via `kafka-clients`
     val lz4 = "at.yawk.lz4" % "lz4-java" % "1.11.1"
 
-    // comes from `kafka-journal`
+    // comes from `kafka-journal` and from `scassandra` via `cassandra-driver-core`
     val jackson = Seq(
       "com.fasterxml.jackson.core" % "jackson-core"     % jacksonVersion,
       "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
     )
 
     // come from `scassandra` and `cassandra-sync` via `cassandra-driver-core`
-    val guava = "com.google.guava" % "guava" % "32.1.3-jre"
+    val guava = "com.google.guava" % "guava" % "33.5.0-jre"
     val netty = Seq(
       "io.netty" % "netty-buffer"                       % nettyVersion,
       "io.netty" % "netty-codec"                        % nettyVersion,


### PR DESCRIPTION
Follow-up to #913.

- Declare jackson in `persistence-cassandra` — its consumers were still resolving
  `jackson-databind:2.7.9.7` from the Cassandra driver, the pin only covered `kafka-journal`.
- Match the versions scassandra pins on master: jackson 2.18.9 → 2.18.10, guava 32.1.3-jre →
  33.5.0-jre. Netty was already 4.1.136.Final on both sides.
- Drop the netty `versionPolicyIgnored` entries — 10.2.0 ships 4.1.136.Final in its POM, so there
  is nothing left to report. Guava stays, joined by the annotation-only artifacts that 33.5.0
  drops or bumps (`jsr305`, `checker-qual`, `j2objc-annotations`), with a TODO — those three go
  away after the next release, the `guava` entry stays as long as the version is pinned here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated bundled Guava and Jackson dependency versions.
  * Improved dependency compatibility handling for Guava-related artifacts.
  * Added consistent Jackson and Netty version pinning for Cassandra persistence.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->