### PR TITLE
Update scassandra to 5.7.0 and drop the pins it makes redundant

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,18 +7,21 @@ ThisBuild / versionPolicyIntention := Compatibility.BinaryCompatible
 // covers the test-only dependency paths, the published modules declare `Pinned` explicitly
 ThisBuild / dependencyOverrides ++= Pinned.all
 
-// The previous release resolves guava and netty to the versions brought in by the Cassandra
-// driver, because back then they were pinned via `dependencyOverrides` only, which sbt does not
-// publish to the POM. TODO remove after the next release, which declares them properly.
+// One-time diff against 10.2.0, which pinned Guava and Netty itself: both now come from
+// `scassandra` at newer versions, and Guava 33.x also swaps its annotation-only dependencies.
+// TODO drop the whole block after the next release; empty it and run `versionPolicyCheck` to confirm.
 ThisBuild / versionPolicyIgnored ++= Seq(
-  "com.google.guava" % "guava",
-  "io.netty"         % "netty-buffer",
-  "io.netty"         % "netty-codec",
-  "io.netty"         % "netty-common",
-  "io.netty"         % "netty-handler",
-  "io.netty"         % "netty-resolver",
-  "io.netty"         % "netty-transport",
-  "io.netty"         % "netty-transport-native-unix-common",
+  "com.google.guava"         % "guava",
+  "com.google.code.findbugs" % "jsr305",
+  "com.google.j2objc"        % "j2objc-annotations",
+  "org.checkerframework"     % "checker-qual",
+  "io.netty"                 % "netty-buffer",
+  "io.netty"                 % "netty-codec",
+  "io.netty"                 % "netty-common",
+  "io.netty"                 % "netty-handler",
+  "io.netty"                 % "netty-resolver",
+  "io.netty"                 % "netty-transport",
+  "io.netty"                 % "netty-transport-native-unix-common",
 )
 
 lazy val Scala3Version = "3.3.8"
@@ -138,9 +141,7 @@ lazy val `persistence-cassandra` = (project in file("persistence-cassandra"))
     libraryDependencies ++= Seq(
       scassandra,
       cassandraSync,
-      Pinned.guava,
     ),
-    libraryDependencies ++= Pinned.netty,
     libraryDependencies ++= crossSettings(
       scalaVersion.value,
       if3 = List(PureConfig.GenericScala3),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   val scache            = "com.evolution"       %% "scache"              % "6.0.2"
   val skafka            = "com.evolutiongaming" %% "skafka"              % "21.0.3"
   val sstream           = "com.evolutiongaming" %% "sstream"             % "1.3.0"
-  val scassandra        = "com.evolutiongaming" %% "scassandra"          % "5.6.0"
+  val scassandra        = "com.evolutiongaming" %% "scassandra"          % "5.7.0"
   val cassandraSync     = "com.evolutiongaming" %% "cassandra-sync"      % "4.0.0"
   val random            = "com.evolution"       %% "random"              % "1.0.5"
   val retry             = "com.evolutiongaming" %% "retry"               % "3.1.0"
@@ -19,33 +19,26 @@ object Dependencies {
     * These are declared as direct dependencies of the modules that pull them in, on top of being listed in
     * `dependencyOverrides`: overrides only affect the resolution of this build and are not published to the POM, so on
     * their own they leave the consumers of the library with the original, vulnerable versions.
+    *
+    * Do not pin what upstream already pins. Since 5.7.0 `scassandra` pins Guava, Netty and Jackson itself, so
+    * `persistence-cassandra` needs no pins for them here. Adding one anyway would risk holding them back: a pin that
+    * falls behind `scassandra` downgrades a patched version instead of raising an unpatched one.
     */
   object Pinned {
-    private val jacksonVersion = "2.18.9"
-    private val nettyVersion   = "4.1.136.Final"
-
-    // comes from `skafka` via `kafka-clients`
+    // comes from `skafka` via `kafka-clients`, which still brings 1.10.2
     val lz4 = "at.yawk.lz4" % "lz4-java" % "1.11.1"
 
-    // comes from `kafka-journal`
+    // Raises Jackson for the `journal` module, which gets 2.14.3 from `kafka-journal` and has no `scassandra` on its
+    // classpath to pin anything newer. The version matches what `scassandra` resolves to, so that the build-wide
+    // `dependencyOverrides` does not drag `persistence-cassandra` down to an older Jackson than it gets today.
+    // Pins `jackson-core` and `jackson-databind` only; `jackson-annotations` and `jackson-datatype-*` stay at 2.14.3.
+    private val jacksonVersion = "2.18.10"
     val jackson = Seq(
       "com.fasterxml.jackson.core" % "jackson-core"     % jacksonVersion,
       "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
     )
 
-    // come from `scassandra` and `cassandra-sync` via `cassandra-driver-core`
-    val guava = "com.google.guava" % "guava" % "32.1.3-jre"
-    val netty = Seq(
-      "io.netty" % "netty-buffer"                       % nettyVersion,
-      "io.netty" % "netty-codec"                        % nettyVersion,
-      "io.netty" % "netty-common"                       % nettyVersion,
-      "io.netty" % "netty-handler"                      % nettyVersion,
-      "io.netty" % "netty-resolver"                     % nettyVersion,
-      "io.netty" % "netty-transport"                    % nettyVersion,
-      "io.netty" % "netty-transport-native-unix-common" % nettyVersion,
-    )
-
-    val all = lz4 +: guava +: (jackson ++ netty)
+    val all = lz4 +: jackson
   }
 
   object Cats {


### PR DESCRIPTION
- scassandra 5.7.0 declares patched Guava, Netty and Jackson itself (evolution-gaming/scassandra#367), so pinning them here is redundant — and now harmful: ours had fallen behind (guava 32.1.3 vs 33.7.1, netty 4.1.136 vs 4.1.137) and, as build-wide `dependencyOverrides`, would downgrade rather than raise.
- Removed the guava and netty pins.
- Kept lz4 (kafka-clients brings 1.10.2) and Jackson (kafka-journal brings 2.14.3 to `journal`, which scassandra isn't on the classpath of). Jackson raised to 2.18.10 to match scassandra so the override doesn't pull `persistence-cassandra` down.
- Guava 32→33 drops `jsr305`/`checker-qual` and moves `j2objc-annotations` to 3.x, so those join `versionPolicyIgnored`. Its comment said to drop the block after the next release, but v10.2.0 is that release — retargeted.
- Verified: resolved tree shows guava 33.7.1 and all seven netty artifacts at 4.1.137 via scassandra; `sbt check` clean; tests pass on 2.13 and 3.3; IT modules compile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the Cassandra testing component to version 5.7.0.
  * Updated the Jackson component to version 2.18.10.
  * Refined dependency version handling for improved build consistency.
  * Simplified dependency management by removing unnecessary explicit version pins while preserving required compression and JSON components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->