### PR TITLE
Unload a key only after its state was persisted

### DIFF
--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/timer/TimerFlowOf.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/timer/TimerFlowOf.scala
@@ -138,7 +138,8 @@ object TimerFlowOf {
 
   }
 
-  /** Combines [[unloadOrphaned]] with [[persistPeriodically]] in a single TimerFlow
+  /** Combines [[unloadOrphaned]] with [[persistPeriodically]] in a single TimerFlow. A key is unloaded only once its
+    * state is persisted: an ignored persist failure keeps it loaded, holding its offset.
     *
     * @param fireEvery
     *   the interval at which `onTimer` triggers
@@ -151,9 +152,10 @@ object TimerFlowOf {
     * @param flushOnRevoke
     *   controls whether persistence flushing should happen on partition revocation
     * @param ignorePersistErrors
-    *   if true, a failure to persist the state will not fail the computation. Instead, an error message will be logged
-    *   and a new offset for the key will not be `held`, so as a result no new offset will be committed for the
-    *   partition.
+    *   if true, a failure to persist the state will not fail the computation. Instead, an error message will be logged,
+    *   a new offset for the key will not be `held`, so no new offset will be committed for the partition, and the key
+    *   is not unloaded: it stays in memory until a later tick persists it, so keys accumulate while the store keeps
+    *   failing.
     */
   def persistPeriodicallyAndUnloadOrphaned[F[_]: MonadThrow](
     fireEvery: FiniteDuration    = 1.minute,
@@ -186,14 +188,16 @@ object TimerFlowOf {
           expired          = current.clock isAfter expiredAt
           canUnload        = expired || offsetDifference > maxOffsetDifference
           canPersist       = (current.clock compareTo triggerFlushAt) >= 0
-          _ <- Applicative[F].whenA(canPersist || canUnload)(
-            persistence.attemptToPersist(
-              ignorePersistErrors = ignorePersistErrors,
-              context             = context,
-              currentOffset       = current.offset
-            )
-          )
-          _ <- Applicative[F].whenA(canUnload)(
+          persisted <-
+            if (canPersist || canUnload)
+              persistence.attemptToPersist(
+                ignorePersistErrors = ignorePersistErrors,
+                context             = context,
+                currentOffset       = current.offset
+              )
+            else false.pure[F]
+          // `remove` drops the held offset too: unloading an unpersisted key lets the partition commit past it
+          _ <- Applicative[F].whenA(canUnload && persisted)(
             context.log.info(s"flush, offset difference: $offsetDifference") *> context.remove
           )
           _ <- register(current)
@@ -230,7 +234,9 @@ object TimerFlowOf {
   }
 
   private implicit class AttemptToPersist[F[_]: MonadThrow](persistence: FlushBuffers[F]) {
-    def attemptToPersist(ignorePersistErrors: Boolean, context: KeyContext[F], currentOffset: Offset): F[Unit] =
+
+    /** Flushes and, on success, holds `currentOffset`; returns whether the state was persisted. */
+    def attemptToPersist(ignorePersistErrors: Boolean, context: KeyContext[F], currentOffset: Offset): F[Boolean] =
       persistence.flush.attempt.flatMap {
         case Left(err) if ignorePersistErrors =>
           // 'context' will continue holding the previous offset from the last time the state was persisted
@@ -240,8 +246,9 @@ object TimerFlowOf {
           context
             .log
             .info(s"Failed to persist state, the error is ignored and offsets won't be committed, error: $err")
-        case Left(err) => err.raiseError[F, Unit]
-        case Right(_)  => context.hold(currentOffset)
+            .as(false)
+        case Left(err) => err.raiseError[F, Boolean]
+        case Right(_)  => context.hold(currentOffset).as(true)
       }
   }
 }

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/timer/TimerFlowOfSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/timer/TimerFlowOfSpec.scala
@@ -627,6 +627,42 @@ class TimerFlowOfSpec extends FunSuite {
     List(persistPeriodicallyFlowOf, persistingAndUnloadingFlowOf).map(flowOf => testIO(flowOf).unsafeRunSync())
   }
 
+  test("persistPeriodicallyAndUnloadOrphaned keeps a key loaded when its persist error is ignored") {
+
+    val f = new ConstFixture
+
+    val flushBuffersErr: FlushBuffers[IO] = new FlushBuffers[IO] {
+      def flush: IO[Unit] = new Exception("Test error").raiseError[IO, Unit]
+    }
+
+    // Given("flow unloads after 3 messages accumulated and the flush always fails")
+    val startedAt = f.timestamp.copy(offset = Offset.unsafe(1000))
+    val context   = Context(timestamps = TimestampState(startedAt))
+    val flowOf = TimerFlowOf.persistPeriodicallyAndUnloadOrphaned[IO](
+      fireEvery           = 0.minutes,
+      maxOffsetDifference = 3,
+      ignorePersistErrors = true,
+    )
+
+    // When("the unload threshold is crossed but the persist fails")
+    def program(flow: Resource[IO, TimerFlow[IO]]) = flow use { flow =>
+      f.timerContext.set(f.timestamp.copy(offset = Offset.unsafe(1004))) *>
+        f.timerContext.trigger(flow)
+    }
+
+    val testIO = for {
+      _      <- f.contextRef.set(context)
+      _      <- program(flowOf(f.keyContext, flushBuffersErr, f.timerContext))
+      result <- f.contextRef.get
+    } yield {
+      // Then("the key is not unloaded and still holds its last persisted offset")
+      assertEquals(result.removed, 0)
+      assertEquals(result.holding, Some(Offset.unsafe(1000)))
+    }
+
+    testIO.unsafeRunSync()
+  }
+
 }
 object TimerFlowSpec {
   implicit val log: Log[IO] = Log.empty[IO]


### PR DESCRIPTION
`persistPeriodicallyAndUnloadOrphaned` unloads a key whenever the unload threshold is crossed, even when the persist right before it failed and `ignorePersistErrors` swallowed the error. `KeyContext.remove` also drops the offset the key held, so the partition can commit past state that never reached the store, and the next recovery skips those events.

The unload is now gated on the persist outcome: `attemptToPersist` returns whether the state was persisted. An unpersisted key stays loaded and keeps holding its offset until a later tick persists it. With `ignorePersistErrors = true` and a store that keeps failing, keys therefore accumulate instead of being unloaded.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Keys are no longer unloaded when persistence fails, including when persistence errors are configured to be ignored.
  - State remains loaded at its last successfully persisted offset until persistence succeeds.

- **Tests**
  - Added coverage for retaining keys after a failed persistence attempt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

The defect is described under "The existing escape and its cost" in #938; that issue is about the fence, and this fix stands on its own.
