### PR TITLE
Keep the TopicFlow permit when a rebalance callback times out [AWAIT cats-helper#425]

### DIFF
--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/TopicFlow.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/TopicFlow.scala
@@ -160,6 +160,9 @@ object TopicFlow {
     *   - resource would be released only after previous steps are completed
     *   - if resource is released before start of messages' processing, then it does nothing (no message processing, no
     *     commits, no persists)
+    *
+    * The safeties also hold when a call is lifted into a rebalance callback and split by `ToTry`; see the comment on
+    * the guarded calls below.
     */
   private def safeguard[F[_]: Concurrent](a: Resource[F, TopicFlow[F]]): Resource[F, TopicFlow[F]] = {
     // A combination of Semaphore and uncancelable is required to implement the aforementioned safeties
@@ -175,13 +178,21 @@ object TopicFlow {
         semaphore           <- Semaphore(1)
         xx                  <- a.allocated
         (topicFlow, release) = xx
+        // skafka runs rebalance-callback effects through ToTry; cats-helper's ioToTry splits them with IO.syncStep.
+        // SyncStep.interpret steps into IO.Uncancelable and drops IO.OnCancel, so a split inside the guarded region
+        // strips the mask and the permit release from the remainder: on timeout the permit leaks for good.
+        // IO.Cede has no case there, so the cede hands the whole region back intact.
+        // Guaranteed for IO only (cede may lawfully be a no-op elsewhere); a ToTry split only exists for IO.
         safeTopicFlow = new TopicFlow[F] {
           def apply(records: ConsumerRecords[String, ByteVector]): F[Unit] =
-            semaphore.permit.use { _ => closed.get.ifM(().pure[F], topicFlow.apply(records)) }.uncancelable
+            Concurrent[F].cede *>
+              semaphore.permit.use { _ => closed.get.ifM(().pure[F], topicFlow.apply(records)) }.uncancelable
           def add(partitions: NonEmptySet[(Partition, Offset)]): F[Unit] =
-            semaphore.permit.use { _ => closed.get.ifM(().pure[F], topicFlow.add(partitions)) }.uncancelable
+            Concurrent[F].cede *>
+              semaphore.permit.use { _ => closed.get.ifM(().pure[F], topicFlow.add(partitions)) }.uncancelable
           def remove(partitions: NonEmptySet[Partition]): F[Unit] =
-            semaphore.permit.use { _ => closed.get.ifM(().pure[F], topicFlow.remove(partitions)) }.uncancelable
+            Concurrent[F].cede *>
+              semaphore.permit.use { _ => closed.get.ifM(().pure[F], topicFlow.remove(partitions)) }.uncancelable
         }
         safeRelease = semaphore.permit.use { _ => closed.set(true) *> release }.uncancelable
       } yield (safeTopicFlow, safeRelease)

--- a/core/src/main/scala/com/evolutiongaming/kafka/flow/TopicFlow.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/flow/TopicFlow.scala
@@ -161,8 +161,7 @@ object TopicFlow {
     *   - if resource is released before start of messages' processing, then it does nothing (no message processing, no
     *     commits, no persists)
     *
-    * The safeties also hold when a call is lifted into a rebalance callback and split by `ToTry`; see the comment on
-    * the guarded calls below.
+    * Also holds when a call is lifted into a rebalance callback; see the comment on the guarded calls below.
     */
   private def safeguard[F[_]: Concurrent](a: Resource[F, TopicFlow[F]]): Resource[F, TopicFlow[F]] = {
     // A combination of Semaphore and uncancelable is required to implement the aforementioned safeties
@@ -178,11 +177,9 @@ object TopicFlow {
         semaphore           <- Semaphore(1)
         xx                  <- a.allocated
         (topicFlow, release) = xx
-        // skafka runs rebalance-callback effects through ToTry; cats-helper's ioToTry splits them with IO.syncStep.
-        // SyncStep.interpret steps into IO.Uncancelable and drops IO.OnCancel, so a split inside the guarded region
-        // strips the mask and the permit release from the remainder: on timeout the permit leaks for good.
-        // IO.Cede has no case there, so the cede hands the whole region back intact.
-        // Guaranteed for IO only (cede may lawfully be a no-op elsewhere); a ToTry split only exists for IO.
+        // ioToTry splits an effect with IO.syncStep, which walks inside uncancelable and past onCancel.
+        // A split inside the guarded region loses the permit release: a timeout leaks the permit.
+        // IO.Cede has no case in the interpreter, so the cede stops the walk before it enters.
         safeTopicFlow = new TopicFlow[F] {
           def apply(records: ConsumerRecords[String, ByteVector]): F[Unit] =
             Concurrent[F].cede *>

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/TopicFlowSafeguardSyncStepSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/TopicFlowSafeguardSyncStepSpec.scala
@@ -15,19 +15,13 @@ import java.util.concurrent.TimeoutException
 import scala.concurrent.duration.*
 import scala.util.Failure
 
-/** Pins the async boundary in front of `TopicFlow.safeguard`'s guarded region (see the comment there). Without it,
-  * `ToTry.ioToTry`'s `IO.syncStep` lands inside `semaphore.permit.use { ... }.uncancelable`, the remainder runs without
-  * the mask and the permit release, and the timeout cancellation leaks the permit: every later call and the flow's
-  * release block forever.
+/** Tests that `TopicFlow.safeguard`'s permit survives a rebalance callback that times out.
   *
-  * Test 1 checks `syncStep` hands the guarded region back untouched. Its `Left` assertions hold even unguarded
-  * (`syncStep` bails at the `parTraverse_` inside `TopicFlow.add`, permit already taken), so the discriminating check
-  * is that the flow is still releasable. Tests 2 and 3 drive the production path: `RebalanceListener` through skafka's
-  * `RebalanceCallback.run` with `ToTry.ioToTry`.
+  * Without the `cede`, `ioToTry`'s `syncStep` walks inside the `uncancelable` region, the returned `IO` lacks the
+  * permit release, and a timeout leaks the permit. Test 1 checks `syncStep` hands the region back untouched; the
+  * discriminating assertion is that the flow is still releasable. Tests 2 and 3 drive the production path.
   *
-  * No outcome depends on timing. Recovery blocks on a gate the test opens only after the callback has returned, so the
-  * budget always expires first; `ToTry` needs a real runtime, so `TestControl` is not an option. Anything that may
-  * block forever runs on its own fiber with a bounded join, so a regression fails instead of hanging.
+  * Recovery blocks on a gate the test opens after the callback has returned, so no outcome depends on timing.
   */
 class TopicFlowSafeguardSyncStepSpec extends FunSuite {
 

--- a/core/src/test/scala/com/evolutiongaming/kafka/flow/TopicFlowSafeguardSyncStepSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/flow/TopicFlowSafeguardSyncStepSpec.scala
@@ -1,0 +1,153 @@
+package com.evolutiongaming.kafka.flow
+
+import cats.data.{NonEmptyMap, NonEmptySet}
+import cats.effect.unsafe.implicits.global
+import cats.effect.{Deferred, IO, Ref, Resource}
+import cats.syntax.all.*
+import com.evolutiongaming.catshelper.{LogOf, Runtime, ToTry}
+import com.evolutiongaming.kafka.flow.kafka.{Consumer, ScheduleCommit}
+import com.evolutiongaming.skafka.*
+import com.evolutiongaming.skafka.consumer.{ConsumerGroupMetadata, ConsumerRecord, ConsumerRecords, RebalanceListener1}
+import munit.FunSuite
+import scodec.bits.ByteVector
+
+import java.util.concurrent.TimeoutException
+import scala.concurrent.duration.*
+import scala.util.Failure
+
+/** Pins the async boundary in front of `TopicFlow.safeguard`'s guarded region (see the comment there). Without it,
+  * `ToTry.ioToTry`'s `IO.syncStep` lands inside `semaphore.permit.use { ... }.uncancelable`, the remainder runs without
+  * the mask and the permit release, and the timeout cancellation leaks the permit: every later call and the flow's
+  * release block forever.
+  *
+  * Test 1 checks `syncStep` hands the guarded region back untouched. Its `Left` assertions hold even unguarded
+  * (`syncStep` bails at the `parTraverse_` inside `TopicFlow.add`, permit already taken), so the discriminating check
+  * is that the flow is still releasable. Tests 2 and 3 drive the production path: `RebalanceListener` through skafka's
+  * `RebalanceCallback.run` with `ToTry.ioToTry`.
+  *
+  * No outcome depends on timing. Recovery blocks on a gate the test opens only after the callback has returned, so the
+  * budget always expires first; `ToTry` needs a real runtime, so `TestControl` is not an option. Anything that may
+  * block forever runs on its own fiber with a bounded join, so a regression fails instead of hanging.
+  */
+class TopicFlowSafeguardSyncStepSpec extends FunSuite {
+
+  private implicit val logOf: LogOf[IO]     = LogOf.empty[IO]
+  private implicit val runtime: Runtime[IO] = Runtime.lift[IO]
+
+  private val topic          = "topic"
+  private val partition      = Partition.min
+  private val records        = ConsumerRecords.empty[String, ByteVector]
+  private val assigned       = NonEmptySet.of((partition, Offset.min))
+  private val topicPartition = TopicPartition(topic, partition)
+  private val budget         = 10.millis
+  // paid only when a probe fails, i.e. only when the permit leaked
+  private val probe = 5.seconds
+
+  private val consumer = new Consumer[IO] {
+    def subscribe(topics: NonEmptySet[Topic], listener: RebalanceListener1[IO]): IO[Unit] = IO.unit
+    def poll(timeout: FiniteDuration): IO[ConsumerRecords[String, ByteVector]]            = records.pure[IO]
+    def commit(offsets: NonEmptyMap[TopicPartition, OffsetAndMetadata]): IO[Unit]         = IO.unit
+    def groupMetadata: IO[Option[ConsumerGroupMetadata]] = none[ConsumerGroupMetadata].pure[IO]
+  }
+
+  /** A `TopicFlow` whose recovery (the `Resource` acquire, as in `PartitionFlow.of`) records that it started and then
+    * waits for `gate`; opening the gate lets an abandoned recovery finish, as it does in production.
+    */
+  private def topicFlow(started: Ref[IO, Boolean], gate: Deferred[IO, Unit]): Resource[IO, TopicFlow[IO]] = {
+    val partitionFlowOf: PartitionFlowOf[IO] = (_: PartitionAssignment[IO], _: ScheduleCommit[IO]) =>
+      Resource
+        .make(started.set(true) *> gate.get)(_ => IO.unit)
+        .as((_: List[ConsumerRecord[String, ByteVector]]) => IO.unit)
+    TopicFlow.of(consumer, topic, partitionFlowOf)
+  }
+
+  /** The synchronous half of `ToTry.ioToTry`: `Left` means the effect was handed back untouched. */
+  private def step(fa: IO[Unit]): IO[Either[IO[Unit], Unit]] =
+    IO.delay(fa.syncStep(Int.MaxValue).unsafeRunSync())
+
+  /** Runs `fa` on its own fiber with `probe` to finish, so a leaked permit fails the test instead of hanging it. */
+  private def completesWithin(label: String, fa: IO[Unit]): IO[Unit] =
+    fa.start.flatMap { fiber =>
+      IO.race(fiber.join, IO.sleep(probe)).flatMap {
+        case Left(_)  => IO.unit
+        case Right(_) => IO.raiseError(new AssertionError(s"$label still blocked after $probe - the permit leaked"))
+      }
+    }
+
+  /** What skafka's Java listener bridge does on the Kafka poll thread. */
+  private def assign(flow: TopicFlow[IO])(implicit toTry: ToTry[IO]) =
+    IO.blocking {
+      RebalanceListener[IO](Map(topic -> flow))
+        .onPartitionsAssigned(NonEmptySet.of(topicPartition))
+        .run(new Consumer.NoopRebalanceConsumer)
+    }
+
+  test("syncStep does not enter the safeguarded region") {
+    // allocated, not use: a regression leaks the permit here too, and `use` would then block on its own release
+    val program = for {
+      started        <- Ref.of[IO, Boolean](false)
+      gate           <- Deferred[IO, Unit]
+      allocated      <- topicFlow(started, gate).allocated
+      (flow, release) = allocated
+      add            <- step(flow.add(assigned))
+      apply          <- step(flow.apply(records))
+      remove         <- step(flow.remove(NonEmptySet.of(partition)))
+      ran            <- started.get
+      _ <- IO {
+        assert(add.isLeft, "add was stepped into: its mask and permit finalizer are lost")
+        assert(apply.isLeft, "apply was stepped into: its mask and permit finalizer are lost")
+        assert(remove.isLeft, "remove was stepped into: its mask and permit finalizer are lost")
+        assert(!ran, "recovery ran inside syncStep, i.e. on the caller's thread and without the mask")
+        ()
+      }
+      _ <- completesWithin("TopicFlow release", release)
+    } yield ()
+    program.unsafeRunSync()
+  }
+
+  test("a rebalance callback that outlives the ToTry budget leaves the flow usable") {
+    implicit val toTry: ToTry[IO] = ToTry.ioToTry(budget)
+
+    val program = for {
+      started        <- Ref.of[IO, Boolean](false)
+      gate           <- Deferred[IO, Unit]
+      allocated      <- topicFlow(started, gate).allocated
+      (flow, release) = allocated
+      outcome        <- assign(flow)
+      // the budget is real: the callback fails; kafka-clients turns that into a KafkaException out of poll()
+      _ <- IO(outcome match {
+        case Failure(_: TimeoutException) => ()
+        case other                        => fail(s"expected the callback to time out, got $other")
+      })
+      _ <- gate.complete(())
+      // what the next poll, the revoke callback and the stream's teardown would do
+      _ <- completesWithin("TopicFlow.apply", flow.apply(records))
+      _ <- completesWithin("TopicFlow.remove", flow.remove(NonEmptySet.of(partition)))
+      _ <- completesWithin("TopicFlow release", release)
+    } yield ()
+    program.unsafeRunSync()
+  }
+
+  test("cancelling a caller blocked on the flow completes") {
+    implicit val toTry: ToTry[IO] = ToTry.ioToTry(budget)
+
+    val program = for {
+      started        <- Ref.of[IO, Boolean](false)
+      gate           <- Deferred[IO, Unit]
+      allocated      <- topicFlow(started, gate).allocated
+      (flow, release) = allocated
+      _              <- assign(flow)
+      // KafkaFlow.resource runs the stream in .background, so shutdown cancels a fiber that may sit on the permit;
+      // `entered` makes sure the caller is running before it is cancelled
+      entered   <- Deferred[IO, Unit]
+      blocked   <- (entered.complete(()) *> flow.apply(records)).start
+      _         <- entered.get
+      cancelled <- blocked.cancel.start
+      _         <- gate.complete(())
+      _         <- completesWithin("cancel of a blocked TopicFlow.apply", cancelled.joinWithNever)
+      _         <- completesWithin("TopicFlow release", release)
+    } yield ()
+    program.unsafeRunSync()
+  }
+
+}

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -19,8 +19,10 @@ backends are provided:
   [compacted](https://kafka.apache.org/documentation/#compaction) topic, recovered by reading that
   topic to the end on assignment. See `KafkaPersistenceModuleOf`.
 
-Both backends recover state per key during partition assignment, relying on Kafka's guarantee that a
-partition is owned by a single consumer in the group. The [stale-writer
+Both backends recover state per key during partition assignment, inside the consumer's rebalance
+callback, relying on Kafka's guarantee that a partition is owned by a single consumer in the group.
+skafka runs that callback through the application's `ToTry[F]`, whose behaviour on a slow recovery is
+therefore the application's choice. The [stale-writer
 protections](#protecting-against-stale-snapshot-writes) below cover the one case where that ownership
 guarantee is not enough for the **Kafka** backend. The Cassandra backend writes snapshots
 unconditionally (last write wins, no offset check), so it stays exposed to the stale-writer

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -21,8 +21,7 @@ backends are provided:
 
 Both backends recover state per key during partition assignment, inside the consumer's rebalance
 callback, relying on Kafka's guarantee that a partition is owned by a single consumer in the group.
-skafka runs that callback through the application's `ToTry[F]`, whose behaviour on a slow recovery is
-therefore the application's choice. The [stale-writer
+skafka runs that callback through the application's `ToTry[F]`. The [stale-writer
 protections](#protecting-against-stale-snapshot-writes) below cover the one case where that ownership
 guarantee is not enough for the **Kafka** backend. The Cassandra backend writes snapshots
 unconditionally (last write wins, no offset check), so it stays exposed to the stale-writer


### PR DESCRIPTION
`ioToTry` splits an effect with `IO.syncStep`, which walks inside `uncancelable` and past `onCancel`. When the walk lands inside `TopicFlow.safeguard`'s `semaphore.permit.use { ... }.uncancelable`, the returned `IO` runs without the permit release. A timeout cancels it and the permit is never returned.

A `cede` in front of each guarded call stops the walk there: `IO.Cede` has no case in the interpreter, so the whole region is returned intact. The callback still fails with `TimeoutException` and the flow is torn down and retried; the budget is unchanged.

`TopicFlowSafeguardSyncStepSpec` fails 3/3 without the `cede` and passes with it.

The real fix is in cats-helper: #425 makes `ioToTry` stop at cancellation structure instead of walking through it. Once that ships this `cede` is belt-and-braces.

Fixes #937.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when persistence operations time out or are cancelled during consumer rebalancing.
  - Ensured resources remain releasable after interrupted recovery or state-management operations, preventing stalled processing.

- **Documentation**
  - Clarified that Cassandra and Kafka persistence recover state per key during partition assignment.
  - Documented how rebalance callbacks process persistence operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->