### PR TITLE
Drop the versionPolicyIgnored entries the 10.3.0 release retires

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,23 +7,6 @@ ThisBuild / versionPolicyIntention := Compatibility.BinaryCompatible
 // covers the test-only dependency paths, the published modules declare `Pinned` explicitly
 ThisBuild / dependencyOverrides ++= Pinned.all
 
-// One-time diff against 10.2.0, which pinned Guava and Netty itself: both now come from
-// `scassandra` at newer versions, and Guava 33.x also swaps its annotation-only dependencies.
-// TODO drop the whole block after the next release; empty it and run `versionPolicyCheck` to confirm.
-ThisBuild / versionPolicyIgnored ++= Seq(
-  "com.google.guava"         % "guava",
-  "com.google.code.findbugs" % "jsr305",
-  "com.google.j2objc"        % "j2objc-annotations",
-  "org.checkerframework"     % "checker-qual",
-  "io.netty"                 % "netty-buffer",
-  "io.netty"                 % "netty-codec",
-  "io.netty"                 % "netty-common",
-  "io.netty"                 % "netty-handler",
-  "io.netty"                 % "netty-resolver",
-  "io.netty"                 % "netty-transport",
-  "io.netty"                 % "netty-transport-native-unix-common",
-)
-
 lazy val Scala3Version = "3.3.8"
 lazy val Scala2Version = "2.13.18"
 


### PR DESCRIPTION
- These suppressed a one-time dependency diff: 10.2.0 pinned Guava and Netty directly, 10.3.0 takes them from `scassandra` instead, at newer versions. Now that 10.3.0 is released the baseline resolves the same versions the build does, so the entries no longer match anything.
- Removes the whole block, comment and TODO included.
- Verified as that comment prescribed — empty the block and run `versionPolicyCheck`: against 10.3.0 all five modules report no dependency issues, where against 10.2.0 the same removal reported eleven.
- `sbt check` clean; tests pass on 2.13.18 and 3.3.8.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version-policy checks now include previously excluded dependency components, improving consistency in dependency validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->