### PR TITLE
Clarify the assignor guidance in persistence.md

### DIFF
--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -186,9 +186,15 @@ Limitations:
 - The mode always uses the identity `KafkaPersistencePartitionMapper` (fencing is per input partition);
   a non-identity mapper is not supported here.
 - The fence works under both the **classic** and the **consumer** group protocols
-  (`group.protocol=classic|consumer`). With `consumer`, use **brokers 4.3.0+** — below that a still-valid
-  owner can be spuriously fenced during a rebalance and crash; the restart converges, but any later
-  rebalance can fence again (safe, never corruption, but not stable).
+  (`group.protocol=classic|consumer`). With `consumer`, use **brokers 4.3.0+**
+  ([KIP-1251](https://cwiki.apache.org/confluence/spaces/KAFKA/pages/399279344/KIP-1251+Assignment+epochs+for+consumer+groups))
+  — below that a still-valid owner can be spuriously fenced during a rebalance and crash; the restart
+  converges, but any later rebalance can fence again (safe, never corruption, but not stable).
+  Under **classic**, `CooperativeStickyAssignor` keeps retained partitions writing through the
+  generation bump, so the spurious fence can occur on any rebalance and each one crashes the flow;
+  under `retryOnError` each restart fences the peers in turn, and the loop can last minutes.
+  An **eager** assignor (`StickyAssignor`, `RangeAssignor`) avoids it by tearing every flow down
+  before the bump.
 
 ### Custom snapshot storage
 


### PR DESCRIPTION
The limitations bullet on the fence covered both protocols but did not say which assignor to use or what happens under cooperative. Rewritten as operational guidance:

- **Eager assignor** (`StickyAssignor`, `RangeAssignor`): the spurious fence cannot occur, because eager tears every flow down before the generation bumps. Recommended unless the re-recovery cost is prohibitive.
- **`CooperativeStickyAssignor`**: a member that retains its partitions keeps writing through a rebalance, so its transactions carry a stale generation. kafka-flow crashes the flow, and with retry-on-error each crash is a leave/rejoin that fences the peers — a storm that lasts minutes per deploy.
- **`consumer` protocol**: use brokers 4.3.0+ (KIP-1251), below which the spurious fence is wider than under classic cooperative.

Relates to #938.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded transactional snapshot write guidance for classic and consumer group protocols.
  - Added warnings about spurious fencing and potential rebalance-related crashes.
  - Recommended eager assignors for the classic protocol.
  - Clarified the broker version requirement and restart behavior for the consumer protocol.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->